### PR TITLE
fix: add path traversal protection to filesystem processors

### DIFF
--- a/crates/runifi-processors/src/get_file.rs
+++ b/crates/runifi-processors/src/get_file.rs
@@ -1,3 +1,4 @@
+use std::path::{Component, Path};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -26,6 +27,25 @@ const PROP_BATCH_SIZE: PropertyDescriptor = PropertyDescriptor::new(
     "Maximum number of files to ingest per trigger",
 )
 .default_value("10");
+
+const PROP_FOLLOW_SYMLINKS: PropertyDescriptor = PropertyDescriptor::new(
+    "Follow Symlinks",
+    "If true, follow symbolic links when reading files (true/false)",
+)
+.default_value("false");
+
+/// Validate that the input directory path does not contain `..` components.
+fn validate_directory_path(dir_str: &str) -> Result<(), PluginError> {
+    let path = Path::new(dir_str);
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            return Err(PluginError::ProcessingFailed(format!(
+                "Input directory contains '..' component: {dir_str}"
+            )));
+        }
+    }
+    Ok(())
+}
 
 /// Watches a directory and ingests files as FlowFiles.
 pub struct GetFile;
@@ -59,8 +79,13 @@ impl Processor for GetFile {
             .unwrap_or("10")
             .parse()
             .unwrap_or(10);
+        let follow_symlinks =
+            context.get_property("Follow Symlinks").unwrap_or("false") == "true";
 
-        let dir = std::path::Path::new(&input_dir);
+        // Validate the input directory path has no `..` components.
+        validate_directory_path(&input_dir)?;
+
+        let dir = Path::new(&input_dir);
         if !dir.is_dir() {
             return Err(PluginError::ProcessingFailed(format!(
                 "Input directory does not exist: {}",
@@ -68,17 +93,62 @@ impl Processor for GetFile {
             )));
         }
 
-        let entries: Vec<_> = std::fs::read_dir(dir)
+        // Canonicalize the input directory to resolve symlinks at the directory level.
+        let canonical_dir = dir.canonicalize().map_err(PluginError::Io)?;
+
+        let entries: Vec<_> = std::fs::read_dir(&canonical_dir)
             .map_err(PluginError::Io)?
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().ok().is_some_and(|ft| ft.is_file()))
+            .filter(|e| {
+                let ft = match e.file_type() {
+                    Ok(ft) => ft,
+                    Err(_) => return false,
+                };
+                if ft.is_file() {
+                    return true;
+                }
+                if ft.is_symlink() && follow_symlinks {
+                    // Check if symlink target is a file.
+                    e.path()
+                        .metadata()
+                        .ok()
+                        .is_some_and(|m| m.is_file())
+                } else {
+                    false
+                }
+            })
             .take(batch_size)
             .collect();
 
         for entry in entries {
             let path = entry.path();
-            let metadata = std::fs::metadata(&path).map_err(PluginError::Io)?;
-            let data = std::fs::read(&path).map_err(PluginError::Io)?;
+
+            // Verify the file's canonical path is within the canonical input directory.
+            // This prevents symlink escape attacks.
+            let canonical_file = match path.canonicalize() {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "Failed to canonicalize file path, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            if !canonical_file.starts_with(&canonical_dir) {
+                tracing::warn!(
+                    path = %path.display(),
+                    canonical = %canonical_file.display(),
+                    dir = %canonical_dir.display(),
+                    "Symlink escape detected: file resolves outside input directory, skipping"
+                );
+                continue;
+            }
+
+            let metadata = std::fs::metadata(&canonical_file).map_err(PluginError::Io)?;
+            let data = std::fs::read(&canonical_file).map_err(PluginError::Io)?;
 
             let mut flowfile = session.create();
 
@@ -88,7 +158,12 @@ impl Processor for GetFile {
             }
             flowfile.set_attribute(
                 Arc::from("path"),
-                Arc::from(path.parent().unwrap_or(dir).to_string_lossy().as_ref()),
+                Arc::from(
+                    path.parent()
+                        .unwrap_or(dir)
+                        .to_string_lossy()
+                        .as_ref(),
+                ),
             );
             flowfile.set_attribute(
                 Arc::from("file.size"),
@@ -113,7 +188,12 @@ impl Processor for GetFile {
     }
 
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
-        vec![PROP_INPUT_DIR, PROP_KEEP_SOURCE, PROP_BATCH_SIZE]
+        vec![
+            PROP_INPUT_DIR,
+            PROP_KEEP_SOURCE,
+            PROP_BATCH_SIZE,
+            PROP_FOLLOW_SYMLINKS,
+        ]
     }
 }
 
@@ -122,5 +202,225 @@ inventory::submit! {
         type_name: "GetFile",
         description: "Watches a directory and ingests files as FlowFiles",
         factory: || Box::new(GetFile::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use runifi_plugin_api::FlowFile;
+    use runifi_plugin_api::property::PropertyValue;
+    use runifi_plugin_api::relationship::Relationship;
+    use runifi_plugin_api::result::ProcessResult;
+
+    struct TestContext {
+        input_dir: String,
+        follow_symlinks: bool,
+        keep_source: bool,
+    }
+
+    impl TestContext {
+        fn new(input_dir: String) -> Self {
+            Self {
+                input_dir,
+                follow_symlinks: false,
+                keep_source: false,
+            }
+        }
+    }
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, name: &str) -> PropertyValue {
+            match name {
+                "Input Directory" => PropertyValue::String(self.input_dir.clone()),
+                "Follow Symlinks" => PropertyValue::String(
+                    if self.follow_symlinks { "true" } else { "false" }.to_string(),
+                ),
+                "Keep Source File" => PropertyValue::String(
+                    if self.keep_source { "true" } else { "false" }.to_string(),
+                ),
+                _ => PropertyValue::Unset,
+            }
+        }
+        fn name(&self) -> &str {
+            "test-get"
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    struct CollectingSession {
+        created_count: u64,
+        flowfiles: Vec<(FlowFile, &'static str)>,
+    }
+
+    impl CollectingSession {
+        fn new() -> Self {
+            Self {
+                created_count: 0,
+                flowfiles: Vec::new(),
+            }
+        }
+    }
+
+    impl ProcessSession for CollectingSession {
+        fn get(&mut self) -> Option<FlowFile> {
+            None
+        }
+        fn get_batch(&mut self, _max: usize) -> Vec<FlowFile> {
+            Vec::new()
+        }
+        fn read_content(&self, _ff: &FlowFile) -> ProcessResult<Bytes> {
+            Ok(Bytes::new())
+        }
+        fn write_content(&mut self, ff: FlowFile, _data: Bytes) -> ProcessResult<FlowFile> {
+            Ok(ff)
+        }
+        fn create(&mut self) -> FlowFile {
+            self.created_count += 1;
+            FlowFile {
+                id: self.created_count,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: 0,
+                created_at_nanos: 0,
+                lineage_start_id: self.created_count,
+                penalized_until_nanos: 0,
+            }
+        }
+        fn clone_flowfile(&mut self, _ff: &FlowFile) -> FlowFile {
+            unimplemented!()
+        }
+        fn transfer(&mut self, ff: FlowFile, rel: &Relationship) {
+            self.flowfiles.push((ff, rel.name));
+        }
+        fn remove(&mut self, _ff: FlowFile) {}
+        fn penalize(&mut self, ff: FlowFile) -> FlowFile {
+            ff
+        }
+        fn commit(&mut self) {}
+        fn rollback(&mut self) {}
+    }
+
+    #[test]
+    fn rejects_input_dir_with_dot_dot() {
+        let mut proc = GetFile::new();
+        let ctx = TestContext::new("/tmp/../etc".to_string());
+        let mut session = CollectingSession::new();
+
+        let result = proc.on_trigger(&ctx, &mut session);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains(".."), "Error should mention '..'");
+    }
+
+    #[test]
+    fn reads_normal_directory() {
+        let tmp = std::env::temp_dir().join("runifi-test-getfile-normal");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Create a test file.
+        std::fs::write(tmp.join("test.txt"), b"hello").unwrap();
+
+        let mut proc = GetFile::new();
+        let mut ctx = TestContext::new(tmp.to_string_lossy().to_string());
+        ctx.follow_symlinks = false;
+
+        let mut session = CollectingSession::new();
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.flowfiles.len(), 1);
+        assert_eq!(session.flowfiles[0].1, "success");
+
+        let ff = &session.flowfiles[0].0;
+        assert_eq!(
+            ff.get_attribute("filename").map(|v| v.as_ref()),
+            Some("test.txt")
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn skips_symlinks_when_follow_disabled() {
+        let tmp = std::env::temp_dir().join("runifi-test-getfile-nosymlink");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Create a real file and a symlink to /etc/hostname.
+        std::fs::write(tmp.join("real.txt"), b"real").unwrap();
+        // Create symlink pointing outside the directory.
+        let symlink_path = tmp.join("escape.txt");
+        let _ = std::os::unix::fs::symlink("/etc/hostname", &symlink_path);
+
+        let mut proc = GetFile::new();
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
+        let mut session = CollectingSession::new();
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // Only the real file should be ingested (symlink skipped due to is_file() check on DirEntry).
+        assert_eq!(session.flowfiles.len(), 1);
+        assert_eq!(
+            session.flowfiles[0].0.get_attribute("filename").map(|v| v.as_ref()),
+            Some("real.txt")
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn blocks_symlink_escape_when_follow_enabled() {
+        let tmp = std::env::temp_dir().join("runifi-test-getfile-symlink-escape");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Create a symlink pointing outside the input directory.
+        let symlink_path = tmp.join("escape.txt");
+        let _ = std::os::unix::fs::symlink("/etc/hostname", &symlink_path);
+
+        let mut proc = GetFile::new();
+        let mut ctx = TestContext::new(tmp.to_string_lossy().to_string());
+        ctx.follow_symlinks = true;
+
+        let mut session = CollectingSession::new();
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // Symlink pointing outside directory should be skipped.
+        assert_eq!(session.flowfiles.len(), 0);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn allows_internal_symlinks_when_follow_enabled() {
+        let tmp = std::env::temp_dir().join("runifi-test-getfile-internal-symlink");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Create a real file and a symlink pointing to it (within same dir).
+        let real_file = tmp.join("original.txt");
+        std::fs::write(&real_file, b"content").unwrap();
+        let symlink_path = tmp.join("link.txt");
+        let _ = std::os::unix::fs::symlink(&real_file, &symlink_path);
+
+        let mut proc = GetFile::new();
+        let mut ctx = TestContext::new(tmp.to_string_lossy().to_string());
+        ctx.follow_symlinks = true;
+        ctx.keep_source = true;
+
+        let mut session = CollectingSession::new();
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // Both files should be ingested (symlink resolves within input dir).
+        assert_eq!(session.flowfiles.len(), 2);
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/runifi-processors/src/put_file.rs
+++ b/crates/runifi-processors/src/put_file.rs
@@ -6,6 +6,9 @@ use runifi_plugin_api::result::{PluginError, ProcessResult};
 use runifi_plugin_api::session::ProcessSession;
 use runifi_plugin_api::{REL_FAILURE, REL_SUCCESS};
 
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Component, Path, PathBuf};
+
 const PROP_OUTPUT_DIR: PropertyDescriptor = PropertyDescriptor::new(
     "Output Directory",
     "The directory to write FlowFile content to",
@@ -17,6 +20,86 @@ const PROP_CONFLICT_STRATEGY: PropertyDescriptor = PropertyDescriptor::new(
     "Strategy when file already exists: 'fail', 'replace', or 'ignore'",
 )
 .default_value("fail");
+
+const PROP_FILE_PERMISSIONS: PropertyDescriptor = PropertyDescriptor::new(
+    "File Permissions",
+    "UNIX file permissions in octal (e.g. '0640')",
+)
+.default_value("0640");
+
+const PROP_DIR_PERMISSIONS: PropertyDescriptor = PropertyDescriptor::new(
+    "Directory Permissions",
+    "UNIX directory permissions in octal (e.g. '0750')",
+)
+.default_value("0750");
+
+/// Sanitize a filename by stripping path separators and `..` components,
+/// rejecting null bytes, and collapsing to just the final file name.
+fn sanitize_filename(raw: &str) -> Result<String, PluginError> {
+    if raw.contains('\0') {
+        return Err(PluginError::ProcessingFailed(
+            "Filename contains null byte".to_string(),
+        ));
+    }
+
+    let path = Path::new(raw);
+    let mut sanitized = String::new();
+
+    for component in path.components() {
+        match component {
+            Component::RootDir
+            | Component::CurDir
+            | Component::ParentDir
+            | Component::Prefix(_) => continue,
+            Component::Normal(seg) => {
+                if let Some(s) = seg.to_str() {
+                    sanitized = s.to_string();
+                }
+            }
+        }
+    }
+
+    if sanitized.is_empty() {
+        return Err(PluginError::ProcessingFailed(
+            "Filename is empty after sanitization".to_string(),
+        ));
+    }
+
+    Ok(sanitized)
+}
+
+/// Validate that the resolved output path is within the canonical output directory.
+fn validate_path_within_dir(path: &Path, canonical_dir: &Path) -> Result<PathBuf, PluginError> {
+    let canonical_path = if let Some(parent) = path.parent() {
+        if parent.exists() {
+            parent
+                .canonicalize()
+                .map_err(PluginError::Io)?
+                .join(path.file_name().unwrap_or_default())
+        } else {
+            path.to_path_buf()
+        }
+    } else {
+        path.to_path_buf()
+    };
+
+    if !canonical_path.starts_with(canonical_dir) {
+        return Err(PluginError::ProcessingFailed(format!(
+            "Path traversal detected: resolved path '{}' is outside output directory '{}'",
+            canonical_path.display(),
+            canonical_dir.display()
+        )));
+    }
+
+    Ok(canonical_path)
+}
+
+fn parse_octal_permissions(s: &str) -> Result<u32, PluginError> {
+    let trimmed = s.trim_start_matches('0');
+    let trimmed = if trimmed.is_empty() { "0" } else { trimmed };
+    u32::from_str_radix(trimmed, 8)
+        .map_err(|_| PluginError::ProcessingFailed(format!("Invalid octal permissions: '{s}'")))
+}
 
 /// Writes FlowFile content to files in a directory.
 pub struct PutFile;
@@ -48,21 +131,64 @@ impl Processor for PutFile {
             .get_property("Conflict Resolution")
             .unwrap_or("fail")
             .to_string();
+        let file_perms_str = context
+            .get_property("File Permissions")
+            .unwrap_or("0640")
+            .to_string();
+        let dir_perms_str = context
+            .get_property("Directory Permissions")
+            .unwrap_or("0750")
+            .to_string();
 
-        let dir = std::path::Path::new(&output_dir);
+        let file_mode = parse_octal_permissions(&file_perms_str)?;
+        let dir_mode = parse_octal_permissions(&dir_perms_str)?;
+
+        let dir = Path::new(&output_dir);
 
         // Create directory if it doesn't exist.
         if !dir.exists() {
             std::fs::create_dir_all(dir).map_err(PluginError::Io)?;
         }
 
+        // Set directory permissions.
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(dir_mode))
+            .map_err(PluginError::Io)?;
+
+        // Canonicalize the output directory for path traversal validation.
+        let canonical_dir = dir.canonicalize().map_err(PluginError::Io)?;
+
         while let Some(flowfile) = session.get() {
-            let filename = flowfile
+            let raw_filename = flowfile
                 .get_attribute("filename")
                 .map(|v| v.to_string())
                 .unwrap_or_else(|| format!("flowfile-{}", flowfile.id));
 
-            let path = dir.join(&filename);
+            // Sanitize the filename to prevent path traversal.
+            let filename = match sanitize_filename(&raw_filename) {
+                Ok(f) => f,
+                Err(e) => {
+                    tracing::warn!(
+                        filename = %raw_filename,
+                        error = %e,
+                        "Rejected unsafe filename"
+                    );
+                    session.transfer(flowfile, &REL_FAILURE);
+                    continue;
+                }
+            };
+
+            let path = canonical_dir.join(&filename);
+
+            // Verify the resolved path is within the output directory.
+            if let Err(e) = validate_path_within_dir(&path, &canonical_dir) {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "Path traversal attempt blocked"
+                );
+                session.transfer(flowfile, &REL_FAILURE);
+                continue;
+            }
 
             // Handle conflict.
             if path.exists() {
@@ -84,6 +210,10 @@ impl Processor for PutFile {
             let content = session.read_content(&flowfile)?;
             std::fs::write(&path, &content).map_err(PluginError::Io)?;
 
+            // Set file permissions.
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(file_mode))
+                .map_err(PluginError::Io)?;
+
             tracing::debug!(
                 path = %path.display(),
                 size = content.len(),
@@ -102,7 +232,12 @@ impl Processor for PutFile {
     }
 
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
-        vec![PROP_OUTPUT_DIR, PROP_CONFLICT_STRATEGY]
+        vec![
+            PROP_OUTPUT_DIR,
+            PROP_CONFLICT_STRATEGY,
+            PROP_FILE_PERMISSIONS,
+            PROP_DIR_PERMISSIONS,
+        ]
     }
 }
 
@@ -124,12 +259,32 @@ mod tests {
 
     struct TestContext {
         output_dir: String,
+        file_permissions: Option<String>,
+        dir_permissions: Option<String>,
+    }
+
+    impl TestContext {
+        fn new(output_dir: String) -> Self {
+            Self {
+                output_dir,
+                file_permissions: None,
+                dir_permissions: None,
+            }
+        }
     }
 
     impl ProcessContext for TestContext {
         fn get_property(&self, name: &str) -> PropertyValue {
             match name {
                 "Output Directory" => PropertyValue::String(self.output_dir.clone()),
+                "File Permissions" => match &self.file_permissions {
+                    Some(v) => PropertyValue::String(v.clone()),
+                    None => PropertyValue::Unset,
+                },
+                "Directory Permissions" => match &self.dir_permissions {
+                    Some(v) => PropertyValue::String(v.clone()),
+                    None => PropertyValue::Unset,
+                },
                 _ => PropertyValue::Unset,
             }
         }
@@ -180,29 +335,30 @@ mod tests {
         fn rollback(&mut self) {}
     }
 
+    fn make_flowfile(id: u64, filename: &str) -> FlowFile {
+        let mut ff = FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 5,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        };
+        ff.set_attribute(Arc::from("filename"), Arc::from(filename));
+        ff
+    }
+
     #[test]
     fn writes_file_to_directory() {
         let tmp = std::env::temp_dir().join("runifi-test-putfile");
         let _ = std::fs::remove_dir_all(&tmp);
 
         let mut proc = PutFile::new();
-        let ctx = TestContext {
-            output_dir: tmp.to_string_lossy().to_string(),
-        };
-
-        let mut ff = FlowFile {
-            id: 1,
-            attributes: Vec::new(),
-            content_claim: None,
-            size: 5,
-            created_at_nanos: 0,
-            lineage_start_id: 1,
-            penalized_until_nanos: 0,
-        };
-        ff.set_attribute(Arc::from("filename"), Arc::from("output.txt"));
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
 
         let mut session = OneFlowFileSession {
-            input: Some(ff),
+            input: Some(make_flowfile(1, "output.txt")),
             content: Bytes::from_static(b"hello"),
             transferred: Vec::new(),
         };
@@ -214,6 +370,150 @@ mod tests {
 
         let written = std::fs::read_to_string(tmp.join("output.txt")).unwrap();
         assert_eq!(written, "hello");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sanitizes_path_traversal_with_dot_dot() {
+        let tmp = std::env::temp_dir().join("runifi-test-putfile-traversal");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let mut proc = PutFile::new();
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
+
+        let mut session = OneFlowFileSession {
+            input: Some(make_flowfile(1, "../../etc/passwd")),
+            content: Bytes::from_static(b"malicious"),
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // The filename is sanitized to "passwd" and written safely within output dir.
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "success");
+        assert!(tmp.join("passwd").exists());
+        let written = std::fs::read_to_string(tmp.join("passwd")).unwrap();
+        assert_eq!(written, "malicious");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sanitizes_absolute_path_filename() {
+        let tmp = std::env::temp_dir().join("runifi-test-putfile-abspath");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let mut proc = PutFile::new();
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
+
+        let mut session = OneFlowFileSession {
+            input: Some(make_flowfile(1, "/etc/shadow")),
+            content: Bytes::from_static(b"malicious"),
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // The filename is sanitized to "shadow" and written safely within output dir.
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "success");
+        assert!(tmp.join("shadow").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn rejects_null_byte_filename() {
+        let tmp = std::env::temp_dir().join("runifi-test-putfile-null");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let mut proc = PutFile::new();
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
+
+        let mut session = OneFlowFileSession {
+            input: Some(make_flowfile(1, "test\0file.txt")),
+            content: Bytes::from_static(b"malicious"),
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // Should be routed to failure.
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn allows_normal_filenames() {
+        let tmp = std::env::temp_dir().join("runifi-test-putfile-normal");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let mut proc = PutFile::new();
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
+
+        let mut session = OneFlowFileSession {
+            input: Some(make_flowfile(1, "my-report-2024.csv")),
+            content: Bytes::from_static(b"data"),
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "success");
+        assert!(tmp.join("my-report-2024.csv").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sets_file_permissions() {
+        let tmp = std::env::temp_dir().join("runifi-test-putfile-perms");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let mut proc = PutFile::new();
+        let mut ctx = TestContext::new(tmp.to_string_lossy().to_string());
+        ctx.file_permissions = Some("0600".to_string());
+
+        let mut session = OneFlowFileSession {
+            input: Some(make_flowfile(1, "secure.txt")),
+            content: Bytes::from_static(b"secret"),
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "success");
+
+        let metadata = std::fs::metadata(tmp.join("secure.txt")).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sanitizes_mixed_traversal_attempts() {
+        let tmp = std::env::temp_dir().join("runifi-test-putfile-mixed");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let mut proc = PutFile::new();
+        let ctx = TestContext::new(tmp.to_string_lossy().to_string());
+
+        let mut session = OneFlowFileSession {
+            input: Some(make_flowfile(1, "./../../secret.txt")),
+            content: Bytes::from_static(b"safe"),
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+        assert_eq!(session.transferred[0].1, "success");
+        assert!(tmp.join("secret.txt").exists());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
## Summary

- **PutFile**: Sanitize filenames by stripping `..`, `/`, and absolute path components; reject null bytes; canonicalize output directory and validate resolved paths stay within it; add configurable `File Permissions` (default `0640`) and `Directory Permissions` (default `0750`) properties with `std::os::unix::fs::PermissionsExt`
- **GetFile**: Reject input directories containing `..` components; canonicalize input directory at runtime; verify discovered files resolve within the configured directory (prevents symlink escape attacks); add `Follow Symlinks` property (default: `false`)
- **Tests**: 10 new unit tests covering path traversal (`../../etc/passwd`), absolute path injection (`/etc/shadow`), null byte injection, symlink escape detection, internal symlink following, and file permission enforcement

## Test plan

- [x] `cargo test -p runifi-processors` — all 16 tests pass (10 new security tests)
- [x] `cargo clippy -p runifi-processors -- -D warnings` — zero warnings
- [ ] Manual verification: attempt to write files outside output directory via crafted filename attributes

Closes #54