### PR TITLE
feat: Phase 4 React dashboard feature parity

### DIFF
--- a/crates/runifi-api/dashboard-react/package-lock.json
+++ b/crates/runifi-api/dashboard-react/package-lock.json
@@ -22,8 +22,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -37,8 +35,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -47,8 +43,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -78,8 +72,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -95,8 +87,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -112,8 +102,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -122,8 +110,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -136,8 +122,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -154,8 +138,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -164,8 +146,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -174,8 +154,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -184,8 +162,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -194,8 +170,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -208,8 +182,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -224,8 +196,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -240,8 +210,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -256,8 +224,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -271,8 +237,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -290,8 +254,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -302,282 +264,8 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -586,159 +274,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -746,8 +281,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -757,8 +290,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -768,8 +299,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -778,15 +307,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -796,253 +321,11 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -1051,110 +334,10 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1167,8 +350,6 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1177,8 +358,6 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1188,8 +367,6 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1198,14 +375,10 @@
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -1213,8 +386,6 @@
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
@@ -1222,14 +393,10 @@
     },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
       "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -1237,8 +404,6 @@
     },
     "node_modules/@types/d3-zoom": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-interpolate": "*",
@@ -1247,15 +412,11 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1264,8 +425,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1274,8 +433,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1295,8 +452,6 @@
     },
     "node_modules/@xyflow/react": {
       "version": "12.10.1",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
-      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
       "license": "MIT",
       "dependencies": {
         "@xyflow/system": "0.0.75",
@@ -1310,8 +465,6 @@
     },
     "node_modules/@xyflow/system": {
       "version": "0.0.75",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
-      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -1327,8 +480,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
-      "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1340,8 +491,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -1374,8 +523,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001778",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
-      "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
       "dev": true,
       "funding": [
         {
@@ -1395,28 +542,20 @@
     },
     "node_modules/classcat": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
-      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1424,8 +563,6 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1433,8 +570,6 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -1446,8 +581,6 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -1455,8 +588,6 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -1467,8 +598,6 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1476,8 +605,6 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1485,8 +612,6 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -1504,8 +629,6 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -1520,8 +643,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1538,15 +659,11 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1587,8 +704,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1597,8 +712,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1613,25 +726,8 @@
         }
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1640,15 +736,11 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1660,8 +752,6 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1673,8 +763,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1683,15 +771,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -1709,22 +793,16 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1736,8 +814,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -1765,8 +841,6 @@
     },
     "node_modules/react": {
       "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1774,8 +848,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -1786,8 +858,6 @@
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1796,8 +866,6 @@
     },
     "node_modules/rollup": {
       "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1841,14 +909,10 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1857,8 +921,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1867,8 +929,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1884,8 +944,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1898,8 +956,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -1929,8 +985,6 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1938,8 +992,6 @@
     },
     "node_modules/vite": {
       "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2013,15 +1065,11 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/zustand": {
       "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.2.2"

--- a/crates/runifi-api/dashboard-react/src/App.tsx
+++ b/crates/runifi-api/dashboard-react/src/App.tsx
@@ -1,13 +1,25 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Header } from './components/Header';
 import { SummaryBar } from './components/SummaryBar';
 import { FlowCanvas } from './components/FlowCanvas';
+import { ProcessorPalette } from './components/ProcessorPalette';
+import { ToastNotifier } from './components/ToastNotifier';
+import { BulletinBoard } from './components/BulletinBoard';
 import { useFlowTopology } from './hooks/useFlowTopology';
 import { useSseMetrics } from './hooks/useSseMetrics';
+import { usePlugins } from './hooks/usePlugins';
+import { useToast } from './hooks/useToast';
+import type { PluginDescriptor } from './types/api';
 
 export function App() {
   const { topology, error, loading } = useFlowTopology();
   const { latest: liveMetrics, status: sseStatus } = useSseMetrics();
+  const { plugins, loading: pluginsLoading } = usePlugins();
+  const { toasts, push: pushToast, dismiss: dismissToast } = useToast();
+
+  const [paletteCollapsed, setPaletteCollapsed] = useState(false);
+  const [draggedPlugin, setDraggedPlugin] = useState<PluginDescriptor | null>(null);
+  const [bulletinOpen, setBulletinOpen] = useState(false);
 
   const uptimeSecs = liveMetrics?.uptime_secs ?? 0;
   const flowName = topology?.name ?? '';
@@ -17,40 +29,68 @@ export function App() {
     [topology?.name],
   );
 
+  const processorNames = useMemo(
+    () => (liveMetrics?.processors ?? []).map((p) => p.name),
+    [liveMetrics],
+  );
+
+  const handleDragEnd = () => setDraggedPlugin(null);
+
   return (
-    <div className="app-layout">
+    <div className="app-layout" onDragEnd={handleDragEnd}>
       <Header flowName={flowName} uptimeSecs={uptimeSecs} sseStatus={sseStatus} />
-      <SummaryBar metrics={liveMetrics} />
+      <SummaryBar
+        metrics={liveMetrics}
+        onOpenBulletins={() => setBulletinOpen((v) => !v)}
+      />
 
-      <main className="app-main">
-        <section className="dag-section" aria-labelledby="dag-heading">
-          <h2 id="dag-heading">Flow Topology</h2>
+      <div className="app-body">
+        <ProcessorPalette
+          plugins={plugins}
+          loading={pluginsLoading}
+          collapsed={paletteCollapsed}
+          onToggle={() => setPaletteCollapsed((c) => !c)}
+          onDragStart={setDraggedPlugin}
+        />
 
-          {loading && (
-            <div className="canvas-placeholder" role="status" aria-live="polite">
-              Loading topology...
-            </div>
-          )}
+        <main className="app-main">
+          <section className="dag-section" aria-labelledby="dag-heading">
+            <h2 id="dag-heading">Flow Topology</h2>
 
-          {error && (
-            <div className="canvas-error" role="alert">
-              Failed to load topology: {error}
-            </div>
-          )}
+            {loading && (
+              <div className="canvas-placeholder" role="status" aria-live="polite">
+                Loading topology...
+              </div>
+            )}
 
-          {topology && !loading && (
-            <FlowCanvas
-              key={canvasKey}
-              topology={topology}
-              liveMetrics={liveMetrics}
+            {error && (
+              <div className="canvas-error" role="alert">
+                Failed to load topology: {error}
+              </div>
+            )}
+
+            {!loading && (
+              <FlowCanvas
+                key={canvasKey}
+                topology={topology ?? { name: 'new-flow', processors: [], connections: [] }}
+                liveMetrics={liveMetrics}
+                plugins={plugins}
+                onToast={pushToast}
+                draggedPlugin={draggedPlugin}
+              />
+            )}
+          </section>
+
+          {bulletinOpen && (
+            <BulletinBoard
+              processorNames={processorNames}
+              onClose={() => setBulletinOpen(false)}
             />
           )}
+        </main>
+      </div>
 
-          {!topology && !loading && !error && (
-            <div className="canvas-placeholder">No processors configured.</div>
-          )}
-        </section>
-      </main>
+      <ToastNotifier toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/crates/runifi-api/dashboard-react/src/components/AddProcessorModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/AddProcessorModal.tsx
@@ -1,0 +1,121 @@
+import { memo, useState, useEffect, useRef, type FormEvent } from 'react';
+import type { PluginDescriptor } from '../types/api';
+
+interface AddProcessorModalProps {
+  plugin: PluginDescriptor;
+  existingNames: Set<string>;
+  onConfirm: (name: string) => void;
+  onCancel: () => void;
+}
+
+function AddProcessorModalInner({
+  plugin,
+  existingNames,
+  onConfirm,
+  onCancel,
+}: AddProcessorModalProps) {
+  // Suggest a default name derived from the type
+  const suggestName = (): string => {
+    const base = plugin.type_name
+      .replace(/([A-Z])/g, (m) => `-${m.toLowerCase()}`)
+      .replace(/^-/, '');
+    let candidate = base;
+    let n = 1;
+    while (existingNames.has(candidate)) {
+      candidate = `${base}-${n++}`;
+    }
+    return candidate;
+  };
+
+  const [name, setName] = useState(() => suggestName());
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  const validate = (value: string): string | null => {
+    if (!value.trim()) return 'Name is required.';
+    if (existingNames.has(value.trim()))
+      return `A processor named "${value.trim()}" already exists.`;
+    if (!/^[a-zA-Z0-9_-]+$/.test(value.trim()))
+      return 'Name may only contain letters, numbers, hyphens, and underscores.';
+    return null;
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const validationError = validate(name);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onConfirm(name.trim());
+  };
+
+  const handleChange = (value: string) => {
+    setName(value);
+    setError(validate(value));
+  };
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-proc-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="modal-panel add-proc-panel">
+        <h3 id="add-proc-title" className="modal-title">
+          Add Processor
+        </h3>
+        <p className="modal-subtitle">
+          <span className="modal-type-tag">{plugin.display_name}</span>
+          <span className="modal-type-desc">{plugin.description}</span>
+        </p>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <label className="form-label" htmlFor="proc-name">
+            Processor Name
+          </label>
+          <input
+            id="proc-name"
+            ref={inputRef}
+            className={`form-input${error ? ' form-input-error' : ''}`}
+            type="text"
+            value={name}
+            onChange={(e) => handleChange(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="e.g. my-generate-flowfile"
+          />
+          {error && <p className="form-error">{error}</p>}
+
+          <div className="modal-actions">
+            <button type="button" className="btn btn-ghost" onClick={onCancel}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={!!error || !name.trim()}>
+              Add
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export const AddProcessorModal = memo(AddProcessorModalInner);

--- a/crates/runifi-api/dashboard-react/src/components/BulletinBoard.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/BulletinBoard.tsx
@@ -1,0 +1,196 @@
+import { memo, useState, useEffect, useCallback } from 'react';
+import type { BulletinResponse } from '../types/api';
+import { formatTimestamp } from '../utils/format';
+
+interface BulletinBoardProps {
+  processorNames: string[];
+  onClose: () => void;
+}
+
+type SeverityFilter = '' | 'warn' | 'error';
+
+function BulletinDetailModal({
+  bulletin,
+  onClose,
+}: {
+  bulletin: BulletinResponse;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const time = new Date(bulletin.timestamp_ms).toLocaleString();
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bulletin-detail-title"
+      style={{ zIndex: 1200 }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal-panel" style={{ maxWidth: 480 }}>
+        <h3 id="bulletin-detail-title" className="modal-title">
+          Bulletin Detail
+        </h3>
+        <div className="ff-detail-meta">
+          <div className="detail-row">
+            <span className="detail-label">Severity</span>
+            <span className={`detail-value bulletin-sev-${bulletin.severity}`}>
+              {bulletin.severity.toUpperCase()}
+            </span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Processor</span>
+            <span className="detail-value">{bulletin.processor_name}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Time</span>
+            <span className="detail-value">{time}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Message</span>
+            <span className="detail-value">{bulletin.message}</span>
+          </div>
+        </div>
+        <div className="modal-actions">
+          <button className="btn btn-primary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BulletinBoardInner({ processorNames, onClose }: BulletinBoardProps) {
+  const [bulletins, setBulletins] = useState<BulletinResponse[]>([]);
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('');
+  const [processorFilter, setProcessorFilter] = useState('');
+  const [selectedBulletin, setSelectedBulletin] = useState<BulletinResponse | null>(null);
+
+  const fetchBulletins = useCallback(
+    (severity: SeverityFilter, processor: string) => {
+      const params = new URLSearchParams();
+      if (severity) params.set('severity', severity);
+      if (processor) params.set('processor', processor);
+      const qs = params.toString();
+      fetch(`/api/v1/bulletins${qs ? `?${qs}` : ''}`)
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json() as Promise<BulletinResponse[]>;
+        })
+        .then((data) => setBulletins(data.slice().reverse()))
+        .catch(() => {});
+    },
+    [],
+  );
+
+  useEffect(() => {
+    fetchBulletins(severityFilter, processorFilter);
+  }, [fetchBulletins, severityFilter, processorFilter]);
+
+  return (
+    <>
+      <div className="bulletin-panel" role="complementary" aria-label="Bulletin board">
+        <div className="bulletin-panel-header">
+          <span className="bulletin-panel-title">Bulletin Board</span>
+          <div className="bulletin-filters">
+            <select
+              className="bulletin-filter-select"
+              value={severityFilter}
+              onChange={(e) => setSeverityFilter(e.target.value as SeverityFilter)}
+              aria-label="Filter by severity"
+            >
+              <option value="">All Severities</option>
+              <option value="warn">Warnings</option>
+              <option value="error">Errors</option>
+            </select>
+            <select
+              className="bulletin-filter-select"
+              value={processorFilter}
+              onChange={(e) => setProcessorFilter(e.target.value)}
+              aria-label="Filter by processor"
+            >
+              <option value="">All Processors</option>
+              {processorNames.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+            <button
+              className="bulletin-refresh-btn"
+              onClick={() => fetchBulletins(severityFilter, processorFilter)}
+              title="Refresh"
+              aria-label="Refresh bulletins"
+            >
+              Refresh
+            </button>
+          </div>
+          <button
+            className="config-close-btn"
+            onClick={onClose}
+            aria-label="Close bulletin board"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="bulletin-list" role="list">
+          {bulletins.length === 0 ? (
+            <div className="bulletin-empty">No bulletins to display.</div>
+          ) : (
+            bulletins.map((b) => (
+              <div
+                key={b.id}
+                className="bulletin-item"
+                role="listitem"
+                onClick={() => setSelectedBulletin(b)}
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setSelectedBulletin(b);
+                  }
+                }}
+                aria-label={`${b.severity} from ${b.processor_name}: ${b.message}`}
+              >
+                <span
+                  className={`bulletin-severity-badge bulletin-sev-${b.severity}`}
+                  aria-hidden="true"
+                >
+                  {b.severity}
+                </span>
+                <div className="bulletin-body">
+                  <div className="bulletin-meta">
+                    <span className="bulletin-processor">{b.processor_name}</span>
+                    <span className="bulletin-time">{formatTimestamp(b.timestamp_ms)}</span>
+                  </div>
+                  <div className="bulletin-message">{b.message}</div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {selectedBulletin && (
+        <BulletinDetailModal
+          bulletin={selectedBulletin}
+          onClose={() => setSelectedBulletin(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export const BulletinBoard = memo(BulletinBoardInner);

--- a/crates/runifi-api/dashboard-react/src/components/ConfirmDialog.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ConfirmDialog.tsx
@@ -1,0 +1,61 @@
+import { memo, useEffect, useRef } from 'react';
+
+interface ConfirmDialogProps {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConfirmDialogInner({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmBtnRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="confirm-title">
+      <div className="modal-panel confirm-panel">
+        <h3 id="confirm-title" className="modal-title">
+          {title}
+        </h3>
+        <p className="modal-body">{message}</p>
+        <div className="modal-actions">
+          <button className="btn btn-ghost" onClick={onCancel}>
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmBtnRef}
+            className={`btn ${destructive ? 'btn-danger' : 'btn-primary'}`}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const ConfirmDialog = memo(ConfirmDialogInner);

--- a/crates/runifi-api/dashboard-react/src/components/ConnectionEdge.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ConnectionEdge.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -10,6 +10,10 @@ import type { ConnectionEdgeData } from '../types/flow';
 
 export type ConnectionEdgeType = Edge<ConnectionEdgeData, 'connectionEdge'>;
 
+interface ConnectionEdgeInnerProps extends EdgeProps<ConnectionEdgeType> {
+  onQueueClick?: (connectionId: string, label: string) => void;
+}
+
 function ConnectionEdgeInner({
   id,
   sourceX,
@@ -18,8 +22,11 @@ function ConnectionEdgeInner({
   targetY,
   sourcePosition,
   targetPosition,
+  source,
+  target,
   data,
-}: EdgeProps<ConnectionEdgeType>) {
+  // onQueueClick is passed via edge data or through a custom mechanism
+}: ConnectionEdgeInnerProps) {
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -32,8 +39,23 @@ function ConnectionEdgeInner({
   const queuedCount = data?.queuedCount ?? 0;
   const backPressured = data?.backPressured ?? false;
   const relationship = data?.relationship ?? '';
+  const connectionId = data?.connectionId ?? '';
+  const onQueueClick = data?.onQueueClick as
+    | ((connectionId: string, label: string) => void)
+    | undefined;
 
   const edgeColor = backPressured ? 'var(--danger)' : 'var(--border)';
+
+  const handleQueueClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onQueueClick && connectionId) {
+        const label = `${source} \u2192 ${relationship} \u2192 ${target}`;
+        onQueueClick(connectionId, label);
+      }
+    },
+    [onQueueClick, connectionId, source, relationship, target],
+  );
 
   return (
     <>
@@ -54,7 +76,23 @@ function ConnectionEdgeInner({
         >
           <span className="conn-edge-rel-badge">{relationship}</span>
           {queuedCount > 0 && (
-            <span className={`conn-edge-queue-badge${backPressured ? ' back-pressured' : ''}`}>
+            <span
+              className={`conn-edge-queue-badge${backPressured ? ' back-pressured' : ''}${connectionId ? ' clickable' : ''}`}
+              onClick={connectionId ? handleQueueClick : undefined}
+              title={connectionId ? 'Click to inspect queue' : undefined}
+              role={connectionId ? 'button' : undefined}
+              tabIndex={connectionId ? 0 : undefined}
+              onKeyDown={
+                connectionId
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleQueueClick(e as unknown as React.MouseEvent);
+                      }
+                    }
+                  : undefined
+              }
+            >
               {queuedCount.toLocaleString()} queued
             </span>
           )}

--- a/crates/runifi-api/dashboard-react/src/components/ConnectionModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ConnectionModal.tsx
@@ -1,0 +1,120 @@
+import { memo, useState, useEffect } from 'react';
+
+interface ConnectionModalProps {
+  sourceId: string;
+  targetId: string;
+  relationships: string[];
+  existingRelationships: string[]; // already connected from this source to target
+  onConfirm: (relationship: string) => void;
+  onCancel: () => void;
+}
+
+function ConnectionModalInner({
+  sourceId,
+  targetId,
+  relationships,
+  existingRelationships,
+  onConfirm,
+  onCancel,
+}: ConnectionModalProps) {
+  const available = relationships.filter((r) => !existingRelationships.includes(r));
+  const [selected, setSelected] = useState<string>(available[0] ?? '');
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  if (available.length === 0) {
+    return (
+      <div
+        className="modal-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="conn-title"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onCancel();
+        }}
+      >
+        <div className="modal-panel confirm-panel">
+          <h3 id="conn-title" className="modal-title">
+            Cannot Connect
+          </h3>
+          <p className="modal-body">
+            All relationships from <strong>{sourceId}</strong> to <strong>{targetId}</strong> are
+            already connected.
+          </p>
+          <div className="modal-actions">
+            <button className="btn btn-primary" onClick={onCancel}>
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="conn-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="modal-panel confirm-panel">
+        <h3 id="conn-title" className="modal-title">
+          Create Connection
+        </h3>
+        <p className="modal-body">
+          Connect <strong>{sourceId}</strong> to <strong>{targetId}</strong>
+        </p>
+
+        {available.length > 1 ? (
+          <div className="form-group">
+            <label className="form-label" htmlFor="rel-select">
+              Relationship
+            </label>
+            <select
+              id="rel-select"
+              className="form-select"
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+            >
+              {available.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <p className="conn-relationship-display">
+            Relationship: <strong>{available[0]}</strong>
+          </p>
+        )}
+
+        <div className="modal-actions">
+          <button className="btn btn-ghost" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={() => onConfirm(selected)}
+            disabled={!selected}
+          >
+            Connect
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const ConnectionModal = memo(ConnectionModalInner);

--- a/crates/runifi-api/dashboard-react/src/components/ContextMenu.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ContextMenu.tsx
@@ -1,0 +1,158 @@
+import { memo, useEffect, useRef } from 'react';
+
+export interface ContextMenuState {
+  x: number;
+  y: number;
+  nodeId: string | null;
+  edgeId: string | null;
+  nodeState?: string;
+}
+
+interface ContextMenuProps {
+  menu: ContextMenuState;
+  onDelete: () => void;
+  onConfigure?: () => void;
+  onStart?: () => void;
+  onStop?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
+  onResetCircuit?: () => void;
+  onClose: () => void;
+}
+
+function ContextMenuInner({
+  menu,
+  onDelete,
+  onConfigure,
+  onStart,
+  onStop,
+  onPause,
+  onResume,
+  onResetCircuit,
+  onClose,
+}: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent | KeyboardEvent) => {
+      if (e instanceof KeyboardEvent) {
+        if (e.key === 'Escape') onClose();
+        return;
+      }
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    window.addEventListener('mousedown', handler);
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('mousedown', handler);
+      window.removeEventListener('keydown', handler);
+    };
+  }, [onClose]);
+
+  const isNode = menu.nodeId !== null;
+  const state = menu.nodeState ?? 'stopped';
+  const isRunning = state === 'running';
+  const isPaused = state === 'paused';
+  const isStopped = state === 'stopped';
+  const isCircuitOpen = state === 'circuit-open';
+  const deleteLabel = isNode ? 'Delete Processor' : 'Delete Connection';
+
+  return (
+    <div
+      ref={menuRef}
+      className="context-menu"
+      style={{ left: menu.x, top: menu.y }}
+      role="menu"
+      aria-label="Context menu"
+    >
+      {isNode && onConfigure && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onConfigure(); onClose(); }}
+          role="menuitem"
+        >
+          Configure
+        </button>
+      )}
+
+      {isNode && (onStart || onStop || onPause || onResume || onResetCircuit) && (
+        <div className="context-menu-separator" aria-hidden="true" />
+      )}
+
+      {isNode && onStart && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onStart(); onClose(); }}
+          disabled={isRunning || isPaused}
+          role="menuitem"
+        >
+          Start
+        </button>
+      )}
+
+      {isNode && onPause && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onPause(); onClose(); }}
+          disabled={!isRunning}
+          role="menuitem"
+        >
+          Pause
+        </button>
+      )}
+
+      {isNode && onResume && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onResume(); onClose(); }}
+          disabled={!isPaused}
+          role="menuitem"
+        >
+          Resume
+        </button>
+      )}
+
+      {isNode && onStop && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onStop(); onClose(); }}
+          disabled={isStopped}
+          role="menuitem"
+        >
+          Stop
+        </button>
+      )}
+
+      {isNode && onResetCircuit && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onResetCircuit(); onClose(); }}
+          disabled={!isCircuitOpen}
+          role="menuitem"
+          title={isCircuitOpen ? 'Reset circuit breaker' : 'Circuit breaker is not open'}
+        >
+          Reset Circuit
+        </button>
+      )}
+
+      {isNode && (
+        <div className="context-menu-separator" aria-hidden="true" />
+      )}
+
+      <button
+        className="context-menu-item context-menu-item-danger"
+        onClick={onDelete}
+        disabled={isNode && isRunning}
+        title={isNode && isRunning ? 'Stop the processor before deleting' : undefined}
+        role="menuitem"
+      >
+        {deleteLabel}
+        {isNode && isRunning && <span className="context-menu-hint"> (stop first)</span>}
+      </button>
+    </div>
+  );
+}
+
+export const ContextMenu = memo(ContextMenuInner);

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -1,6 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- CSS import resolved by Vite at build time
 import '@xyflow/react/dist/style.css';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ReactFlow,
   Background,
@@ -9,31 +11,71 @@ import {
   ReactFlowProvider,
   useNodesState,
   useEdgesState,
+  useReactFlow,
   BackgroundVariant,
+  addEdge,
   type Node,
   type Edge,
+  type Connection,
+  type OnConnect,
+  type NodeMouseHandler,
+  type EdgeMouseHandler,
 } from '@xyflow/react';
 
 import { ProcessorNode } from './ProcessorNode';
 import { ConnectionEdge } from './ConnectionEdge';
+import { AddProcessorModal } from './AddProcessorModal';
+import { ConnectionModal } from './ConnectionModal';
+import { ConfirmDialog } from './ConfirmDialog';
+import { ContextMenu, type ContextMenuState } from './ContextMenu';
+import { ProcessorConfigModal } from './ProcessorConfigModal';
+import { QueueInspectorModal } from './QueueInspectorModal';
 import { computeLayout } from '../utils/layout';
 import { stateColor } from '../utils/format';
-import type { FlowResponse, SseMetricsEvent } from '../types/api';
+import type { FlowResponse, SseMetricsEvent, PluginDescriptor } from '../types/api';
 import type { ProcessorNodeData, ConnectionEdgeData } from '../types/flow';
+import type { ToastKind } from '../hooks/useToast';
 
-// Concrete node and edge types for use throughout this file
+// Concrete node and edge types
 type ProcNode = Node<ProcessorNodeData, 'processorNode'>;
 type ConnEdge = Edge<ConnectionEdgeData, 'connectionEdge'>;
 
 const nodeTypes = { processorNode: ProcessorNode } as const;
 const edgeTypes = { connectionEdge: ConnectionEdge } as const;
 
-interface FlowCanvasProps {
-  topology: FlowResponse;
-  liveMetrics: SseMetricsEvent | null;
+// Debounce delay for position persistence (ms)
+const POSITION_DEBOUNCE_MS = 800;
+
+interface PendingDrop {
+  plugin: PluginDescriptor;
+  position: { x: number; y: number };
 }
 
-function buildEdges(topology: FlowResponse, metrics: SseMetricsEvent | null): ConnEdge[] {
+interface DeleteTarget {
+  kind: 'node' | 'edge';
+  id: string;
+  label: string;
+  nodeState?: string;
+}
+
+interface QueueInspectTarget {
+  connectionId: string;
+  label: string;
+}
+
+export interface FlowCanvasProps {
+  topology: FlowResponse;
+  liveMetrics: SseMetricsEvent | null;
+  plugins: PluginDescriptor[];
+  onToast: (kind: ToastKind, message: string) => void;
+  draggedPlugin: PluginDescriptor | null;
+}
+
+function buildEdges(
+  topology: FlowResponse,
+  metrics: SseMetricsEvent | null,
+  onQueueClick: (connectionId: string, label: string) => void,
+): ConnEdge[] {
   return topology.connections.map((conn, idx) => {
     const live =
       metrics?.connections.find(
@@ -49,6 +91,8 @@ function buildEdges(topology: FlowResponse, metrics: SseMetricsEvent | null): Co
       id: `${conn.source}--${conn.relationship}--${conn.destination}--${idx}`,
       source: conn.source,
       target: conn.destination,
+      sourceHandle: conn.relationship,
+      targetHandle: 'target',
       type: 'connectionEdge' as const,
       data: {
         relationship: conn.relationship,
@@ -56,21 +100,74 @@ function buildEdges(topology: FlowResponse, metrics: SseMetricsEvent | null): Co
         queuedBytes: live?.queued_bytes ?? 0,
         backPressured,
         connectionId: live?.id ?? '',
+        pending: false,
+        onQueueClick,
       },
       style: { stroke: backPressured ? 'var(--danger)' : 'var(--border)' },
     };
   });
 }
 
-function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
+function pluginForNode(
+  nodes: ProcNode[],
+  nodeId: string,
+  plugins: PluginDescriptor[],
+): PluginDescriptor | null {
+  const node = nodes.find((n) => n.id === nodeId);
+  if (!node) return null;
+  return plugins.find((p) => p.type_name === node.data.typeName) ?? null;
+}
+
+function FlowCanvasInner({
+  topology,
+  liveMetrics,
+  plugins,
+  onToast,
+  draggedPlugin,
+}: FlowCanvasProps) {
+  const { screenToFlowPosition } = useReactFlow();
+
+  // Queue click handler — defined before buildEdges use
+  const [queueInspectTarget, setQueueInspectTarget] = useState<QueueInspectTarget | null>(null);
+  const handleQueueClick = useCallback((connectionId: string, label: string) => {
+    setQueueInspectTarget({ connectionId, label });
+  }, []);
+
   const initialNodes = useMemo(
-    () => computeLayout(topology.processors, topology.connections),
+    () =>
+      computeLayout(topology.processors, topology.connections).map((n) => ({
+        ...n,
+        data: {
+          ...n.data,
+          relationships: plugins.find((p) => p.type_name === n.data.typeName)?.relationships ?? [
+            'success',
+          ],
+          pending: false,
+        },
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [topology],
   );
-  const initialEdges = useMemo(() => buildEdges(topology, null), [topology]);
+  const initialEdges = useMemo(
+    () => buildEdges(topology, null, handleQueueClick),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [topology],
+  );
 
   const [nodes, setNodes, onNodesChange] = useNodesState<ProcNode>(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState<ConnEdge>(initialEdges);
+
+  // Modal state
+  const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const [pendingConnectionContext, setPendingConnectionContext] = useState<{
+    sourceId: string;
+    targetId: string;
+    relationships: string[];
+    existingRels: string[];
+  } | null>(null);
+  const [configTarget, setConfigTarget] = useState<{ name: string; state: string } | null>(null);
 
   // Guard to prevent re-layout on first metrics update
   const topologyKey = useRef(topology.name);
@@ -78,9 +175,19 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
   useEffect(() => {
     if (topologyKey.current === topology.name) return;
     topologyKey.current = topology.name;
-    setNodes(computeLayout(topology.processors, topology.connections));
-    setEdges(buildEdges(topology, liveMetrics));
-  }, [topology, liveMetrics, setNodes, setEdges]);
+    const newNodes = computeLayout(topology.processors, topology.connections).map((n) => ({
+      ...n,
+      data: {
+        ...n.data,
+        relationships: plugins.find((p) => p.type_name === n.data.typeName)?.relationships ?? [
+          'success',
+        ],
+        pending: false,
+      },
+    }));
+    setNodes(newNodes);
+    setEdges(buildEdges(topology, liveMetrics, handleQueueClick));
+  }, [topology, liveMetrics, setNodes, setEdges, plugins, handleQueueClick]);
 
   // Update node data from live metrics without touching positions
   useEffect(() => {
@@ -96,7 +203,6 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
 
         const bulletin = bulletinMap.get(node.id) ?? null;
 
-        // Skip update if nothing changed
         if (
           node.data.state === proc.state &&
           node.data.metrics?.total_invocations === proc.metrics.total_invocations &&
@@ -112,6 +218,7 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
             state: proc.state,
             metrics: proc.metrics,
             bulletin,
+            pending: false,
           },
         };
       }),
@@ -127,7 +234,6 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
         );
         if (!live) return edge;
 
-        // Skip update if nothing changed
         if (
           edge.data?.queuedCount === live.queued_count &&
           edge.data?.backPressured === live.back_pressured
@@ -143,6 +249,8 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
             queuedBytes: live.queued_bytes,
             backPressured: live.back_pressured,
             connectionId: live.id,
+            pending: false,
+            onQueueClick: handleQueueClick,
           },
           style: {
             stroke: live.back_pressured ? 'var(--danger)' : 'var(--border)',
@@ -150,27 +258,424 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
         };
       }),
     );
-  }, [liveMetrics, setNodes, setEdges]);
+  }, [liveMetrics, setNodes, setEdges, handleQueueClick]);
 
+  // ── Position persistence (debounced) ──────────────────────────────────────
+  const positionTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const persistPosition = useCallback((nodeId: string, x: number, y: number) => {
+    const existing = positionTimers.current.get(nodeId);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      positionTimers.current.delete(nodeId);
+      fetch(`/api/v1/processors/${encodeURIComponent(nodeId)}/position`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x, y }),
+      }).catch(() => {
+        // Position save is best-effort — do not surface to user
+      });
+    }, POSITION_DEBOUNCE_MS);
+
+    positionTimers.current.set(nodeId, timer);
+  }, []);
+
+  const handleNodesChange: typeof onNodesChange = useCallback(
+    (changes) => {
+      for (const change of changes) {
+        if (change.type === 'position' && change.position && !change.dragging) {
+          persistPosition(change.id, change.position.x, change.position.y);
+        }
+      }
+      onNodesChange(changes);
+    },
+    [onNodesChange, persistPosition],
+  );
+
+  useEffect(() => {
+    const timers = positionTimers.current;
+    return () => {
+      for (const t of timers.values()) clearTimeout(t);
+    };
+  }, []);
+
+  // ── Drag-and-drop from palette ────────────────────────────────────────────
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const typeName = e.dataTransfer.getData('application/runifi-plugin');
+      if (!typeName) return;
+
+      const plugin = plugins.find((p) => p.type_name === typeName);
+      if (!plugin) return;
+
+      const position = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+      setPendingDrop({ plugin, position });
+    },
+    [plugins, screenToFlowPosition],
+  );
+
+  // ── Add processor on modal confirm ───────────────────────────────────────
+  const handleAddProcessor = useCallback(
+    (name: string) => {
+      if (!pendingDrop) return;
+      const { plugin, position } = pendingDrop;
+      setPendingDrop(null);
+
+      const newNode: ProcNode = {
+        id: name,
+        type: 'processorNode' as const,
+        position,
+        data: {
+          label: name,
+          typeName: plugin.type_name,
+          state: 'stopped',
+          metrics: null,
+          bulletin: null,
+          relationships: plugin.relationships,
+          pending: true,
+        },
+      };
+
+      setNodes((prev) => [...prev, newNode]);
+
+      fetch('/api/v1/processors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: plugin.type_name,
+          name,
+          position,
+          properties: {},
+        }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          setNodes((prev) =>
+            prev.map((n) =>
+              n.id === name ? { ...n, data: { ...n.data, pending: false } } : n,
+            ),
+          );
+          onToast('success', `Processor "${name}" added.`);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          onToast(
+            'error',
+            `Failed to save processor "${name}" to backend: ${msg}. Shown locally only.`,
+          );
+        });
+    },
+    [pendingDrop, setNodes, onToast],
+  );
+
+  // ── Connection creation ───────────────────────────────────────────────────
+  const handleConnect: OnConnect = useCallback(
+    (connection: Connection) => {
+      const { source, target } = connection;
+      if (!source || !target) return;
+
+      if (source === target) {
+        onToast('warning', 'Self-connections are not allowed.');
+        return;
+      }
+
+      const srcPlugin = pluginForNode(nodes, source, plugins);
+      const relationships = srcPlugin?.relationships ?? ['success'];
+
+      const existingRels = edges
+        .filter((e) => e.source === source && e.target === target)
+        .map((e) => e.data?.relationship ?? '');
+
+      setPendingConnectionContext({
+        sourceId: source,
+        targetId: target,
+        relationships,
+        existingRels,
+      });
+    },
+    [nodes, edges, plugins, onToast],
+  );
+
+  const handleConfirmConnection = useCallback(
+    (relationship: string) => {
+      if (!pendingConnectionContext) return;
+      const { sourceId, targetId } = pendingConnectionContext;
+      setPendingConnectionContext(null);
+
+      const edgeId = `${sourceId}--${relationship}--${targetId}--${Date.now()}`;
+      const newEdge: ConnEdge = {
+        id: edgeId,
+        source: sourceId,
+        target: targetId,
+        sourceHandle: relationship,
+        targetHandle: 'target',
+        type: 'connectionEdge' as const,
+        data: {
+          relationship,
+          queuedCount: 0,
+          queuedBytes: 0,
+          backPressured: false,
+          connectionId: '',
+          pending: true,
+          onQueueClick: handleQueueClick,
+        },
+        style: { stroke: 'var(--border)' },
+      };
+
+      setEdges((prev) => addEdge(newEdge, prev));
+
+      fetch('/api/v1/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: sourceId, relationship, destination: targetId }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json() as Promise<{ id: string }>;
+        })
+        .then((data) => {
+          setEdges((prev) =>
+            prev.map((e) =>
+              e.id === edgeId
+                ? { ...e, data: { ...e.data!, connectionId: data.id, pending: false } }
+                : e,
+            ),
+          );
+          onToast('success', `Connection ${sourceId} → ${targetId} (${relationship}) created.`);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          onToast(
+            'error',
+            `Failed to save connection to backend: ${msg}. Shown locally only.`,
+          );
+        });
+    },
+    [pendingConnectionContext, setEdges, onToast, handleQueueClick],
+  );
+
+  // ── Deletion ──────────────────────────────────────────────────────────────
+  const initiateDelete = useCallback(
+    (kind: 'node' | 'edge', id: string) => {
+      if (kind === 'node') {
+        const node = nodes.find((n) => n.id === id);
+        if (!node) return;
+        setDeleteTarget({
+          kind: 'node',
+          id,
+          label: node.data.label,
+          nodeState: node.data.state,
+        });
+      } else {
+        const edge = edges.find((e) => e.id === id);
+        if (!edge) return;
+        setDeleteTarget({
+          kind: 'edge',
+          id,
+          label: `${edge.source} → ${edge.target} (${edge.data?.relationship ?? ''})`,
+        });
+      }
+    },
+    [nodes, edges],
+  );
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deleteTarget) return;
+    setDeleteTarget(null);
+
+    if (deleteTarget.kind === 'node') {
+      const { id, nodeState } = deleteTarget;
+
+      if (nodeState === 'running') {
+        onToast('error', `Cannot delete running processor "${id}". Stop it first.`);
+        return;
+      }
+
+      setNodes((prev) => prev.filter((n) => n.id !== id));
+      setEdges((prev) => prev.filter((e) => e.source !== id && e.target !== id));
+
+      fetch(`/api/v1/processors/${encodeURIComponent(id)}`, { method: 'DELETE' })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          onToast('success', `Processor "${id}" deleted.`);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          onToast('error', `Failed to delete processor from backend: ${msg}.`);
+        });
+    } else {
+      const { id } = deleteTarget;
+      const edge = edges.find((e) => e.id === id);
+      const connId = edge?.data?.connectionId;
+
+      setEdges((prev) => prev.filter((e) => e.id !== id));
+
+      if (connId) {
+        fetch(`/api/v1/connections/${encodeURIComponent(connId)}`, { method: 'DELETE' })
+          .then((res) => {
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            onToast('success', 'Connection deleted.');
+          })
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            onToast('error', `Failed to delete connection from backend: ${msg}.`);
+          });
+      } else {
+        onToast('success', 'Connection removed (was pending, not yet persisted).');
+      }
+    }
+  }, [deleteTarget, nodes, edges, setNodes, setEdges, onToast]);
+
+  // ── Processor controls ────────────────────────────────────────────────────
+  const controlProcessor = useCallback(
+    (name: string, action: 'start' | 'stop' | 'pause' | 'resume' | 'reset-circuit') => {
+      fetch(`/api/v1/processors/${encodeURIComponent(name)}/${action}`, { method: 'POST' })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const labels: Record<string, string> = {
+            start: 'started',
+            stop: 'stopped',
+            pause: 'paused',
+            resume: 'resumed',
+            'reset-circuit': 'circuit reset',
+          };
+          onToast('success', `Processor "${name}" ${labels[action] ?? action}.`);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          onToast('error', `Failed to ${action} "${name}": ${msg}`);
+        });
+    },
+    [onToast],
+  );
+
+  // ── Keyboard shortcuts ────────────────────────────────────────────────────
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (
+          document.activeElement?.tagName === 'INPUT' ||
+          document.activeElement?.tagName === 'TEXTAREA'
+        )
+          return;
+
+        const selectedNode = nodes.find((n) => n.selected);
+        const selectedEdge = edges.find((edge) => edge.selected);
+
+        if (selectedNode) {
+          initiateDelete('node', selectedNode.id);
+        } else if (selectedEdge) {
+          initiateDelete('edge', selectedEdge.id);
+        }
+      }
+      if (e.key === 'Escape') {
+        setContextMenu(null);
+        setPendingDrop(null);
+        setPendingConnectionContext(null);
+        setDeleteTarget(null);
+      }
+    },
+    [nodes, edges, initiateDelete],
+  );
+
+  // ── Context menu ──────────────────────────────────────────────────────────
+  const handleNodeContextMenu: NodeMouseHandler<ProcNode> = useCallback(
+    (event, node) => {
+      event.preventDefault();
+      setContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        nodeId: node.id,
+        edgeId: null,
+        nodeState: node.data.state,
+      });
+    },
+    [],
+  );
+
+  const handleEdgeContextMenu: EdgeMouseHandler<ConnEdge> = useCallback(
+    (event, edge) => {
+      event.preventDefault();
+      setContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        nodeId: null,
+        edgeId: edge.id,
+      });
+    },
+    [],
+  );
+
+  const handleContextDelete = useCallback(() => {
+    if (!contextMenu) return;
+    const { nodeId, edgeId } = contextMenu;
+    setContextMenu(null);
+    if (nodeId) initiateDelete('node', nodeId);
+    else if (edgeId) initiateDelete('edge', edgeId);
+  }, [contextMenu, initiateDelete]);
+
+  const handleContextConfigure = useCallback(() => {
+    if (!contextMenu?.nodeId) return;
+    const nodeId = contextMenu.nodeId;
+    const node = nodes.find((n) => n.id === nodeId);
+    setContextMenu(null);
+    if (node) {
+      setConfigTarget({ name: node.id, state: node.data.state });
+    }
+  }, [contextMenu, nodes]);
+
+  // ── Double-click to configure ─────────────────────────────────────────────
+  const handleNodeDoubleClick: NodeMouseHandler<ProcNode> = useCallback(
+    (_event, node) => {
+      setConfigTarget({ name: node.id, state: node.data.state });
+    },
+    [],
+  );
+
+  // ── MiniMap color ─────────────────────────────────────────────────────────
   const nodeColor = useCallback((node: ProcNode) => {
+    if (node.data?.pending) return 'var(--warning)';
     return stateColor(node.data?.state ?? 'stopped');
   }, []);
 
+  const existingNames = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes]);
+
   return (
-    <div className="flow-canvas-wrapper" aria-label="Flow topology canvas">
+    <div
+      className="flow-canvas-wrapper"
+      aria-label="Flow topology canvas"
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        onNodesChange={onNodesChange}
+        onNodesChange={handleNodesChange}
         onEdgesChange={onEdgesChange}
+        onConnect={handleConnect}
+        onNodeContextMenu={handleNodeContextMenu}
+        onEdgeContextMenu={handleEdgeContextMenu}
+        onNodeDoubleClick={handleNodeDoubleClick}
+        onPaneClick={() => setContextMenu(null)}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
+        connectOnClick={false}
         fitView
         fitViewOptions={{ padding: 0.15 }}
         minZoom={0.3}
         maxZoom={2}
         attributionPosition="bottom-right"
         colorMode="dark"
+        deleteKeyCode={null}
       >
         <Background
           variant={BackgroundVariant.Dots}
@@ -191,6 +696,99 @@ function FlowCanvasInner({ topology, liveMetrics }: FlowCanvasProps) {
           }}
         />
       </ReactFlow>
+
+      {draggedPlugin && (
+        <div className="canvas-drop-hint" aria-hidden="true">
+          Drop to add {draggedPlugin.display_name}
+        </div>
+      )}
+
+      {pendingDrop && (
+        <AddProcessorModal
+          plugin={pendingDrop.plugin}
+          existingNames={existingNames}
+          onConfirm={handleAddProcessor}
+          onCancel={() => setPendingDrop(null)}
+        />
+      )}
+
+      {pendingConnectionContext && (
+        <ConnectionModal
+          sourceId={pendingConnectionContext.sourceId}
+          targetId={pendingConnectionContext.targetId}
+          relationships={pendingConnectionContext.relationships}
+          existingRelationships={pendingConnectionContext.existingRels}
+          onConfirm={handleConfirmConnection}
+          onCancel={() => setPendingConnectionContext(null)}
+        />
+      )}
+
+      {deleteTarget && (
+        <ConfirmDialog
+          title={deleteTarget.kind === 'node' ? 'Delete Processor' : 'Delete Connection'}
+          message={
+            deleteTarget.kind === 'node'
+              ? `Delete processor "${deleteTarget.label}"? This will also remove all its connections.`
+              : `Delete connection ${deleteTarget.label}?`
+          }
+          confirmLabel="Delete"
+          destructive
+          onConfirm={handleDeleteConfirm}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+
+      {contextMenu && (
+        <ContextMenu
+          menu={contextMenu}
+          onDelete={handleContextDelete}
+          onConfigure={contextMenu.nodeId ? handleContextConfigure : undefined}
+          onStart={
+            contextMenu.nodeId
+              ? () => controlProcessor(contextMenu.nodeId!, 'start')
+              : undefined
+          }
+          onStop={
+            contextMenu.nodeId
+              ? () => controlProcessor(contextMenu.nodeId!, 'stop')
+              : undefined
+          }
+          onPause={
+            contextMenu.nodeId
+              ? () => controlProcessor(contextMenu.nodeId!, 'pause')
+              : undefined
+          }
+          onResume={
+            contextMenu.nodeId
+              ? () => controlProcessor(contextMenu.nodeId!, 'resume')
+              : undefined
+          }
+          onResetCircuit={
+            contextMenu.nodeId
+              ? () => controlProcessor(contextMenu.nodeId!, 'reset-circuit')
+              : undefined
+          }
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+
+      {configTarget && (
+        <ProcessorConfigModal
+          processorName={configTarget.name}
+          processorState={configTarget.state}
+          onToast={onToast}
+          onClose={() => setConfigTarget(null)}
+        />
+      )}
+
+      {queueInspectTarget && (
+        <QueueInspectorModal
+          connectionId={queueInspectTarget.connectionId}
+          connectionLabel={queueInspectTarget.label}
+          onToast={onToast}
+          onClose={() => setQueueInspectTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
@@ -1,0 +1,342 @@
+import { memo, useState, useEffect, useCallback, type FormEvent } from 'react';
+import type { ProcessorConfigResponse, PropertyDescriptorFull } from '../types/api';
+import type { ToastKind } from '../hooks/useToast';
+
+type ActiveTab = 'properties' | 'scheduling' | 'relationships';
+
+interface ProcessorConfigModalProps {
+  processorName: string;
+  processorState: string;
+  onToast: (kind: ToastKind, message: string) => void;
+  onClose: () => void;
+}
+
+function validateProperties(
+  descriptors: PropertyDescriptorFull[],
+  values: Record<string, string>,
+): string | null {
+  for (const desc of descriptors) {
+    if (desc.required && !values[desc.name] && !desc.default_value) {
+      return `Required property "${desc.name}" is missing.`;
+    }
+  }
+  return null;
+}
+
+function ProcessorConfigModalInner({
+  processorName,
+  processorState,
+  onToast,
+  onClose,
+}: ProcessorConfigModalProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>('properties');
+  const [config, setConfig] = useState<ProcessorConfigResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<{ kind: 'error' | 'success'; message: string } | null>(null);
+
+  const isStopped = processorState === 'stopped';
+
+  // Load config on mount
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/v1/processors/${encodeURIComponent(processorName)}/config`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<ProcessorConfigResponse>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setConfig(data);
+        // Initialise form with current values, falling back to descriptor defaults
+        const initial: Record<string, string> = {};
+        for (const desc of data.property_descriptors) {
+          initial[desc.name] = data.properties[desc.name] ?? desc.default_value ?? '';
+        }
+        setFormValues(initial);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [processorName]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const handleFieldChange = useCallback((name: string, value: string) => {
+    setFormValues((prev) => ({ ...prev, [name]: value }));
+    setSaveStatus(null);
+  }, []);
+
+  const handleSave = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      if (!config || !isStopped) return;
+
+      const validationError = validateProperties(config.property_descriptors, formValues);
+      if (validationError) {
+        setSaveStatus({ kind: 'error', message: validationError });
+        return;
+      }
+
+      // Strip empty values before sending
+      const properties: Record<string, string> = {};
+      for (const [k, v] of Object.entries(formValues)) {
+        if (v !== '') properties[k] = v;
+      }
+
+      setSaving(true);
+      setSaveStatus(null);
+
+      fetch(`/api/v1/processors/${encodeURIComponent(processorName)}/config`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ properties }),
+      })
+        .then((res) => {
+          if (!res.ok) {
+            return res.json().then((body: unknown) => {
+              const msg =
+                body && typeof body === 'object' && 'error' in body
+                  ? String((body as { error: unknown }).error)
+                  : `HTTP ${res.status}`;
+              throw new Error(msg);
+            });
+          }
+          return res.json();
+        })
+        .then(() => {
+          setSaveStatus({ kind: 'success', message: 'Configuration saved.' });
+          onToast('success', `Processor "${processorName}" configuration saved.`);
+          setSaving(false);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          setSaveStatus({ kind: 'error', message: msg });
+          setSaving(false);
+        });
+    },
+    [config, isStopped, formValues, processorName, onToast],
+  );
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="config-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal-panel config-panel">
+        <div className="config-modal-header">
+          <div>
+            <h3 id="config-modal-title" className="modal-title">
+              {processorName}
+            </h3>
+            {config && (
+              <span className="modal-type-tag">{config.type_name}</span>
+            )}
+          </div>
+          <button className="config-close-btn" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        {!isStopped && (
+          <p className="config-warning">
+            Stop the processor to edit its configuration.
+          </p>
+        )}
+
+        {loadError && (
+          <p className="config-load-error">Failed to load configuration: {loadError}</p>
+        )}
+
+        {!loadError && !config && (
+          <p className="config-loading">Loading...</p>
+        )}
+
+        {config && (
+          <form onSubmit={handleSave} noValidate>
+            <div className="config-tabs" role="tablist">
+              {(['properties', 'scheduling', 'relationships'] as ActiveTab[]).map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  role="tab"
+                  className={`config-tab${activeTab === tab ? ' active' : ''}`}
+                  aria-selected={activeTab === tab}
+                  onClick={() => setActiveTab(tab)}
+                >
+                  {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                </button>
+              ))}
+            </div>
+
+            {/* Properties tab */}
+            {activeTab === 'properties' && (
+              <div className="config-tab-content" role="tabpanel">
+                {config.property_descriptors.length === 0 ? (
+                  <p className="config-empty">This processor has no configurable properties.</p>
+                ) : (
+                  config.property_descriptors.map((desc) => (
+                    <div key={desc.name} className="config-field">
+                      <label className="config-label" htmlFor={`prop-${desc.name}`}>
+                        {desc.display_name || desc.name}
+                        {desc.required && (
+                          <span className="config-required" title="Required">REQUIRED</span>
+                        )}
+                      </label>
+                      <span className="config-description">{desc.description}</span>
+
+                      {desc.allowed_values && desc.allowed_values.length > 0 ? (
+                        <select
+                          id={`prop-${desc.name}`}
+                          className="form-select"
+                          value={formValues[desc.name] ?? ''}
+                          onChange={(e) => handleFieldChange(desc.name, e.target.value)}
+                          disabled={!isStopped}
+                        >
+                          {!desc.required && <option value="">-- Select --</option>}
+                          {desc.allowed_values.map((av) => (
+                            <option key={av} value={av}>
+                              {av}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          id={`prop-${desc.name}`}
+                          className="form-input"
+                          type="text"
+                          value={formValues[desc.name] ?? ''}
+                          placeholder={
+                            desc.default_value ? `Default: ${desc.default_value}` : ''
+                          }
+                          onChange={(e) => handleFieldChange(desc.name, e.target.value)}
+                          disabled={!isStopped}
+                          autoComplete="off"
+                          spellCheck={false}
+                        />
+                      )}
+
+                      {desc.default_value && (
+                        <span className="config-default">Default: {desc.default_value}</span>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+
+            {/* Scheduling tab */}
+            {activeTab === 'scheduling' && (
+              <div className="config-tab-content" role="tabpanel">
+                <div className="config-field">
+                  <label className="config-label">Strategy</label>
+                  <span className="config-description">How the processor is triggered</span>
+                  <input
+                    className="form-input"
+                    type="text"
+                    value={config.scheduling.strategy}
+                    disabled
+                    readOnly
+                  />
+                </div>
+                {config.scheduling.interval_ms !== null &&
+                  config.scheduling.interval_ms !== undefined && (
+                    <div className="config-field">
+                      <label className="config-label">Interval</label>
+                      <span className="config-description">Trigger interval in milliseconds</span>
+                      <input
+                        className="form-input"
+                        type="text"
+                        value={`${config.scheduling.interval_ms} ms`}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+                  )}
+              </div>
+            )}
+
+            {/* Relationships tab */}
+            {activeTab === 'relationships' && (
+              <div className="config-tab-content" role="tabpanel">
+                {config.relationships.length === 0 ? (
+                  <p className="config-empty">This processor has no relationships.</p>
+                ) : (
+                  <table className="rel-table">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                        <th>Auto-Terminated</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {config.relationships.map((rel) => (
+                        <tr key={rel.name}>
+                          <td>
+                            <strong>{rel.name}</strong>
+                          </td>
+                          <td>{rel.description}</td>
+                          <td>
+                            <span
+                              className={`rel-auto-term ${rel.auto_terminated ? 'yes' : 'no'}`}
+                            >
+                              {rel.auto_terminated ? 'Yes' : 'No'}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            )}
+
+            {saveStatus && (
+              <p
+                className={`config-save-status ${saveStatus.kind}`}
+                role="status"
+                aria-live="polite"
+              >
+                {saveStatus.message}
+              </p>
+            )}
+
+            <div className="modal-actions">
+              <button type="button" className="btn btn-ghost" onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={!isStopped || saving || activeTab !== 'properties'}
+                title={!isStopped ? 'Stop the processor to save configuration' : undefined}
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const ProcessorConfigModal = memo(ProcessorConfigModalInner);

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
@@ -23,18 +23,32 @@ function stateLabel(state: string): string {
   return state.charAt(0).toUpperCase() + state.slice(1);
 }
 
+// Distribute multiple source handles evenly along the right edge
+function handleTopPercent(index: number, total: number): string {
+  if (total <= 1) return '50%';
+  const step = 100 / (total + 1);
+  return `${step * (index + 1)}%`;
+}
+
 function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
-  const { label, typeName, state, metrics, bulletin } = data;
-  const borderColor = stateColor(state);
+  const { label, typeName, state, metrics, bulletin, relationships, pending } = data;
+  const borderColor = pending ? 'var(--warning)' : stateColor(state);
+  const rels = relationships && relationships.length > 0 ? relationships : ['success'];
 
   return (
     <div
-      className="processor-node"
+      className={`processor-node${pending ? ' processor-node-pending' : ''}`}
       style={{ borderColor }}
       role="article"
-      aria-label={`Processor ${label}`}
+      aria-label={`Processor ${label}${pending ? ' (pending)' : ''}`}
     >
-      <Handle type="target" position={Position.Left} />
+      {/* Target handle — left side, centered */}
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="target"
+        style={{ top: '50%' }}
+      />
 
       <div className="proc-node-header">
         <div className="proc-node-identity">
@@ -46,7 +60,13 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
           </span>
         </div>
         <div className="proc-node-badges">
-          <span className={stateBadgeClass(state)}>{stateLabel(state)}</span>
+          {pending ? (
+            <span className="state-badge paused" title="Pending API confirmation">
+              Pending
+            </span>
+          ) : (
+            <span className={stateBadgeClass(state)}>{stateLabel(state)}</span>
+          )}
           {bulletin && (
             <span
               className={`bulletin-dot ${bulletin.severity}`}
@@ -57,7 +77,7 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         </div>
       </div>
 
-      {metrics && (
+      {metrics && !pending && (
         <div className="proc-node-metrics">
           <div className="proc-node-metric">
             <span className="proc-node-metric-label">In</span>
@@ -88,7 +108,17 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         </div>
       )}
 
-      <Handle type="source" position={Position.Right} />
+      {/* Source handles — right side, one per relationship */}
+      {rels.map((rel, idx) => (
+        <Handle
+          key={rel}
+          type="source"
+          position={Position.Right}
+          id={rel}
+          style={{ top: handleTopPercent(idx, rels.length) }}
+          title={rel}
+        />
+      ))}
     </div>
   );
 }

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorPalette.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorPalette.tsx
@@ -1,0 +1,150 @@
+import { memo, useState, useMemo } from 'react';
+import type { PluginDescriptor, PluginKind } from '../types/api';
+
+interface ProcessorPaletteProps {
+  plugins: PluginDescriptor[];
+  loading: boolean;
+  collapsed: boolean;
+  onToggle: () => void;
+  onDragStart: (plugin: PluginDescriptor) => void;
+}
+
+const KIND_LABELS: Record<PluginKind, string> = {
+  source: 'Sources',
+  processor: 'Processors',
+  sink: 'Sinks',
+};
+
+const KIND_ORDER: PluginKind[] = ['source', 'processor', 'sink'];
+
+function kindIcon(kind: PluginKind): string {
+  switch (kind) {
+    case 'source':
+      return '▶';
+    case 'sink':
+      return '◼';
+    default:
+      return '◆';
+  }
+}
+
+function PaletteItem({
+  plugin,
+  onDragStart,
+}: {
+  plugin: PluginDescriptor;
+  onDragStart: (plugin: PluginDescriptor) => void;
+}) {
+  return (
+    <div
+      className={`palette-item palette-item-${plugin.kind}`}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.effectAllowed = 'copy';
+        e.dataTransfer.setData('application/runifi-plugin', plugin.type_name);
+        onDragStart(plugin);
+      }}
+      title={plugin.description}
+      role="listitem"
+      aria-label={`Drag to add ${plugin.display_name}`}
+    >
+      <span className="palette-item-icon" aria-hidden="true">
+        {kindIcon(plugin.kind)}
+      </span>
+      <div className="palette-item-text">
+        <span className="palette-item-name">{plugin.display_name}</span>
+        <span className="palette-item-desc">{plugin.description}</span>
+      </div>
+    </div>
+  );
+}
+
+function ProcessorPaletteInner({
+  plugins,
+  loading,
+  collapsed,
+  onToggle,
+  onDragStart,
+}: ProcessorPaletteProps) {
+  const [search, setSearch] = useState('');
+
+  const grouped = useMemo(() => {
+    const q = search.toLowerCase();
+    const filtered = plugins.filter(
+      (p) =>
+        p.display_name.toLowerCase().includes(q) ||
+        p.type_name.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q),
+    );
+
+    const groups = new Map<PluginKind, PluginDescriptor[]>();
+    for (const kind of KIND_ORDER) {
+      const items = filtered.filter((p) => p.kind === kind);
+      if (items.length > 0) groups.set(kind, items);
+    }
+    return groups;
+  }, [plugins, search]);
+
+  if (collapsed) {
+    return (
+      <aside className="palette-sidebar palette-sidebar-collapsed" aria-label="Processor palette">
+        <button
+          className="palette-toggle"
+          onClick={onToggle}
+          aria-label="Expand processor palette"
+          title="Expand palette"
+        >
+          &#9654;
+        </button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="palette-sidebar" aria-label="Processor palette">
+      <div className="palette-header">
+        <span className="palette-title">Processors</span>
+        <button
+          className="palette-toggle"
+          onClick={onToggle}
+          aria-label="Collapse processor palette"
+          title="Collapse palette"
+        >
+          &#9664;
+        </button>
+      </div>
+
+      <div className="palette-search-wrap">
+        <input
+          className="palette-search"
+          type="search"
+          placeholder="Search..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search processors"
+        />
+      </div>
+
+      <div className="palette-list" role="list" aria-label="Available processor types">
+        {loading && <div className="palette-loading">Loading plugins...</div>}
+
+        {!loading && grouped.size === 0 && (
+          <div className="palette-empty">No processors match your search.</div>
+        )}
+
+        {[...grouped.entries()].map(([kind, items]) => (
+          <div key={kind} className="palette-group">
+            <div className="palette-group-label">{KIND_LABELS[kind]}</div>
+            {items.map((plugin) => (
+              <PaletteItem key={plugin.type_name} plugin={plugin} onDragStart={onDragStart} />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="palette-hint">Drag a processor onto the canvas</div>
+    </aside>
+  );
+}
+
+export const ProcessorPalette = memo(ProcessorPaletteInner);

--- a/crates/runifi-api/dashboard-react/src/components/QueueInspectorModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/QueueInspectorModal.tsx
@@ -1,0 +1,409 @@
+import { memo, useState, useEffect, useCallback } from 'react';
+import type { QueueResponse, FlowFileEntry } from '../types/api';
+import { ConfirmDialog } from './ConfirmDialog';
+import { formatBytes, formatAge } from '../utils/format';
+import type { ToastKind } from '../hooks/useToast';
+
+const PAGE_SIZE = 50;
+
+interface QueueInspectorModalProps {
+  connectionId: string;
+  connectionLabel: string;
+  onToast: (kind: ToastKind, message: string) => void;
+  onClose: () => void;
+}
+
+interface FlowFileDetailModalProps {
+  flowfile: FlowFileEntry;
+  connectionId: string;
+  onClose: () => void;
+}
+
+function FlowFileDetailModal({ flowfile, connectionId, onClose }: FlowFileDetailModalProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const downloadUrl = `/api/v1/connections/${encodeURIComponent(connectionId)}/queue/${flowfile.id}/content`;
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ff-detail-title"
+      style={{ zIndex: 1100 }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal-panel ff-detail-panel">
+        <div className="config-modal-header">
+          <h3 id="ff-detail-title" className="modal-title">
+            FlowFile #{flowfile.id}
+          </h3>
+          <button className="config-close-btn" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        <div className="ff-detail-meta">
+          <div className="detail-row">
+            <span className="detail-label">ID</span>
+            <span className="detail-value">{flowfile.id}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Size</span>
+            <span className="detail-value">{formatBytes(flowfile.size)}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Age</span>
+            <span className="detail-value">{formatAge(flowfile.age_ms)}</span>
+          </div>
+          <div className="detail-row">
+            <span className="detail-label">Has Content</span>
+            <span className="detail-value">{flowfile.has_content ? 'Yes' : 'No'}</span>
+          </div>
+        </div>
+
+        <div className="ff-attr-section">
+          <h4 className="ff-attr-heading">Attributes</h4>
+          {flowfile.attributes.length === 0 ? (
+            <p className="config-empty">No attributes</p>
+          ) : (
+            <table className="rel-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {flowfile.attributes.map((attr) => (
+                  <tr key={attr.key}>
+                    <td>{attr.key}</td>
+                    <td>{attr.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="modal-actions">
+          {flowfile.has_content && (
+            <a
+              href={downloadUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-ghost"
+            >
+              Download Content
+            </a>
+          )}
+          <button className="btn btn-primary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QueueInspectorModalInner({
+  connectionId,
+  connectionLabel,
+  onToast,
+  onClose,
+}: QueueInspectorModalProps) {
+  const [queueData, setQueueData] = useState<QueueResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [selectedFlowFile, setSelectedFlowFile] = useState<FlowFileEntry | null>(null);
+  const [confirmEmpty, setConfirmEmpty] = useState(false);
+  const [confirmRemoveId, setConfirmRemoveId] = useState<number | null>(null);
+
+  const loadPage = useCallback(
+    (pageOffset: number) => {
+      setLoadError(null);
+      const url = `/api/v1/connections/${encodeURIComponent(connectionId)}/queue?offset=${pageOffset}&limit=${PAGE_SIZE}`;
+      fetch(url)
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json() as Promise<QueueResponse>;
+        })
+        .then((data) => setQueueData(data))
+        .catch((err: unknown) => {
+          setLoadError(err instanceof Error ? err.message : String(err));
+        });
+    },
+    [connectionId],
+  );
+
+  useEffect(() => {
+    loadPage(0);
+  }, [loadPage]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !selectedFlowFile && !confirmEmpty && confirmRemoveId === null) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose, selectedFlowFile, confirmEmpty, confirmRemoveId]);
+
+  const handleEmptyQueue = useCallback(() => {
+    fetch(`/api/v1/connections/${encodeURIComponent(connectionId)}/queue`, {
+      method: 'DELETE',
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then(() => {
+        onToast('success', 'Queue emptied.');
+        setOffset(0);
+        loadPage(0);
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        onToast('error', `Failed to empty queue: ${msg}`);
+      });
+  }, [connectionId, loadPage, onToast]);
+
+  const handleRemoveFlowFile = useCallback(
+    (ffId: number) => {
+      fetch(
+        `/api/v1/connections/${encodeURIComponent(connectionId)}/queue/${ffId}`,
+        { method: 'DELETE' },
+      )
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then(() => {
+          onToast('success', `FlowFile #${ffId} removed.`);
+          loadPage(offset);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          onToast('error', `Failed to remove FlowFile: ${msg}`);
+        });
+    },
+    [connectionId, offset, loadPage, onToast],
+  );
+
+  const totalCount = queueData?.total_count ?? 0;
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  const goToPrev = () => {
+    const newOffset = Math.max(0, offset - PAGE_SIZE);
+    setOffset(newOffset);
+    loadPage(newOffset);
+  };
+
+  const goToNext = () => {
+    const newOffset = offset + PAGE_SIZE;
+    setOffset(newOffset);
+    loadPage(newOffset);
+  };
+
+  return (
+    <>
+      <div
+        className="modal-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="queue-modal-title"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div className="modal-panel queue-panel">
+          <div className="config-modal-header">
+            <div>
+              <h3 id="queue-modal-title" className="modal-title">
+                Queue Inspector
+              </h3>
+              <span className="modal-type-tag">{connectionLabel}</span>
+            </div>
+            <button className="config-close-btn" onClick={onClose} aria-label="Close">
+              &times;
+            </button>
+          </div>
+
+          <div className="queue-summary-row">
+            <span className="queue-summary-count">
+              {totalCount.toLocaleString()} FlowFile{totalCount !== 1 ? 's' : ''} queued
+            </span>
+            <button
+              className="btn btn-danger"
+              style={{ fontSize: '0.78rem', padding: '0.3rem 0.7rem' }}
+              disabled={totalCount === 0}
+              onClick={() => setConfirmEmpty(true)}
+            >
+              Empty Queue
+            </button>
+          </div>
+
+          {loadError && (
+            <p className="config-load-error">Failed to load queue: {loadError}</p>
+          )}
+
+          {!loadError && !queueData && (
+            <p className="config-loading">Loading...</p>
+          )}
+
+          {queueData && (
+            <>
+              <div className="queue-table-wrap">
+                <table className="queue-table">
+                  <thead>
+                    <tr>
+                      <th>#</th>
+                      <th>ID</th>
+                      <th>Size</th>
+                      <th>Age</th>
+                      <th>Content</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {queueData.flowfiles.length === 0 ? (
+                      <tr>
+                        <td colSpan={6} className="queue-empty-row">
+                          Queue is empty
+                        </td>
+                      </tr>
+                    ) : (
+                      queueData.flowfiles.map((ff) => (
+                        <tr
+                          key={ff.id}
+                          className="queue-row"
+                          onClick={() => setSelectedFlowFile(ff)}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          <td className="queue-cell-dim">{ff.position + 1}</td>
+                          <td className="queue-cell-mono">{ff.id}</td>
+                          <td className="queue-cell-dim">{formatBytes(ff.size)}</td>
+                          <td className="queue-cell-dim">{formatAge(ff.age_ms)}</td>
+                          <td className="queue-cell-dim">{ff.has_content ? 'Yes' : 'No'}</td>
+                          <td>
+                            <div
+                              className="queue-actions"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <button
+                                className="btn-link"
+                                onClick={() => setSelectedFlowFile(ff)}
+                              >
+                                View
+                              </button>
+                              {ff.has_content && (
+                                <a
+                                  href={`/api/v1/connections/${encodeURIComponent(connectionId)}/queue/${ff.id}/content`}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="btn-link"
+                                >
+                                  Download
+                                </a>
+                              )}
+                              <button
+                                className="btn-link btn-link-danger"
+                                onClick={() => setConfirmRemoveId(ff.id)}
+                              >
+                                Remove
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              {totalPages > 1 && (
+                <div className="queue-pagination">
+                  <button
+                    className="btn btn-ghost"
+                    style={{ fontSize: '0.78rem', padding: '0.3rem 0.7rem' }}
+                    disabled={currentPage <= 1}
+                    onClick={goToPrev}
+                  >
+                    Previous
+                  </button>
+                  <span className="queue-page-info">
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <button
+                    className="btn btn-ghost"
+                    style={{ fontSize: '0.78rem', padding: '0.3rem 0.7rem' }}
+                    disabled={currentPage >= totalPages}
+                    onClick={goToNext}
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="modal-actions">
+            <button className="btn btn-ghost" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {selectedFlowFile && (
+        <FlowFileDetailModal
+          flowfile={selectedFlowFile}
+          connectionId={connectionId}
+          onClose={() => setSelectedFlowFile(null)}
+        />
+      )}
+
+      {confirmEmpty && (
+        <ConfirmDialog
+          title="Empty Queue"
+          message="Empty the entire queue? This will remove all FlowFiles from this connection."
+          confirmLabel="Empty"
+          destructive
+          onConfirm={() => {
+            setConfirmEmpty(false);
+            handleEmptyQueue();
+          }}
+          onCancel={() => setConfirmEmpty(false)}
+        />
+      )}
+
+      {confirmRemoveId !== null && (
+        <ConfirmDialog
+          title="Remove FlowFile"
+          message={`Remove FlowFile #${confirmRemoveId} from the queue?`}
+          confirmLabel="Remove"
+          destructive
+          onConfirm={() => {
+            const id = confirmRemoveId;
+            setConfirmRemoveId(null);
+            handleRemoveFlowFile(id);
+          }}
+          onCancel={() => setConfirmRemoveId(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export const QueueInspectorModal = memo(QueueInspectorModalInner);

--- a/crates/runifi-api/dashboard-react/src/components/SummaryBar.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/SummaryBar.tsx
@@ -1,12 +1,13 @@
 import { memo, useMemo } from 'react';
 import type { SseMetricsEvent } from '../types/api';
-import { formatRate } from '../utils/format';
+import { formatRate, formatBytes } from '../utils/format';
 
 interface SummaryBarProps {
   metrics: SseMetricsEvent | null;
+  onOpenBulletins?: () => void;
 }
 
-function SummaryBarInner({ metrics }: SummaryBarProps) {
+function SummaryBarInner({ metrics, onOpenBulletins }: SummaryBarProps) {
   const stats = useMemo(() => {
     if (!metrics) return null;
 
@@ -21,13 +22,29 @@ function SummaryBarInner({ metrics }: SummaryBarProps) {
     const backPressureCount = metrics.connections.filter((c) => c.back_pressured).length;
 
     const totalFFOutRate = procs.reduce((s, p) => s + p.metrics.flowfiles_out_rate, 0);
+    const totalBytesOutRate = procs.reduce((s, p) => s + p.metrics.bytes_out_rate, 0);
+
+    const warnCount = metrics.bulletins.filter((b) => b.severity === 'warn').length;
+    const errorCount = metrics.bulletins.filter((b) => b.severity === 'error').length;
 
     const hasUnhealthy = counts['circuit-open'] > 0;
     const hasWarning = counts.stopped > 0 || counts.paused > 0 || backPressureCount > 0;
     const procHealth = hasUnhealthy ? 'danger' : hasWarning ? 'warning' : 'healthy';
     const bpHealth = backPressureCount > 0 ? 'danger' : 'healthy';
+    const bulletinHealth = errorCount > 0 ? 'danger' : warnCount > 0 ? 'warning' : 'healthy';
 
-    return { counts, totalQueued, backPressureCount, totalFFOutRate, procHealth, bpHealth };
+    return {
+      counts,
+      totalQueued,
+      backPressureCount,
+      totalFFOutRate,
+      totalBytesOutRate,
+      warnCount,
+      errorCount,
+      procHealth,
+      bpHealth,
+      bulletinHealth,
+    };
   }, [metrics]);
 
   if (!stats) {
@@ -40,14 +57,27 @@ function SummaryBarInner({ metrics }: SummaryBarProps) {
     );
   }
 
-  const { counts, totalQueued, backPressureCount, totalFFOutRate, procHealth, bpHealth } = stats;
+  const {
+    counts,
+    totalQueued,
+    backPressureCount,
+    totalFFOutRate,
+    totalBytesOutRate,
+    warnCount,
+    errorCount,
+    procHealth,
+    bpHealth,
+    bulletinHealth,
+  } = stats;
   const procTotal = Object.values(counts).reduce((a, b) => a + b, 0);
 
   return (
     <section className="summary-bar" aria-label="System summary">
       <div className="summary-item">
         <span className="summary-label">Processors</span>
-        <span className="summary-value">{procTotal}</span>
+        <span className="summary-value">
+          {counts.running} / {procTotal} Running
+        </span>
         <span
           className={`summary-indicator ${procHealth}`}
           aria-label={`Processor health: ${procHealth}`}
@@ -61,7 +91,9 @@ function SummaryBarInner({ metrics }: SummaryBarProps) {
 
       <div className="summary-item">
         <span className="summary-label">Throughput</span>
-        <span className="summary-value">{formatRate(totalFFOutRate, 'FF')}</span>
+        <span className="summary-value">
+          {formatRate(totalFFOutRate, 'FF')} &middot; {formatBytes(Math.round(totalBytesOutRate))}/s
+        </span>
       </div>
 
       <div className="summary-item">
@@ -88,6 +120,31 @@ function SummaryBarInner({ metrics }: SummaryBarProps) {
         <span
           className={`summary-indicator ${bpHealth}`}
           aria-label={`Back-pressure: ${bpHealth}`}
+        />
+      </div>
+
+      <div className="summary-item">
+        <span className="summary-label">Bulletins</span>
+        <button
+          className={`summary-bulletins-btn${onOpenBulletins ? ' clickable' : ''}`}
+          onClick={onOpenBulletins}
+          disabled={!onOpenBulletins}
+          aria-label={`Bulletins: ${warnCount} warnings, ${errorCount} errors`}
+          title="Open bulletin board"
+        >
+          {errorCount > 0 && (
+            <span className="bulletin-count error">{errorCount} err</span>
+          )}
+          {warnCount > 0 && (
+            <span className="bulletin-count warn">{warnCount} warn</span>
+          )}
+          {errorCount === 0 && warnCount === 0 && (
+            <span className="bulletin-count ok">Clear</span>
+          )}
+        </button>
+        <span
+          className={`summary-indicator ${bulletinHealth}`}
+          aria-label={`Bulletin health: ${bulletinHealth}`}
         />
       </div>
     </section>

--- a/crates/runifi-api/dashboard-react/src/components/ToastNotifier.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ToastNotifier.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+import type { Toast } from '../hooks/useToast';
+
+interface ToastNotifierProps {
+  toasts: Toast[];
+  onDismiss: (id: number) => void;
+}
+
+function ToastNotifierInner({ toasts, onDismiss }: ToastNotifierProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="toast-container" role="region" aria-live="polite" aria-label="Notifications">
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`toast toast-${toast.kind}`} role="alert">
+          <span className="toast-message">{toast.message}</span>
+          <button
+            className="toast-close"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss notification"
+          >
+            &times;
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const ToastNotifier = memo(ToastNotifierInner);

--- a/crates/runifi-api/dashboard-react/src/hooks/usePlugins.ts
+++ b/crates/runifi-api/dashboard-react/src/hooks/usePlugins.ts
@@ -1,0 +1,122 @@
+// Fetches available processor types from GET /api/v1/plugins
+
+import { useState, useEffect } from 'react';
+import type { PluginDescriptor, PluginsResponse } from '../types/api';
+
+// Fallback plugins when the backend is not yet ready
+const FALLBACK_PLUGINS: PluginDescriptor[] = [
+  {
+    type_name: 'GenerateFlowFile',
+    display_name: 'Generate FlowFile',
+    description: 'Generates synthetic FlowFiles for testing and benchmarking.',
+    kind: 'source',
+    relationships: ['success'],
+    properties: [
+      {
+        name: 'File Size',
+        display_name: 'File Size',
+        description: 'Size of generated content in bytes.',
+        default_value: '5120',
+        required: false,
+      },
+    ],
+  },
+  {
+    type_name: 'LogAttribute',
+    display_name: 'Log Attribute',
+    description: 'Logs FlowFile attributes to the bulletin board.',
+    kind: 'processor',
+    relationships: ['success'],
+    properties: [],
+  },
+  {
+    type_name: 'RouteOnAttribute',
+    display_name: 'Route On Attribute',
+    description: 'Routes FlowFiles based on attribute expressions.',
+    kind: 'processor',
+    relationships: ['matched', 'unmatched'],
+    properties: [],
+  },
+  {
+    type_name: 'UpdateAttribute',
+    display_name: 'Update Attribute',
+    description: 'Adds or updates FlowFile attributes.',
+    kind: 'processor',
+    relationships: ['success'],
+    properties: [],
+  },
+  {
+    type_name: 'GetFile',
+    display_name: 'Get File',
+    description: 'Reads files from a directory on disk.',
+    kind: 'source',
+    relationships: ['success'],
+    properties: [
+      {
+        name: 'Input Directory',
+        display_name: 'Input Directory',
+        description: 'Directory to watch for files.',
+        default_value: '/tmp/input',
+        required: true,
+      },
+    ],
+  },
+  {
+    type_name: 'PutFile',
+    display_name: 'Put File',
+    description: 'Writes FlowFiles to a directory on disk.',
+    kind: 'sink',
+    relationships: ['success', 'failure'],
+    properties: [
+      {
+        name: 'Output Directory',
+        display_name: 'Output Directory',
+        description: 'Directory to write files to.',
+        default_value: '/tmp/output',
+        required: true,
+      },
+    ],
+  },
+];
+
+interface UsePluginsResult {
+  plugins: PluginDescriptor[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function usePlugins(): UsePluginsResult {
+  const [plugins, setPlugins] = useState<PluginDescriptor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch('/api/v1/plugins')
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<PluginsResponse>;
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setPlugins(data.plugins);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          // Backend not ready yet — use fallback list
+          setPlugins(FALLBACK_PLUGINS);
+          setError('Using offline plugin list (backend unavailable)');
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { plugins, loading, error };
+}

--- a/crates/runifi-api/dashboard-react/src/hooks/useToast.ts
+++ b/crates/runifi-api/dashboard-react/src/hooks/useToast.ts
@@ -1,0 +1,40 @@
+// Lightweight toast notification system — no external dependencies
+
+import { useState, useCallback, useRef } from 'react';
+
+export type ToastKind = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+interface UseToastResult {
+  toasts: Toast[];
+  push: (kind: ToastKind, message: string) => void;
+  dismiss: (id: number) => void;
+}
+
+export function useToast(): UseToastResult {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const nextId = useRef(1);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const push = useCallback(
+    (kind: ToastKind, message: string) => {
+      const id = nextId.current++;
+      setToasts((prev) => [...prev, { id, kind, message }]);
+      // Auto-dismiss after 5 seconds
+      setTimeout(() => {
+        dismiss(id);
+      }, 5000);
+    },
+    [dismiss],
+  );
+
+  return { toasts, push, dismiss };
+}

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -37,15 +37,23 @@ body {
 .app-layout {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* Body row: palette + canvas */
+.app-body {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-height: 0;
 }
 
 .app-main {
   flex: 1;
   padding: 1.5rem 2rem;
-  max-width: 1600px;
-  margin: 0 auto;
-  width: 100%;
+  min-width: 0;
+  overflow: auto;
 }
 
 /* ── Header ─────────────────────────────────────────────────── */
@@ -199,7 +207,9 @@ body {
 /* ── DAG section ────────────────────────────────────────────── */
 
 .dag-section {
-  margin-bottom: 2rem;
+  height: calc(100vh - 180px);
+  display: flex;
+  flex-direction: column;
 }
 
 .dag-section h2 {
@@ -209,6 +219,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin-bottom: 1rem;
+  flex-shrink: 0;
 }
 
 /* ── Flow canvas container ──────────────────────────────────── */
@@ -217,9 +228,14 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  height: 560px;
+  flex: 1;
   overflow: hidden;
   position: relative;
+  outline: none;
+}
+
+.flow-canvas-wrapper:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent);
 }
 
 .canvas-placeholder,
@@ -297,10 +313,29 @@ body {
   font-family: var(--font);
   transition: border-color 0.2s;
   cursor: default;
+  position: relative;
 }
 
 .processor-node:hover {
   border-color: var(--accent);
+}
+
+.processor-node-pending {
+  opacity: 0.85;
+}
+
+.processor-node-pending::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 9px;
+  pointer-events: none;
+  animation: pending-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pending-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }
+  50%       { box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.25); }
 }
 
 .proc-node-header {
@@ -438,7 +473,1074 @@ body {
   background: var(--accent) !important;
 }
 
-/* ── Connection edge label ──────────────────────────────────── */
+/* ── Processor Palette sidebar ──────────────────────────────── */
+
+.palette-sidebar {
+  width: 220px;
+  min-width: 220px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  transition: width 0.2s ease, min-width 0.2s ease;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.palette-sidebar-collapsed {
+  width: 36px;
+  min-width: 36px;
+  align-items: center;
+  padding-top: 0.75rem;
+}
+
+.palette-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.palette-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.palette-toggle {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0.2rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  line-height: 1;
+  transition: color 0.15s, background 0.15s;
+}
+
+.palette-toggle:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.palette-search-wrap {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.palette-search {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 0.8rem;
+  font-family: var(--font);
+  padding: 0.3rem 0.5rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.palette-search:focus {
+  border-color: var(--accent);
+}
+
+.palette-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.4rem 0;
+}
+
+.palette-group {
+  margin-bottom: 0.25rem;
+}
+
+.palette-group-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  padding: 0.4rem 0.75rem 0.15rem;
+}
+
+.palette-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  cursor: grab;
+  border-radius: 4px;
+  margin: 0 0.25rem;
+  transition: background 0.12s;
+  user-select: none;
+}
+
+.palette-item:hover {
+  background: var(--surface-hover);
+}
+
+.palette-item:active {
+  cursor: grabbing;
+}
+
+.palette-item-icon {
+  font-size: 0.65rem;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+
+.palette-item-source .palette-item-icon { color: var(--success); }
+.palette-item-processor .palette-item-icon { color: var(--accent); }
+.palette-item-sink .palette-item-icon { color: var(--warning); }
+
+.palette-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.palette-item-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette-item-desc {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette-loading,
+.palette-empty {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  padding: 0.75rem;
+  text-align: center;
+}
+
+.palette-hint {
+  font-size: 0.62rem;
+  color: var(--text-dim);
+  text-align: center;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* ── Canvas drop hint ───────────────────────────────────────── */
+
+.canvas-drop-hint {
+  position: absolute;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(79, 143, 247, 0.15);
+  border: 1px dashed var(--accent);
+  color: var(--accent);
+  border-radius: 6px;
+  padding: 0.4rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+/* ── Modal overlay & panels ─────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+}
+
+.modal-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+  min-width: 320px;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.modal-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.75rem;
+}
+
+.modal-subtitle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 1rem;
+}
+
+.modal-type-tag {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.modal-type-desc {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.modal-body {
+  font-size: 0.85rem;
+  color: var(--text);
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.conn-relationship-display {
+  font-size: 0.85rem;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+}
+
+/* ── Form elements ──────────────────────────────────────────── */
+
+.form-group {
+  margin-bottom: 0.75rem;
+}
+
+.form-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.form-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: var(--font);
+  padding: 0.5rem 0.7rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.form-input:focus {
+  border-color: var(--accent);
+}
+
+.form-input-error {
+  border-color: var(--danger) !important;
+}
+
+.form-select {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: var(--font);
+  padding: 0.5rem 0.7rem;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s;
+  appearance: none;
+}
+
+.form-select:focus {
+  border-color: var(--accent);
+}
+
+.form-error {
+  font-size: 0.75rem;
+  color: var(--danger);
+  margin-top: 0.3rem;
+}
+
+/* ── Buttons ────────────────────────────────────────────────── */
+
+.btn {
+  font-family: var(--font);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  border-radius: 5px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+  white-space: nowrap;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #6ba3f8;
+}
+
+.btn-danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #f98989;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+/* ── Context menu ───────────────────────────────────────────── */
+
+.context-menu {
+  position: fixed;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+  min-width: 160px;
+  z-index: 500;
+  overflow: hidden;
+  padding: 0.2rem 0;
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 0.85rem;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: var(--font);
+  font-size: 0.82rem;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.12s;
+  gap: 0.5rem;
+}
+
+.context-menu-item:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.context-menu-item:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.context-menu-item-danger {
+  color: var(--danger);
+}
+
+.context-menu-hint {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+/* ── Toast notifications ────────────────────────────────────── */
+
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 2000;
+  max-width: 380px;
+  width: 100%;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 7px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  animation: toast-in 0.2s ease;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.toast-success { border-left: 3px solid var(--success); }
+.toast-error   { border-left: 3px solid var(--danger); }
+.toast-warning { border-left: 3px solid var(--warning); }
+.toast-info    { border-left: 3px solid var(--accent); }
+
+.toast-message {
+  flex: 1;
+  font-size: 0.82rem;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  flex-shrink: 0;
+  transition: color 0.12s;
+}
+
+.toast-close:hover {
+  color: var(--text);
+}
+
+/* ── Context menu separator ─────────────────────────────────── */
+
+.context-menu-separator {
+  height: 1px;
+  background: var(--border);
+  margin: 0.2rem 0;
+}
+
+/* ── Summary bar bulletin button ────────────────────────────── */
+
+.summary-bulletins-btn {
+  background: none;
+  border: none;
+  cursor: default;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0;
+  font-family: var(--font);
+}
+
+.summary-bulletins-btn.clickable {
+  cursor: pointer;
+}
+
+.summary-bulletins-btn.clickable:hover .bulletin-count {
+  opacity: 0.8;
+}
+
+.bulletin-count {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+}
+
+.bulletin-count.error {
+  background: rgba(248, 113, 113, 0.2);
+  color: var(--danger);
+}
+
+.bulletin-count.warn {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--warning);
+}
+
+.bulletin-count.ok {
+  background: rgba(52, 211, 153, 0.1);
+  color: var(--success);
+  font-size: 0.68rem;
+}
+
+/* ── Processor config modal ─────────────────────────────────── */
+
+.config-panel {
+  max-width: 560px;
+  width: 100%;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.config-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+  flex-shrink: 0;
+}
+
+.config-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+  transition: color 0.12s;
+  flex-shrink: 0;
+}
+
+.config-close-btn:hover {
+  color: var(--text);
+}
+
+.config-warning {
+  font-size: 0.8rem;
+  color: var(--warning);
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: 5px;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.75rem;
+  flex-shrink: 0;
+}
+
+.config-load-error {
+  font-size: 0.8rem;
+  color: var(--danger);
+  margin-bottom: 0.5rem;
+}
+
+.config-loading {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.config-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0.75rem;
+  flex-shrink: 0;
+}
+
+.config-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-family: var(--font);
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+  margin-bottom: -1px;
+}
+
+.config-tab:hover {
+  color: var(--text);
+}
+
+.config-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.config-tab-content {
+  overflow-y: auto;
+  max-height: 55vh;
+  padding-right: 0.25rem;
+  flex: 1;
+}
+
+.config-field {
+  margin-bottom: 1rem;
+}
+
+.config-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.config-required {
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--danger);
+  background: rgba(248, 113, 113, 0.1);
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+}
+
+.config-description {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  margin-bottom: 0.35rem;
+  line-height: 1.4;
+}
+
+.config-default {
+  display: block;
+  font-size: 0.68rem;
+  color: var(--text-dim);
+  margin-top: 0.2rem;
+}
+
+.config-empty {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.config-save-status {
+  font-size: 0.78rem;
+  margin-top: 0.5rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+}
+
+.config-save-status.success {
+  color: var(--success);
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.config-save-status.error {
+  color: var(--danger);
+  background: rgba(248, 113, 113, 0.08);
+}
+
+/* ── Relationship table (shared by config + queue) ──────────── */
+
+.rel-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.rel-table th {
+  text-align: left;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.rel-table td {
+  padding: 0.45rem 0.5rem;
+  border-bottom: 1px solid rgba(42, 46, 61, 0.5);
+  color: var(--text);
+  vertical-align: top;
+}
+
+.rel-table tr:last-child td {
+  border-bottom: none;
+}
+
+.rel-auto-term {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+}
+
+.rel-auto-term.yes {
+  background: rgba(52, 211, 153, 0.1);
+  color: var(--success);
+}
+
+.rel-auto-term.no {
+  background: rgba(139, 144, 160, 0.1);
+  color: var(--text-dim);
+}
+
+/* ── Queue inspector modal ──────────────────────────────────── */
+
+.queue-panel {
+  max-width: 760px;
+  width: 100%;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.queue-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  flex-shrink: 0;
+}
+
+.queue-summary-count {
+  font-size: 0.82rem;
+  color: var(--text-dim);
+}
+
+.queue-table-wrap {
+  overflow-y: auto;
+  flex: 1;
+  max-height: 55vh;
+  margin-bottom: 0.5rem;
+}
+
+.queue-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.queue-table th {
+  text-align: left;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+}
+
+.queue-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(42, 46, 61, 0.4);
+}
+
+.queue-row:hover {
+  background: var(--surface-hover);
+}
+
+.queue-cell-dim {
+  color: var(--text-dim);
+  font-size: 0.78rem;
+}
+
+.queue-cell-mono {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.queue-empty-row {
+  text-align: center;
+  color: var(--text-dim);
+  padding: 1.5rem 0.5rem;
+  font-size: 0.82rem;
+}
+
+.queue-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-family: var(--font);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: opacity 0.12s;
+}
+
+.btn-link:hover {
+  opacity: 0.75;
+}
+
+.btn-link-danger {
+  color: var(--danger);
+}
+
+.queue-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+  flex-shrink: 0;
+}
+
+.queue-page-info {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+
+/* ── FlowFile detail modal ──────────────────────────────────── */
+
+.ff-detail-panel {
+  max-width: 520px;
+  width: 100%;
+}
+
+.ff-detail-meta {
+  margin-bottom: 1rem;
+}
+
+.detail-row {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid rgba(42, 46, 61, 0.5);
+}
+
+.detail-row:last-child {
+  border-bottom: none;
+}
+
+.detail-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  min-width: 90px;
+  flex-shrink: 0;
+}
+
+.detail-value {
+  font-size: 0.82rem;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.ff-attr-section {
+  margin-bottom: 0.75rem;
+}
+
+.ff-attr-heading {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.5rem;
+}
+
+/* ── Bulletin board panel ───────────────────────────────────── */
+
+.bulletin-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  max-height: 260px;
+  overflow: hidden;
+}
+
+.bulletin-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.bulletin-panel-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-dim);
+  margin-right: auto;
+}
+
+.bulletin-filters {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.bulletin-filter-select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 0.73rem;
+  font-family: var(--font);
+  padding: 0.2rem 0.4rem;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.12s;
+  appearance: none;
+}
+
+.bulletin-filter-select:focus {
+  border-color: var(--accent);
+}
+
+.bulletin-refresh-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font);
+  font-size: 0.72rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.bulletin-refresh-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.bulletin-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.bulletin-empty {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  padding: 1rem;
+  text-align: center;
+}
+
+.bulletin-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid rgba(42, 46, 61, 0.4);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.bulletin-item:hover {
+  background: var(--surface-hover);
+}
+
+.bulletin-item:last-child {
+  border-bottom: none;
+}
+
+.bulletin-item:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.bulletin-severity-badge {
+  font-size: 0.62rem;
+  font-weight: 700;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.bulletin-sev-error,
+.bulletin-severity-badge.bulletin-sev-error {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+}
+
+.bulletin-sev-warn,
+.bulletin-severity-badge.bulletin-sev-warn {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--warning);
+}
+
+.bulletin-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.bulletin-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.15rem;
+}
+
+.bulletin-processor {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bulletin-time {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.bulletin-message {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Connection edge labels (CSS classes over inline styles) ── */
 
 .conn-edge-label {
   display: flex;
@@ -481,6 +1583,13 @@ body {
   color: var(--danger);
 }
 
+.conn-edge-queue-badge.clickable {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
 /* ── Responsive ─────────────────────────────────────────────── */
 
 @media (max-width: 768px) {
@@ -505,7 +1614,7 @@ body {
     padding: 1rem;
   }
 
-  .flow-canvas-wrapper {
-    height: 400px;
+  .palette-sidebar {
+    display: none;
   }
 }

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -83,3 +83,95 @@ export interface SystemResponse {
   processor_count: number;
   connection_count: number;
 }
+
+// Plugin/processor type registry (GET /api/v1/plugins)
+export type PluginKind = 'processor' | 'source' | 'sink';
+
+export interface PluginDescriptor {
+  type_name: string;
+  display_name: string;
+  description: string;
+  kind: PluginKind;
+  relationships: string[];
+  properties: PropertyDescriptor[];
+}
+
+export interface PropertyDescriptor {
+  name: string;
+  display_name: string;
+  description: string;
+  default_value: string | null;
+  required: boolean;
+}
+
+export interface PluginsResponse {
+  plugins: PluginDescriptor[];
+}
+
+// CRUD request bodies
+export interface CreateProcessorRequest {
+  type: string;
+  name: string;
+  position: { x: number; y: number };
+  properties: Record<string, string>;
+}
+
+export interface CreateConnectionRequest {
+  source: string;
+  relationship: string;
+  destination: string;
+}
+
+export interface UpdatePositionRequest {
+  x: number;
+  y: number;
+}
+
+// ── Processor config ───────────────────────────────────────────────
+
+export interface PropertyDescriptorFull {
+  name: string;
+  display_name: string;
+  description: string;
+  default_value: string | null;
+  required: boolean;
+  allowed_values: string[] | null;
+}
+
+export interface RelationshipDescriptor {
+  name: string;
+  description: string;
+  auto_terminated: boolean;
+}
+
+export interface SchedulingConfig {
+  strategy: string;
+  interval_ms: number | null;
+}
+
+export interface ProcessorConfigResponse {
+  processor_name: string;
+  type_name: string;
+  properties: Record<string, string>;
+  property_descriptors: PropertyDescriptorFull[];
+  scheduling: SchedulingConfig;
+  relationships: RelationshipDescriptor[];
+}
+
+// ── Queue inspection ───────────────────────────────────────────────
+
+export interface FlowFileEntry {
+  id: number;
+  position: number;
+  size: number;
+  age_ms: number;
+  has_content: boolean;
+  attributes: Array<{ key: string; value: string }>;
+}
+
+export interface QueueResponse {
+  total_count: number;
+  offset: number;
+  limit: number;
+  flowfiles: FlowFileEntry[];
+}

--- a/crates/runifi-api/dashboard-react/src/types/flow.ts
+++ b/crates/runifi-api/dashboard-react/src/types/flow.ts
@@ -9,6 +9,10 @@ export interface ProcessorNodeData extends Record<string, unknown> {
   state: string;
   metrics: MetricsResponse | null;
   bulletin: BulletinResponse | null;
+  // Relationships this processor can produce (drives source handle count)
+  relationships: string[];
+  // True when created optimistically before the backend confirms
+  pending: boolean;
 }
 
 export interface ConnectionEdgeData extends Record<string, unknown> {
@@ -17,4 +21,8 @@ export interface ConnectionEdgeData extends Record<string, unknown> {
   queuedBytes: number;
   backPressured: boolean;
   connectionId: string;
+  // True when created optimistically before the backend confirms
+  pending: boolean;
+  // Optional callback injected from FlowCanvas to open the queue inspector
+  onQueueClick?: (connectionId: string, label: string) => void;
 }

--- a/crates/runifi-api/dashboard-react/src/utils/format.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/format.ts
@@ -41,3 +41,19 @@ export function backPressureColor(pct: number): string {
   if (pct >= 0.75) return 'var(--warning)';
   return 'var(--accent)';
 }
+
+export function formatAge(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ${secs % 60}s`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ${mins % 60}m`;
+}
+
+export function formatTimestamp(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}

--- a/crates/runifi-api/dashboard-react/src/utils/layout.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/layout.ts
@@ -16,6 +16,8 @@ const PADDING_Y = 60;
 /**
  * Compute layered positions for React Flow nodes using Kahn's topological
  * sort. Returns fully formed ProcNode objects ready for React Flow.
+ * The `relationships` and `pending` fields are set to defaults here and
+ * overridden by the caller once the plugin list is available.
  */
 export function computeLayout(
   processors: FlowNodeResponse[],
@@ -95,6 +97,8 @@ export function computeLayout(
       state: 'stopped',
       metrics: null,
       bulletin: null,
+      relationships: ['success'], // overridden by caller once plugins are loaded
+      pending: false,
     },
   }));
 }


### PR DESCRIPTION
## Summary

Implements full feature parity between the vanilla JS dashboard and the React Flow app (Phase 4 of the React migration, #39).

- **Processor Configuration Modal** — tabbed modal with Properties (dynamic form built from `PropertyDescriptor`, with `<select>` for `allowableValues` and text input otherwise, required field validation), Scheduling (read-only display), and Relationships (table with auto-terminate status). Opens via double-click on a node or context menu "Configure". Save is disabled unless the processor is stopped.
- **Queue Inspection Modal** — paginated FlowFile list (50/page), shows ID, size, age, content flag. Per-row: View details (attributes table), Download content (direct link), Remove (with confirmation). Empty Queue button with confirmation. Triggered by clicking the queue depth label on a connection edge.
- **Bulletin Board Panel** — toggleable bottom panel, opened from the SummaryBar bulletin button. Filterable by severity and processor name. Click any entry for full details. Newest first.
- **Processor Controls** — Start, Stop, Pause, Resume, Reset-Circuit in the right-click context menu. Buttons disabled based on current processor state. Toast feedback on all actions.
- **SummaryBar enhancement** — Running/total processor count, bytes/s throughput alongside FF/s, clickable bulletin pill (error/warn counts, opens bulletin board), bulletin health indicator.
- **ContextMenu** — Configure option, full control action set with separators between groups.
- **ConnectionEdge** — Queue depth label is now clickable (underline hint) when a `connectionId` is available, opening the queue inspector.

## Test plan

- [ ] Build passes: `npm run build` in `dashboard-react/` with zero TypeScript errors
- [ ] Double-click a processor node opens the config modal showing tabs
- [ ] Properties tab: free-form fields and select fields render correctly; required badge shown
- [ ] Save disabled when processor is running/paused; enabled when stopped
- [ ] Right-click context menu shows Configure, Start/Stop/Pause/Resume/Reset-Circuit, Delete with correct enabled states
- [ ] Clicking a connection's "queued" label opens the Queue Inspector
- [ ] Queue Inspector: pagination works, View/Download/Remove actions work, Empty Queue prompts confirmation
- [ ] Summary bar shows "X / Y Running", bytes/s throughput, bulletin pills
- [ ] Bulletin pill button opens the Bulletin Board panel
- [ ] Bulletin Board filters by severity and processor; click opens detail modal

Closes #45