### PR TITLE
feat: harden CI pipeline with audit, deny, SHA pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: Format & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -29,12 +29,12 @@ jobs:
         run: npm ci && npm run build
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache cargo registry & target
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry
@@ -53,10 +53,10 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -67,10 +67,10 @@ jobs:
         run: npm ci && npm run build
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
 
       - name: Cache cargo registry & target
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry
@@ -84,3 +84,15 @@ jobs:
 
       - name: Build release
         run: cargo build --workspace --release
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Run cargo deny
+        run: cargo deny check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,18 +8,17 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Build & Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -30,10 +29,10 @@ jobs:
         run: npm ci && npm run build
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
 
       - name: Cache cargo registry & target
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry
@@ -47,6 +46,18 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Run cargo deny
+        run: cargo deny check
 
       - name: Install cargo-deb
         run: cargo install cargo-deb
@@ -79,7 +90,7 @@ jobs:
         id: tarball
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           generate_release_notes: true
           files: |

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,43 @@
+[advisories]
+# Deny any crates with known security vulnerabilities
+version = 2
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+
+[licenses]
+version = 2
+# Allowed licenses (permissive only — no copyleft)
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+]
+# Deny copyleft licenses
+deny = [
+    "GPL-2.0",
+    "GPL-3.0",
+    "AGPL-3.0",
+    "LGPL-2.0",
+    "LGPL-2.1",
+    "LGPL-3.0",
+]
+# Confidence threshold for license detection
+confidence-threshold = 0.8
+
+[bans]
+# Warn on duplicate versions of the same crate
+multiple-versions = "warn"
+# Deny wildcard dependencies in workspace crates
+wildcards = "deny"
+
+[sources]
+# Only allow crates from crates.io by default
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to immutable commit SHAs (supply-chain attack prevention)
- Add `cargo audit --deny warnings` to fail CI on known CVEs
- Add `cargo deny check` with `deny.toml` for license compliance and advisory enforcement
- Scope `release.yml` permissions from workflow level to job level (principle of least privilege)
- Add Dependabot configuration for weekly automated updates of Actions and Cargo deps

## Changes

### `.github/workflows/ci.yml`
- All `uses:` directives now reference commit SHAs with version comments
- Added `cargo audit` and `cargo deny` steps after build in the `test` job

### `.github/workflows/release.yml`
- All `uses:` directives now reference commit SHAs with version comments
- Moved `permissions: contents: write` from workflow level to job level
- Added `cargo audit` and `cargo deny` steps before packaging

### `deny.toml`
- Allows permissive licenses: MIT, Apache-2.0, BSD-2/3-Clause, ISC, Unicode-3.0, Zlib, CC0-1.0
- Denies copyleft licenses: GPL-2.0/3.0, AGPL-3.0, LGPL-2.0/2.1/3.0
- Warns on duplicate dependency versions, denies wildcard deps and unknown registries

### `.github/dependabot.yml`
- Weekly updates for GitHub Actions (monday)
- Weekly updates for Cargo dependencies (monday)

## SHA Reference

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |
| `actions/setup-node` | `1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a` | v4.2.0 |
| `actions/cache` | `5a3ec84eff668545956fd18022155c47e93e2684` | v4.2.3 |
| `dtolnay/rust-toolchain` | `efa25f7f19611383d5b0ccf2d1c8914531636bf9` | stable |
| `softprops/action-gh-release` | `72f2c25fcb47643c292f7107632f7a47c1df5cd8` | v2.3.2 |

## Test plan

- [ ] CI workflow runs without YAML parse errors
- [ ] `cargo audit` step passes (no known CVEs in deps)
- [ ] `cargo deny check` step passes (all licenses allowed)
- [ ] Release workflow `permissions` is scoped to job level only
- [ ] Dependabot PRs appear on the weekly schedule

Closes #59