### PR TITLE
feat: harden API with CORS, rate limiting, and input validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +66,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
@@ -182,6 +197,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "cipher"
@@ -680,6 +709,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +946,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1207,6 +1269,7 @@ dependencies = [
  "governor",
  "include_dir",
  "runifi-core",
+ "runifi-plugin-api",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1234,6 +1297,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "bytes",
+ "chrono",
  "crossbeam",
  "dashmap",
  "futures",
@@ -2105,10 +2169,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/runifi-api/src/error.rs
+++ b/crates/runifi-api/src/error.rs
@@ -121,9 +121,9 @@ impl From<MutationError> for ApiError {
                 "Processor has active connections: {}. Remove them first.",
                 ids
             )),
-            MutationError::UnknownRelationship(rel, proc) => ApiError::BadRequest(format!(
+            MutationError::UnknownRelationship(rel, proc_name) => ApiError::BadRequest(format!(
                 "Processor '{}' does not have a relationship named '{}'",
-                proc, rel
+                proc_name, rel
             )),
             MutationError::DuplicateConnection(src, rel, dst) => ApiError::Conflict(format!(
                 "Connection from '{}' via '{}' to '{}' already exists",

--- a/crates/runifi-api/src/routes/processors.rs
+++ b/crates/runifi-api/src/routes/processors.rs
@@ -59,7 +59,6 @@ async fn get_processor(
     Ok(Json(ProcessorResponse::from_info(&info)))
 }
 
-/// Validate a processor name: non-empty, max 128 chars, only `[a-zA-Z0-9_-]`.
 fn validate_processor_name(name: &str) -> Result<(), ApiError> {
     if name.is_empty() {
         return Err(ApiError::BadRequest(
@@ -138,8 +137,6 @@ async fn create_processor(
     validate_processor_name(&body.name)?;
 
     // Look up the processor type to get its property descriptors for validation.
-    // We create a temporary instance just to extract descriptors, then discard it.
-    // The engine will create the real instance via add_processor.
     let plugin_types = &state.handle.plugin_types;
     let type_exists = plugin_types.iter().any(|p| p.type_name == body.type_name);
     if !type_exists {
@@ -151,12 +148,6 @@ async fn create_processor(
 
     // Get property descriptors from an existing processor of the same type,
     // or validate after creation using the info that comes back.
-    // Since we cannot access the plugin registry directly from here,
-    // we validate properties after the processor is successfully created
-    // using the property descriptors stored in ProcessorInfo.
-    //
-    // However, to avoid creating a processor with bad properties, we first
-    // try to look up descriptors from an existing processor of the same type.
     let descriptors: Vec<runifi_plugin_api::PropertyDescriptor> = state
         .handle
         .processors
@@ -248,7 +239,6 @@ async fn create_processor(
         state.handle.set_position(&body.name, pos.x, pos.y);
     }
 
-    // Build detailed response.
     let info = state
         .handle
         .get_processor_info(&body.name)
@@ -283,7 +273,6 @@ async fn create_processor(
     Ok((StatusCode::CREATED, Json(detail)).into_response())
 }
 
-/// Remove a processor at runtime.
 async fn delete_processor(
     State(state): State<ApiState>,
     Path(name): Path<String>,
@@ -294,19 +283,16 @@ async fn delete_processor(
         .await
         .map_err(ApiError::from)?;
 
-    // Remove stored position.
     state.handle.positions.remove(&name);
 
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// Update the canvas position for a processor.
 async fn update_position(
     State(state): State<ApiState>,
     Path(name): Path<String>,
     Json(body): Json<UpdatePositionRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // Validate processor exists.
     if state.handle.get_processor_info(&name).is_none() {
         return Err(ApiError::ProcessorNotFound(name));
     }


### PR DESCRIPTION
## Summary

Closes #58

- **CORS restrictions**: Configurable `cors_allowed_origins` in `ApiConfig`. Empty list (default) = same-origin only (no CORS headers sent). When origins are specified, only those origins are allowed. Methods restricted to GET/POST/PUT/DELETE, headers to Content-Type and Authorization.
- **Request body size limit**: `RequestBodyLimitLayer` with configurable `max_request_body_bytes` (default: 1MB / 1,048,576 bytes). Prevents oversized payloads from consuming server memory.
- **Per-IP rate limiting**: Uses `governor` crate with `DashMapStateStore` for per-IP tracking. Configurable `rate_limit_per_second` (default: 100). Supports `X-Forwarded-For` header parsing for reverse proxy deployments. Returns 429 when exceeded.
- **SSE connection limit**: `AtomicUsize` counter tracks active SSE connections. Configurable `max_sse_connections` (default: 50). Returns 429 when limit reached. `SseGuardedStream` wrapper ensures counter cleanup on client disconnect via `Drop`.
- **Error message sanitization**: `detailed_errors` flag (default: `false`). When disabled, error responses use generic messages (e.g., "Resource not found" instead of "Processor 'my-secret-processor' not found") to prevent leaking internal topology.
- **Property validation on processor creation**: Validates property keys against `PropertyDescriptorInfo` list, rejects unknown keys with 400, enforces required properties and `allowed_values` constraints.

## Files Changed

- `Cargo.toml` — Added `tower`, `governor` workspace deps; added `limit` feature to `tower-http`
- `crates/runifi-api/Cargo.toml` — Added `tower`, `governor` deps; `limit` feature for `tower-http`
- `crates/runifi-core/src/config/flow_config.rs` — Added security fields to `ApiConfig` (Clone derive, 5 new fields with defaults)
- `crates/runifi-api/src/lib.rs` — Rewrote router setup with CORS, rate limiting, body limit middleware; new `start_api_server` signature accepts `&ApiConfig`
- `crates/runifi-api/src/state.rs` — Added SSE connection tracking fields, `with_config()` constructor
- `crates/runifi-api/src/error.rs` — Added `TooManyRequests` variant, `status()`, `sanitized_message()`, `into_response_with_detail()`
- `crates/runifi-api/src/routes/events.rs` — SSE connection limiting with `SseGuardedStream`
- `crates/runifi-api/src/routes/processors.rs` — Property validation via `validate_properties_against_descriptors()`
- `crates/runifi-server/src/main.rs` — Updated to pass `ApiConfig` to API server

## Test plan

- [x] All 67 workspace tests pass
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] No regressions in existing processor, connection, or engine tests
- [ ] Manual test: verify CORS headers absent when `cors_allowed_origins` is empty
- [ ] Manual test: verify 429 response when rate limit exceeded
- [ ] Manual test: verify SSE connection limit enforcement
- [ ] Manual test: verify sanitized error messages in default mode