### PR TITLE
feat: add role-based access control (RBAC)

### DIFF
--- a/crates/runifi-api/src/auth.rs
+++ b/crates/runifi-api/src/auth.rs
@@ -17,6 +17,7 @@ use axum::response::{IntoResponse, Response};
 use rand::Rng;
 use subtle::ConstantTimeEq;
 
+use crate::rbac::Role;
 use crate::state::ApiState;
 
 /// Name of the CSRF cookie set on dashboard pages.
@@ -53,16 +54,22 @@ pub fn generate_csrf_token() -> String {
 // Authentication middleware
 // ---------------------------------------------------------------------------
 
-/// Axum middleware that enforces API key authentication.
+/// Axum middleware that enforces API key authentication and attaches the
+/// caller's [`Role`] to request extensions for downstream permission checks.
 ///
-/// If no API keys are configured, all requests are allowed through.
+/// If no API keys are configured, all requests are allowed through (no role
+/// is attached — handlers default to `Admin`).
 /// Dashboard static paths (`/`, `/assets/*`) are always exempt.
 ///
 /// Valid authentication methods:
 ///   1. `Authorization: Bearer <key>` header
 ///   2. `?api_key=<key>` query parameter (useful for SSE EventSource)
-pub async fn auth_middleware(State(state): State<ApiState>, req: Request, next: Next) -> Response {
-    // If auth is not enabled, pass through.
+pub async fn auth_middleware(
+    State(state): State<ApiState>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    // If auth is not enabled, pass through (no role set — defaults to Admin).
     if !state.security.auth_enabled() {
         return next.run(req).await;
     }
@@ -78,7 +85,13 @@ pub async fn auth_middleware(State(state): State<ApiState>, req: Request, next: 
     let provided_key = extract_api_key(&req);
 
     match provided_key {
-        Some(key) if validate_api_key(&key, &state.security.api_keys) => next.run(req).await,
+        Some(ref key) if validate_api_key(key, &state.security) => {
+            // Look up the role for this key and attach it to extensions.
+            if let Some(role) = resolve_role(key, &state.security) {
+                req.extensions_mut().insert(role);
+            }
+            next.run(req).await
+        }
         _ => {
             let body = serde_json::json!({ "error": "Unauthorized" });
             (StatusCode::UNAUTHORIZED, axum::Json(body)).into_response()
@@ -180,14 +193,30 @@ fn extract_api_key(req: &Request) -> Option<String> {
 }
 
 /// Validate an API key against the configured keys using constant-time comparison.
-fn validate_api_key(provided: &str, configured_keys: &[String]) -> bool {
+fn validate_api_key(
+    provided: &str,
+    security: &runifi_core::config::flow_config::SecurityConfig,
+) -> bool {
+    let configured_keys = security.key_strings();
     let provided_bytes = provided.as_bytes();
     for key in configured_keys {
-        if constant_time_eq(provided, key.as_str()) && provided_bytes.len() == key.len() {
+        if constant_time_eq(provided, key) && provided_bytes.len() == key.len() {
             return true;
         }
     }
     false
+}
+
+/// Resolve the [`Role`] for a validated API key.
+///
+/// Simple string keys (backward compat) are treated as `Admin`.
+/// Structured keys use the configured role. Unknown role strings default to `Viewer`.
+fn resolve_role(
+    provided: &str,
+    security: &runifi_core::config::flow_config::SecurityConfig,
+) -> Option<Role> {
+    let role_str = security.role_for_key(provided)?;
+    Some(Role::parse(role_str).unwrap_or(Role::Viewer))
 }
 
 /// Constant-time string comparison to prevent timing attacks.
@@ -284,13 +313,93 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_api_key() {
-        let keys = vec!["key-abc123".to_string(), "key-def456".to_string()];
-        assert!(validate_api_key("key-abc123", &keys));
-        assert!(validate_api_key("key-def456", &keys));
-        assert!(!validate_api_key("key-invalid", &keys));
-        assert!(!validate_api_key("", &keys));
-        assert!(!validate_api_key("key-abc12", &keys)); // partial match
+    fn test_validate_api_key_simple() {
+        use runifi_core::config::flow_config::{ApiKeyEntry, SecurityConfig};
+        let security = SecurityConfig {
+            api_keys: vec![
+                ApiKeyEntry::Simple("key-abc123".to_string()),
+                ApiKeyEntry::Simple("key-def456".to_string()),
+            ],
+            ..SecurityConfig::default()
+        };
+        assert!(validate_api_key("key-abc123", &security));
+        assert!(validate_api_key("key-def456", &security));
+        assert!(!validate_api_key("key-invalid", &security));
+        assert!(!validate_api_key("", &security));
+        assert!(!validate_api_key("key-abc12", &security)); // partial match
+    }
+
+    #[test]
+    fn test_validate_api_key_with_roles() {
+        use runifi_core::config::flow_config::{ApiKeyEntry, ApiKeyWithRole, SecurityConfig};
+        let security = SecurityConfig {
+            api_keys: vec![
+                ApiKeyEntry::WithRole(ApiKeyWithRole {
+                    key: "admin-key".to_string(),
+                    role: "admin".to_string(),
+                }),
+                ApiKeyEntry::WithRole(ApiKeyWithRole {
+                    key: "viewer-key".to_string(),
+                    role: "viewer".to_string(),
+                }),
+            ],
+            ..SecurityConfig::default()
+        };
+        assert!(validate_api_key("admin-key", &security));
+        assert!(validate_api_key("viewer-key", &security));
+        assert!(!validate_api_key("unknown", &security));
+    }
+
+    #[test]
+    fn test_resolve_role_simple_keys() {
+        use runifi_core::config::flow_config::{ApiKeyEntry, SecurityConfig};
+        let security = SecurityConfig {
+            api_keys: vec![ApiKeyEntry::Simple("key-abc123".to_string())],
+            ..SecurityConfig::default()
+        };
+        // Simple keys default to Admin.
+        assert_eq!(resolve_role("key-abc123", &security), Some(Role::Admin));
+        assert_eq!(resolve_role("unknown", &security), None);
+    }
+
+    #[test]
+    fn test_resolve_role_with_roles() {
+        use runifi_core::config::flow_config::{ApiKeyEntry, ApiKeyWithRole, SecurityConfig};
+        let security = SecurityConfig {
+            api_keys: vec![
+                ApiKeyEntry::WithRole(ApiKeyWithRole {
+                    key: "admin-key".to_string(),
+                    role: "admin".to_string(),
+                }),
+                ApiKeyEntry::WithRole(ApiKeyWithRole {
+                    key: "op-key".to_string(),
+                    role: "operator".to_string(),
+                }),
+                ApiKeyEntry::WithRole(ApiKeyWithRole {
+                    key: "view-key".to_string(),
+                    role: "viewer".to_string(),
+                }),
+            ],
+            ..SecurityConfig::default()
+        };
+        assert_eq!(resolve_role("admin-key", &security), Some(Role::Admin));
+        assert_eq!(resolve_role("op-key", &security), Some(Role::Operator));
+        assert_eq!(resolve_role("view-key", &security), Some(Role::Viewer));
+        assert_eq!(resolve_role("missing", &security), None);
+    }
+
+    #[test]
+    fn test_resolve_role_unknown_role_string() {
+        use runifi_core::config::flow_config::{ApiKeyEntry, ApiKeyWithRole, SecurityConfig};
+        let security = SecurityConfig {
+            api_keys: vec![ApiKeyEntry::WithRole(ApiKeyWithRole {
+                key: "bad-role-key".to_string(),
+                role: "superadmin".to_string(),
+            })],
+            ..SecurityConfig::default()
+        };
+        // Unknown role strings default to Viewer for safety.
+        assert_eq!(resolve_role("bad-role-key", &security), Some(Role::Viewer));
     }
 
     #[test]

--- a/crates/runifi-api/src/error.rs
+++ b/crates/runifi-api/src/error.rs
@@ -34,6 +34,9 @@ pub enum ApiError {
 
     #[error("Too many requests")]
     TooManyRequests,
+
+    #[error("Forbidden: insufficient permissions")]
+    Forbidden,
 }
 
 impl ApiError {
@@ -49,6 +52,7 @@ impl ApiError {
             ApiError::Conflict(_) => StatusCode::CONFLICT,
             ApiError::EngineNotRunning => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
+            ApiError::Forbidden => StatusCode::FORBIDDEN,
         }
     }
 
@@ -65,6 +69,7 @@ impl ApiError {
             ApiError::Conflict(_) => "Conflict",
             ApiError::EngineNotRunning => "Service unavailable",
             ApiError::TooManyRequests => "Too many requests",
+            ApiError::Forbidden => "Forbidden",
         }
     }
 

--- a/crates/runifi-api/src/lib.rs
+++ b/crates/runifi-api/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 mod dashboard;
 mod dto;
 mod error;
+pub mod rbac;
 mod routes;
 mod state;
 

--- a/crates/runifi-api/src/rbac.rs
+++ b/crates/runifi-api/src/rbac.rs
@@ -1,0 +1,290 @@
+//! Role-based access control (RBAC) types and permission checking.
+//!
+//! Defines the role hierarchy (`Admin > Operator > Viewer`) and the set of
+//! permissions that each role grants. Route handlers use [`require_permission`]
+//! to enforce access control after the auth middleware has attached a [`Role`]
+//! to the request extensions.
+
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// Roles ordered by privilege level (highest to lowest).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+    /// Full control: flow mutations, config changes, operations, and viewing.
+    Admin,
+    /// Operational control: start/stop/pause processors, view, access content.
+    Operator,
+    /// Read-only: view flow state, metrics, bulletins.
+    Viewer,
+}
+
+impl Role {
+    /// Parse a role from a string (case-insensitive).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "admin" => Some(Role::Admin),
+            "operator" => Some(Role::Operator),
+            "viewer" => Some(Role::Viewer),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this role has the given permission.
+    pub fn has_permission(self, permission: Permission) -> bool {
+        match permission {
+            Permission::ViewFlow => true, // All roles can view.
+            Permission::OperateProcessors => matches!(self, Role::Admin | Role::Operator),
+            Permission::AccessContent => matches!(self, Role::Admin | Role::Operator),
+            Permission::ModifyFlow => matches!(self, Role::Admin),
+            Permission::ManageConfig => matches!(self, Role::Admin),
+        }
+    }
+
+    /// Return a human-readable name for this role.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::Admin => "admin",
+            Role::Operator => "operator",
+            Role::Viewer => "viewer",
+        }
+    }
+}
+
+/// Permissions that can be required by route handlers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Permission {
+    /// View flow state, metrics, processors, connections, bulletins.
+    /// Required role: Viewer or higher.
+    ViewFlow,
+    /// Start, stop, pause, resume processors; manage queue items.
+    /// Required role: Operator or higher.
+    OperateProcessors,
+    /// Download FlowFile content, access provenance data.
+    /// Required role: Operator or higher.
+    AccessContent,
+    /// Create, delete, or structurally modify processors and connections.
+    /// Required role: Admin only.
+    ModifyFlow,
+    /// Change processor configuration properties.
+    /// Required role: Admin only.
+    ManageConfig,
+}
+
+impl Permission {
+    /// Return a human-readable label for this permission.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Permission::ViewFlow => "ViewFlow",
+            Permission::OperateProcessors => "OperateProcessors",
+            Permission::AccessContent => "AccessContent",
+            Permission::ModifyFlow => "ModifyFlow",
+            Permission::ManageConfig => "ManageConfig",
+        }
+    }
+
+    /// Return the minimum role required for this permission.
+    pub fn minimum_role(self) -> &'static str {
+        match self {
+            Permission::ViewFlow => "viewer",
+            Permission::OperateProcessors => "operator",
+            Permission::AccessContent => "operator",
+            Permission::ModifyFlow => "admin",
+            Permission::ManageConfig => "admin",
+        }
+    }
+}
+
+/// Check that the request has the required permission.
+///
+/// When auth is disabled, all requests are treated as `Admin`. When auth is
+/// enabled, the [`Role`] must have been inserted into request extensions by
+/// the auth middleware.
+///
+/// Returns `Ok(())` on success, or a 403 Forbidden response on failure.
+pub fn require_permission(req: &Request, permission: Permission) -> Result<(), Box<Response>> {
+    // If no role is attached, auth is disabled — treat as Admin.
+    let role = req
+        .extensions()
+        .get::<Role>()
+        .copied()
+        .unwrap_or(Role::Admin);
+
+    if role.has_permission(permission) {
+        Ok(())
+    } else {
+        let body = serde_json::json!({
+            "error": "Forbidden",
+            "required_permission": permission.as_str(),
+            "minimum_role": permission.minimum_role(),
+        });
+        Err(Box::new(
+            (StatusCode::FORBIDDEN, axum::Json(body)).into_response(),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Permission middleware helpers
+// ---------------------------------------------------------------------------
+
+/// Axum middleware that requires `ViewFlow` permission (Viewer+).
+pub async fn require_view_flow(req: Request, next: Next) -> Response {
+    if let Err(resp) = require_permission(&req, Permission::ViewFlow) {
+        return *resp;
+    }
+    next.run(req).await
+}
+
+/// Axum middleware that requires `OperateProcessors` permission (Operator+).
+pub async fn require_operate_processors(req: Request, next: Next) -> Response {
+    if let Err(resp) = require_permission(&req, Permission::OperateProcessors) {
+        return *resp;
+    }
+    next.run(req).await
+}
+
+/// Axum middleware that requires `AccessContent` permission (Operator+).
+pub async fn require_access_content(req: Request, next: Next) -> Response {
+    if let Err(resp) = require_permission(&req, Permission::AccessContent) {
+        return *resp;
+    }
+    next.run(req).await
+}
+
+/// Axum middleware that requires `ModifyFlow` permission (Admin only).
+pub async fn require_modify_flow(req: Request, next: Next) -> Response {
+    if let Err(resp) = require_permission(&req, Permission::ModifyFlow) {
+        return *resp;
+    }
+    next.run(req).await
+}
+
+/// Axum middleware that requires `ManageConfig` permission (Admin only).
+pub async fn require_manage_config(req: Request, next: Next) -> Response {
+    if let Err(resp) = require_permission(&req, Permission::ManageConfig) {
+        return *resp;
+    }
+    next.run(req).await
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_role_parse() {
+        assert_eq!(Role::parse("admin"), Some(Role::Admin));
+        assert_eq!(Role::parse("Admin"), Some(Role::Admin));
+        assert_eq!(Role::parse("ADMIN"), Some(Role::Admin));
+        assert_eq!(Role::parse("operator"), Some(Role::Operator));
+        assert_eq!(Role::parse("Operator"), Some(Role::Operator));
+        assert_eq!(Role::parse("viewer"), Some(Role::Viewer));
+        assert_eq!(Role::parse("Viewer"), Some(Role::Viewer));
+        assert_eq!(Role::parse("unknown"), None);
+        assert_eq!(Role::parse(""), None);
+    }
+
+    #[test]
+    fn test_role_as_str() {
+        assert_eq!(Role::Admin.as_str(), "admin");
+        assert_eq!(Role::Operator.as_str(), "operator");
+        assert_eq!(Role::Viewer.as_str(), "viewer");
+    }
+
+    #[test]
+    fn test_admin_has_all_permissions() {
+        assert!(Role::Admin.has_permission(Permission::ViewFlow));
+        assert!(Role::Admin.has_permission(Permission::OperateProcessors));
+        assert!(Role::Admin.has_permission(Permission::AccessContent));
+        assert!(Role::Admin.has_permission(Permission::ModifyFlow));
+        assert!(Role::Admin.has_permission(Permission::ManageConfig));
+    }
+
+    #[test]
+    fn test_operator_permissions() {
+        assert!(Role::Operator.has_permission(Permission::ViewFlow));
+        assert!(Role::Operator.has_permission(Permission::OperateProcessors));
+        assert!(Role::Operator.has_permission(Permission::AccessContent));
+        assert!(!Role::Operator.has_permission(Permission::ModifyFlow));
+        assert!(!Role::Operator.has_permission(Permission::ManageConfig));
+    }
+
+    #[test]
+    fn test_viewer_permissions() {
+        assert!(Role::Viewer.has_permission(Permission::ViewFlow));
+        assert!(!Role::Viewer.has_permission(Permission::OperateProcessors));
+        assert!(!Role::Viewer.has_permission(Permission::AccessContent));
+        assert!(!Role::Viewer.has_permission(Permission::ModifyFlow));
+        assert!(!Role::Viewer.has_permission(Permission::ManageConfig));
+    }
+
+    #[test]
+    fn test_permission_as_str() {
+        assert_eq!(Permission::ViewFlow.as_str(), "ViewFlow");
+        assert_eq!(Permission::OperateProcessors.as_str(), "OperateProcessors");
+        assert_eq!(Permission::AccessContent.as_str(), "AccessContent");
+        assert_eq!(Permission::ModifyFlow.as_str(), "ModifyFlow");
+        assert_eq!(Permission::ManageConfig.as_str(), "ManageConfig");
+    }
+
+    #[test]
+    fn test_permission_minimum_role() {
+        assert_eq!(Permission::ViewFlow.minimum_role(), "viewer");
+        assert_eq!(Permission::OperateProcessors.minimum_role(), "operator");
+        assert_eq!(Permission::AccessContent.minimum_role(), "operator");
+        assert_eq!(Permission::ModifyFlow.minimum_role(), "admin");
+        assert_eq!(Permission::ManageConfig.minimum_role(), "admin");
+    }
+
+    #[test]
+    fn test_require_permission_no_role_in_extensions() {
+        // When no role is in extensions (auth disabled), defaults to Admin.
+        let req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        assert!(require_permission(&req, Permission::ViewFlow).is_ok());
+        assert!(require_permission(&req, Permission::ModifyFlow).is_ok());
+        assert!(require_permission(&req, Permission::ManageConfig).is_ok());
+    }
+
+    #[test]
+    fn test_require_permission_viewer_role() {
+        let mut req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        req.extensions_mut().insert(Role::Viewer);
+
+        assert!(require_permission(&req, Permission::ViewFlow).is_ok());
+        assert!(require_permission(&req, Permission::ModifyFlow).is_err());
+        assert!(require_permission(&req, Permission::OperateProcessors).is_err());
+        assert!(require_permission(&req, Permission::AccessContent).is_err());
+        assert!(require_permission(&req, Permission::ManageConfig).is_err());
+    }
+
+    #[test]
+    fn test_require_permission_operator_role() {
+        let mut req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        req.extensions_mut().insert(Role::Operator);
+
+        assert!(require_permission(&req, Permission::ViewFlow).is_ok());
+        assert!(require_permission(&req, Permission::OperateProcessors).is_ok());
+        assert!(require_permission(&req, Permission::AccessContent).is_ok());
+        assert!(require_permission(&req, Permission::ModifyFlow).is_err());
+        assert!(require_permission(&req, Permission::ManageConfig).is_err());
+    }
+
+    #[test]
+    fn test_require_permission_admin_role() {
+        let mut req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        req.extensions_mut().insert(Role::Admin);
+
+        assert!(require_permission(&req, Permission::ViewFlow).is_ok());
+        assert!(require_permission(&req, Permission::OperateProcessors).is_ok());
+        assert!(require_permission(&req, Permission::AccessContent).is_ok());
+        assert!(require_permission(&req, Permission::ModifyFlow).is_ok());
+        assert!(require_permission(&req, Permission::ManageConfig).is_ok());
+    }
+}

--- a/crates/runifi-api/src/routes/bulletins.rs
+++ b/crates/runifi-api/src/routes/bulletins.rs
@@ -7,6 +7,7 @@ use runifi_core::engine::bulletin::BulletinSeverity;
 
 use crate::dto::BulletinResponse;
 use crate::error::ApiError;
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
@@ -16,6 +17,7 @@ pub fn routes() -> Router<ApiState> {
             "/api/v1/processors/{name}/bulletins",
             get(list_processor_bulletins),
         )
+        .layer(axum::middleware::from_fn(rbac::require_view_flow))
 }
 
 #[derive(Deserialize)]

--- a/crates/runifi-api/src/routes/connections.rs
+++ b/crates/runifi-api/src/routes/connections.rs
@@ -3,8 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use axum::extract::{Path, Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
-use axum::routing::{delete, get};
-use axum::{Json, Router};
+use axum::routing::{delete as delete_method, get};
+use axum::{Json, Router, middleware};
 use serde::Deserialize;
 
 use runifi_core::audit::{AuditAction, AuditEvent, AuditTarget};
@@ -15,27 +15,50 @@ use crate::dto::{
     FlowFileAttributeResponse, QueueListingResponse, QueuedFlowFileResponse,
 };
 use crate::error::ApiError;
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
-    Router::new()
-        .route(
-            "/api/v1/connections",
-            get(list_connections).post(create_connection),
-        )
-        .route("/api/v1/connections/{id}", delete(delete_connection))
-        .route(
-            "/api/v1/connections/{id}/queue",
-            get(list_queue).delete(empty_queue),
-        )
+    // GET endpoints — ViewFlow (Viewer+)
+    let view_routes = Router::new()
+        .route("/api/v1/connections", get(list_connections))
+        .route("/api/v1/connections/{id}/queue", get(list_queue))
         .route(
             "/api/v1/connections/{id}/queue/{flowfile_id}",
-            get(get_flowfile).delete(remove_flowfile),
+            get(get_flowfile),
         )
+        .layer(middleware::from_fn(rbac::require_view_flow));
+
+    // Content access — AccessContent (Operator+)
+    let content_routes = Router::new()
         .route(
             "/api/v1/connections/{id}/queue/{flowfile_id}/content",
             get(download_content),
         )
+        .layer(middleware::from_fn(rbac::require_access_content));
+
+    // Flow mutation endpoints — ModifyFlow (Admin only)
+    let modify_routes = Router::new()
+        .route(
+            "/api/v1/connections",
+            axum::routing::post(create_connection),
+        )
+        .route("/api/v1/connections/{id}", delete_method(delete_connection))
+        .layer(middleware::from_fn(rbac::require_modify_flow));
+
+    // Queue management — OperateProcessors (Operator+)
+    let operate_routes = Router::new()
+        .route("/api/v1/connections/{id}/queue", delete_method(empty_queue))
+        .route(
+            "/api/v1/connections/{id}/queue/{flowfile_id}",
+            delete_method(remove_flowfile),
+        )
+        .layer(middleware::from_fn(rbac::require_operate_processors));
+
+    view_routes
+        .merge(content_routes)
+        .merge(modify_routes)
+        .merge(operate_routes)
 }
 
 async fn list_connections(State(state): State<ApiState>) -> Json<Vec<ConnectionResponse>> {

--- a/crates/runifi-api/src/routes/events.rs
+++ b/crates/runifi-api/src/routes/events.rs
@@ -13,10 +13,13 @@ use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::IntervalStream;
 
 use crate::dto::{BulletinResponse, ConnectionResponse, ProcessorResponse, SseMetricsEvent};
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
-    Router::new().route("/api/v1/events", get(sse_events))
+    Router::new()
+        .route("/api/v1/events", get(sse_events))
+        .layer(axum::middleware::from_fn(rbac::require_view_flow))
 }
 
 async fn sse_events(

--- a/crates/runifi-api/src/routes/flow.rs
+++ b/crates/runifi-api/src/routes/flow.rs
@@ -1,12 +1,15 @@
 use axum::extract::State;
 use axum::routing::get;
-use axum::{Json, Router};
+use axum::{Json, Router, middleware};
 
 use crate::dto::{FlowEdgeResponse, FlowNodeResponse, FlowResponse, PositionResponse};
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
-    Router::new().route("/api/v1/flow", get(get_flow))
+    Router::new()
+        .route("/api/v1/flow", get(get_flow))
+        .layer(middleware::from_fn(rbac::require_view_flow))
 }
 
 async fn get_flow(State(state): State<ApiState>) -> Json<FlowResponse> {

--- a/crates/runifi-api/src/routes/plugins.rs
+++ b/crates/runifi-api/src/routes/plugins.rs
@@ -1,12 +1,15 @@
 use axum::extract::State;
 use axum::routing::get;
-use axum::{Json, Router};
+use axum::{Json, Router, middleware};
 
 use crate::dto::PluginResponse;
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
-    Router::new().route("/api/v1/plugins", get(list_plugins))
+    Router::new()
+        .route("/api/v1/plugins", get(list_plugins))
+        .layer(middleware::from_fn(rbac::require_view_flow))
 }
 
 async fn list_plugins(State(state): State<ApiState>) -> Json<Vec<PluginResponse>> {

--- a/crates/runifi-api/src/routes/processors.rs
+++ b/crates/runifi-api/src/routes/processors.rs
@@ -1,30 +1,30 @@
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{get, post, put};
-use axum::{Json, Router};
+use axum::routing::{delete as delete_method, get, post, put};
+use axum::{Json, Router, middleware};
 
 use crate::dto::{
     CreateProcessorRequest, ProcessorConfigResponse, ProcessorConfigUpdateRequest,
     ProcessorDetailResponse, ProcessorResponse, RelationshipResponse, UpdatePositionRequest,
 };
 use crate::error::ApiError;
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
-    Router::new()
-        .route(
-            "/api/v1/processors",
-            get(list_processors).post(create_processor),
-        )
-        .route(
-            "/api/v1/processors/{name}",
-            get(get_processor).delete(delete_processor),
-        )
+    // GET endpoints — ViewFlow (Viewer+)
+    let view_routes = Router::new()
+        .route("/api/v1/processors", get(list_processors))
+        .route("/api/v1/processors/{name}", get(get_processor))
         .route(
             "/api/v1/processors/{name}/config",
-            get(get_processor_config).put(update_processor_config),
+            get(get_processor_config),
         )
+        .layer(middleware::from_fn(rbac::require_view_flow));
+
+    // POST lifecycle endpoints — OperateProcessors (Operator+)
+    let operate_routes = Router::new()
         .route(
             "/api/v1/processors/{name}/reset-circuit",
             post(reset_circuit),
@@ -33,7 +33,27 @@ pub fn routes() -> Router<ApiState> {
         .route("/api/v1/processors/{name}/start", post(start_processor))
         .route("/api/v1/processors/{name}/pause", post(pause_processor))
         .route("/api/v1/processors/{name}/resume", post(resume_processor))
+        .layer(middleware::from_fn(rbac::require_operate_processors));
+
+    // Flow mutation endpoints — ModifyFlow (Admin only)
+    let modify_routes = Router::new()
+        .route("/api/v1/processors", post(create_processor))
+        .route("/api/v1/processors/{name}", delete_method(delete_processor))
         .route("/api/v1/processors/{name}/position", put(update_position))
+        .layer(middleware::from_fn(rbac::require_modify_flow));
+
+    // Config update endpoint — ManageConfig (Admin only)
+    let config_routes = Router::new()
+        .route(
+            "/api/v1/processors/{name}/config",
+            put(update_processor_config),
+        )
+        .layer(middleware::from_fn(rbac::require_manage_config));
+
+    view_routes
+        .merge(operate_routes)
+        .merge(modify_routes)
+        .merge(config_routes)
 }
 
 async fn list_processors(State(state): State<ApiState>) -> Json<Vec<ProcessorResponse>> {

--- a/crates/runifi-api/src/routes/system.rs
+++ b/crates/runifi-api/src/routes/system.rs
@@ -1,12 +1,15 @@
 use axum::extract::State;
 use axum::routing::get;
-use axum::{Json, Router};
+use axum::{Json, Router, middleware};
 
 use crate::dto::SystemResponse;
+use crate::rbac;
 use crate::state::ApiState;
 
 pub fn routes() -> Router<ApiState> {
-    Router::new().route("/api/v1/system", get(get_system))
+    Router::new()
+        .route("/api/v1/system", get(get_system))
+        .layer(middleware::from_fn(rbac::require_view_flow))
 }
 
 async fn get_system(State(state): State<ApiState>) -> Json<SystemResponse> {

--- a/crates/runifi-core/src/config/flow_config.rs
+++ b/crates/runifi-core/src/config/flow_config.rs
@@ -50,18 +50,35 @@ pub struct ApiConfig {
 
 /// Security configuration for API authentication and TLS.
 ///
+/// Supports two formats for `api_keys`:
+///
+/// **Simple format** (backward compatible — all keys get `Admin` role):
 /// ```toml
 /// [api.security]
 /// api_keys = ["key-abc123", "key-def456"]
-/// tls_enabled = false
-/// tls_cert_path = "/etc/runifi/cert.pem"
-/// tls_key_path = "/etc/runifi/key.pem"
+/// ```
+///
+/// **Role-based format**:
+/// ```toml
+/// [api.security]
+/// [[api.security.api_keys]]
+/// key = "admin-key-abc123"
+/// role = "admin"
+///
+/// [[api.security.api_keys]]
+/// key = "operator-key-def456"
+/// role = "operator"
+///
+/// [[api.security.api_keys]]
+/// key = "viewer-key-ghi789"
+/// role = "viewer"
 /// ```
 #[derive(Debug, Default, Deserialize, Clone)]
 pub struct SecurityConfig {
     /// API keys for bearer-token authentication. If empty, auth is disabled.
+    /// Supports both simple string keys (all Admin) and structured key-role mappings.
     #[serde(default)]
-    pub api_keys: Vec<String>,
+    pub api_keys: Vec<ApiKeyEntry>,
     /// Whether TLS is enabled for the API server.
     #[serde(default)]
     pub tls_enabled: bool,
@@ -78,6 +95,50 @@ impl SecurityConfig {
     pub fn auth_enabled(&self) -> bool {
         !self.api_keys.is_empty()
     }
+
+    /// Get the plain key strings for authentication validation.
+    pub fn key_strings(&self) -> Vec<&str> {
+        self.api_keys
+            .iter()
+            .map(|entry| match entry {
+                ApiKeyEntry::Simple(key) => key.as_str(),
+                ApiKeyEntry::WithRole(akr) => akr.key.as_str(),
+            })
+            .collect()
+    }
+
+    /// Look up the role name for a given key. Returns `None` if the key is not found.
+    /// Simple string keys return `"admin"`.
+    pub fn role_for_key(&self, provided: &str) -> Option<&str> {
+        for entry in &self.api_keys {
+            match entry {
+                ApiKeyEntry::Simple(key) if key == provided => return Some("admin"),
+                ApiKeyEntry::WithRole(akr) if akr.key == provided => return Some(&akr.role),
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+/// An API key entry that supports both simple string keys (backward compatible)
+/// and structured key-role mappings.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ApiKeyEntry {
+    /// Simple string key — treated as Admin role for backward compatibility.
+    Simple(String),
+    /// Structured key with an explicit role assignment.
+    WithRole(ApiKeyWithRole),
+}
+
+/// A structured API key with an explicit role assignment.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiKeyWithRole {
+    /// The API key string.
+    pub key: String,
+    /// The role assigned to this key (e.g. "admin", "operator", "viewer").
+    pub role: String,
 }
 
 /// Configuration for content encryption at rest.


### PR DESCRIPTION
## Summary

Implements Phase 1 of role-based access control (RBAC) for the RuniFi API, building on the API key authentication from #52.

- **Three-tier role hierarchy**: `Admin` (full control), `Operator` (start/stop/monitor/content access), `Viewer` (read-only)
- **Five permission types**: `ViewFlow`, `OperateProcessors`, `AccessContent`, `ModifyFlow`, `ManageConfig`
- **Key-to-role mapping in config**: Structured TOML format (`[[api.security.api_keys]]` with `key` and `role` fields)
- **Backward compatibility**: Plain string `api_keys = ["key1", "key2"]` format still works; all such keys default to `Admin` role
- **Per-route RBAC enforcement**: Middleware layers applied to route groups by permission level
- **Auth middleware extension**: After validating the API key, the middleware resolves the role and attaches it to request extensions

### Route permission mapping

| Permission | Min Role | Routes |
|---|---|---|
| `ViewFlow` | Viewer | All GET endpoints (processors, connections, flow, system, plugins, events, bulletins) |
| `OperateProcessors` | Operator | POST start/stop/pause/resume/reset-circuit; DELETE queue items |
| `AccessContent` | Operator | GET content download |
| `ModifyFlow` | Admin | POST/DELETE processors and connections; PUT position |
| `ManageConfig` | Admin | PUT processor config |

### Config example

```toml
[api.security]
[[api.security.api_keys]]
key = "admin-key-abc123"
role = "admin"

[[api.security.api_keys]]
key = "operator-key-def456"
role = "operator"

[[api.security.api_keys]]
key = "viewer-key-ghi789"
role = "viewer"
```

Closes #53

## Test plan

- [x] All 112 existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Unit tests for `Role::parse()`, `Role::has_permission()`, role hierarchy
- [x] Unit tests for `Permission` types and minimum role requirements
- [x] Unit tests for `require_permission()` with all three roles and no-role (auth disabled) case
- [x] Unit tests for `validate_api_key()` with both simple and structured key formats
- [x] Unit tests for `resolve_role()` with simple keys, structured keys, and unknown role strings
- [x] Backward compatibility: simple string keys treated as Admin