### PR TITLE
fix: handle optional PluginDescriptor fields preventing dashboard crash

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/AddProcessorModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/AddProcessorModal.tsx
@@ -83,8 +83,8 @@ function AddProcessorModalInner({
           Add Processor
         </h3>
         <p className="modal-subtitle">
-          <span className="modal-type-tag">{plugin.display_name}</span>
-          <span className="modal-type-desc">{plugin.description}</span>
+          <span className="modal-type-tag">{plugin.display_name ?? plugin.type_name}</span>
+          {plugin.description && <span className="modal-type-desc">{plugin.description}</span>}
         </p>
 
         <form onSubmit={handleSubmit} noValidate>

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -338,7 +338,7 @@ function FlowCanvasInner({
           state: 'stopped',
           metrics: null,
           bulletin: null,
-          relationships: plugin.relationships,
+          relationships: plugin.relationships ?? ['success'],
           pending: true,
         },
       };
@@ -699,7 +699,7 @@ function FlowCanvasInner({
 
       {draggedPlugin && (
         <div className="canvas-drop-hint" aria-hidden="true">
-          Drop to add {draggedPlugin.display_name}
+          Drop to add {draggedPlugin.display_name ?? draggedPlugin.type_name}
         </div>
       )}
 

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorPalette.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorPalette.tsx
@@ -44,16 +44,16 @@ function PaletteItem({
         e.dataTransfer.setData('application/runifi-plugin', plugin.type_name);
         onDragStart(plugin);
       }}
-      title={plugin.description}
+      title={plugin.description ?? plugin.type_name}
       role="listitem"
-      aria-label={`Drag to add ${plugin.display_name}`}
+      aria-label={`Drag to add ${plugin.display_name ?? plugin.type_name}`}
     >
       <span className="palette-item-icon" aria-hidden="true">
         {kindIcon(plugin.kind)}
       </span>
       <div className="palette-item-text">
-        <span className="palette-item-name">{plugin.display_name}</span>
-        <span className="palette-item-desc">{plugin.description}</span>
+        <span className="palette-item-name">{plugin.display_name ?? plugin.type_name}</span>
+        {plugin.description && <span className="palette-item-desc">{plugin.description}</span>}
       </div>
     </div>
   );
@@ -72,9 +72,9 @@ function ProcessorPaletteInner({
     const q = search.toLowerCase();
     const filtered = plugins.filter(
       (p) =>
-        p.display_name.toLowerCase().includes(q) ||
+        (p.display_name ?? p.type_name).toLowerCase().includes(q) ||
         p.type_name.toLowerCase().includes(q) ||
-        p.description.toLowerCase().includes(q),
+        (p.description ?? '').toLowerCase().includes(q),
     );
 
     const groups = new Map<PluginKind, PluginDescriptor[]>();

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -89,11 +89,11 @@ export type PluginKind = 'processor' | 'source' | 'sink';
 
 export interface PluginDescriptor {
   type_name: string;
-  display_name: string;
-  description: string;
+  display_name?: string;
+  description?: string;
   kind: PluginKind;
-  relationships: string[];
-  properties: PropertyDescriptor[];
+  relationships?: string[];
+  properties?: PropertyDescriptor[];
 }
 
 export interface PropertyDescriptor {


### PR DESCRIPTION
## Summary

- The plugins API (`GET /api/v1/plugins`) returns only `type_name` and `kind` per plugin, but the frontend `PluginDescriptor` TypeScript interface declared `display_name`, `description`, `relationships`, and `properties` as **required** fields
- This caused `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` crashes in `ProcessorPalette`, `AddProcessorModal`, and `FlowCanvas` whenever the dashboard loaded with live API data
- **Root cause**: components were developed against the hardcoded fallback plugin list (which populates all fields) but never tested against the actual API response shape

## Changes

| File | Fix |
|---|---|
| `types/api.ts` | Made `display_name`, `description`, `relationships`, `properties` optional (`?`) |
| `ProcessorPalette.tsx` | Added `??` fallbacks for `display_name` → `type_name`, `description` → `''` in search filter, render, title, and aria-label |
| `AddProcessorModal.tsx` | Fallback `display_name` → `type_name`, conditional render for `description` |
| `FlowCanvas.tsx` | Default `relationships` to `['success']` when undefined, fallback `display_name` → `type_name` in drop hint |

## Test plan

- [x] `npx tsc --noEmit` passes with no type errors
- [x] `npm run build` produces clean production bundle
- [x] Dashboard renders correctly in browser with live API (no blank screen)
- [x] Processor palette shows all 6 registered processors by `type_name`
- [ ] Drag-and-drop a processor onto canvas — verify name modal shows `type_name` fallback
- [ ] Search filter in palette works with partial `type_name` matches

Closes #39