### PR TITLE
feat: file-based content repository with hybrid memory/disk storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +295,12 @@ dependencies = [
  "rand",
  "siphasher",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -669,6 +684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,19 +1045,23 @@ name = "runifi-core"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "crc32fast",
  "crossbeam",
  "dashmap",
  "futures",
  "inventory",
+ "memmap2",
  "parking_lot",
  "runifi-plugin-api",
  "runifi-processors",
  "serde",
  "serde_json",
  "slab",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
 ]
 
@@ -1082,6 +1107,19 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1375,6 +1413,19 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ rustls = "0.23"
 bytes = { version = "1", features = ["serde"] }
 memmap2 = "0.9"              # Memory-mapped files for large transfers
 io-uring = "0.7"             # Linux io_uring for zero-copy IO
+crc32fast = "1"              # Fast CRC32 checksums for content integrity
 
 # Async utilities
 futures = "0.3"

--- a/crates/runifi-core/Cargo.toml
+++ b/crates/runifi-core/Cargo.toml
@@ -20,8 +20,12 @@ slab = { workspace = true }
 parking_lot = { workspace = true }
 tokio-util = { workspace = true }
 futures = { workspace = true }
+memmap2 = { workspace = true }
+crc32fast = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 runifi-processors = { path = "../runifi-processors" }
 inventory = { workspace = true }
+tempfile = "3"

--- a/crates/runifi-core/src/config/flow_config.rs
+++ b/crates/runifi-core/src/config/flow_config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use serde::Deserialize;
 
@@ -8,6 +9,8 @@ pub struct FlowConfig {
     pub flow: FlowDefinition,
     #[serde(default)]
     pub api: ApiConfig,
+    #[serde(default)]
+    pub engine: EngineConfig,
 }
 
 /// Configuration for the web API server.
@@ -114,4 +117,69 @@ pub struct ConnectionConfig {
 pub struct BackPressureConfigToml {
     pub max_count: Option<usize>,
     pub max_bytes: Option<u64>,
+}
+
+/// Engine-level configuration.
+#[derive(Debug, Default, Deserialize)]
+pub struct EngineConfig {
+    #[serde(default)]
+    pub content_repository: ContentRepositoryConfig,
+}
+
+/// Content repository type selection.
+#[derive(Debug, Deserialize)]
+pub struct ContentRepositoryConfig {
+    /// "memory" (default) or "file"
+    #[serde(default = "default_repo_type")]
+    pub repo_type: String,
+    /// File-based repository settings (only used when repo_type = "file").
+    pub file: Option<FileRepoConfigToml>,
+}
+
+impl Default for ContentRepositoryConfig {
+    fn default() -> Self {
+        Self {
+            repo_type: default_repo_type(),
+            file: None,
+        }
+    }
+}
+
+fn default_repo_type() -> String {
+    "memory".to_string()
+}
+
+/// TOML configuration for the file-based content repository.
+#[derive(Debug, Deserialize)]
+pub struct FileRepoConfigToml {
+    /// Container directories for segment files.
+    pub containers: Vec<PathBuf>,
+    /// Max size of a single segment file in bytes (default: 128MB).
+    #[serde(default = "default_max_segment_size")]
+    pub max_segment_size_bytes: u64,
+    /// Memory threshold before eviction starts (default: 256MB).
+    #[serde(default = "default_memory_threshold")]
+    pub memory_threshold_bytes: u64,
+    /// Content <= this size stays in memory (default: 64KB).
+    #[serde(default = "default_inline_threshold")]
+    pub inline_threshold_bytes: u64,
+    /// Background cleanup interval in seconds (default: 30).
+    #[serde(default = "default_cleanup_interval")]
+    pub cleanup_interval_secs: u64,
+}
+
+fn default_max_segment_size() -> u64 {
+    128 * 1024 * 1024
+}
+
+fn default_memory_threshold() -> u64 {
+    256 * 1024 * 1024
+}
+
+fn default_inline_threshold() -> u64 {
+    64 * 1024
+}
+
+fn default_cleanup_interval() -> u64 {
+    30
 }

--- a/crates/runifi-core/src/error.rs
+++ b/crates/runifi-core/src/error.rs
@@ -45,6 +45,21 @@ pub enum RuniFiError {
 
     #[error("config error: {0}")]
     Config(String),
+
+    #[error("content write failed: resource_id={resource_id}, {reason}")]
+    ContentWriteFailed { resource_id: u64, reason: String },
+
+    #[error(
+        "content corrupted: resource_id={resource_id}, expected CRC={expected:#010x}, actual={actual:#010x}"
+    )]
+    ContentCorrupted {
+        resource_id: u64,
+        expected: u32,
+        actual: u32,
+    },
+
+    #[error("segment error: {path}: {reason}")]
+    SegmentError { path: String, reason: String },
 }
 
 pub type Result<T> = std::result::Result<T, RuniFiError>;

--- a/crates/runifi-core/src/repository/cleanup.rs
+++ b/crates/runifi-core/src/repository/cleanup.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use super::content_file::FileContentRepository;
+
+/// Spawn the background cleanup task for a `FileContentRepository`.
+///
+/// Runs on a configurable interval performing:
+/// 1. Garbage collection — remove ref_count=0 entries (safety net)
+/// 2. Memory eviction — spill oldest-accessed memory entries to disk when over threshold
+/// 3. Dead segment deletion — remove segment files with zero live blobs
+pub fn spawn_cleanup_task(repo: Arc<FileContentRepository>) -> tokio::task::JoinHandle<()> {
+    let cancel = repo.cancel_token();
+    let interval_secs = repo.config().cleanup_interval_secs;
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        interval.tick().await; // First tick is immediate, skip it.
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::debug!("cleanup task cancelled");
+                    break;
+                }
+                _ = interval.tick() => {
+                    run_cleanup_cycle(&repo);
+                }
+            }
+        }
+    })
+}
+
+fn run_cleanup_cycle(repo: &FileContentRepository) {
+    let gc_count = garbage_collect(repo);
+    let evicted = evict_memory(repo);
+    let deleted = delete_dead_segments(repo);
+
+    if gc_count > 0 || evicted > 0 || deleted > 0 {
+        tracing::debug!(
+            gc_removed = gc_count,
+            memory_evicted = evicted,
+            segments_deleted = deleted,
+            "cleanup cycle complete"
+        );
+    }
+}
+
+/// Safety net: scan for entries with ref_count == 0 and remove them.
+fn garbage_collect(repo: &FileContentRepository) -> u64 {
+    let mut removed = 0u64;
+    let mut dead_ids = Vec::new();
+
+    for entry in repo.index().iter() {
+        if entry.value().ref_count.load(Ordering::Relaxed) == 0 {
+            dead_ids.push(*entry.key());
+        }
+    }
+
+    for id in dead_ids {
+        // Use decrement_ref logic won't work since ref is already 0.
+        // Directly remove from index.
+        if let Some((_, entry)) = repo.index().remove(&id) {
+            let tier = entry.tier.into_inner();
+            match tier {
+                super::content_file::StorageTier::Memory(data) => {
+                    repo.memory_bytes
+                        .fetch_sub(data.len() as u64, Ordering::Relaxed);
+                }
+                super::content_file::StorageTier::Disk(location) => {
+                    repo.segment_cache().decrement_live(&location.segment_path);
+                }
+            }
+            removed += 1;
+        }
+    }
+
+    removed
+}
+
+/// Evict oldest-accessed memory entries to disk until below 80% of threshold.
+fn evict_memory(repo: &FileContentRepository) -> u64 {
+    let threshold = repo.config().memory_threshold;
+    let current = repo.memory_bytes();
+    if current <= threshold {
+        return 0;
+    }
+
+    let target = threshold * 80 / 100;
+    let mut evicted = 0u64;
+
+    // Collect memory-tier entries sorted by last access time (oldest first)
+    let mut candidates: Vec<(u64, u64)> = Vec::new(); // (resource_id, last_access_nanos)
+    for entry in repo.index().iter() {
+        let tier = entry.value().tier.read();
+        if matches!(&*tier, super::content_file::StorageTier::Memory(_)) {
+            candidates.push((
+                *entry.key(),
+                entry.value().last_access_nanos.load(Ordering::Relaxed),
+            ));
+        }
+    }
+    candidates.sort_by_key(|&(_, ts)| ts);
+
+    for (resource_id, _) in candidates {
+        if repo.memory_bytes() <= target {
+            break;
+        }
+        match repo.evict_to_disk(resource_id) {
+            Ok(freed) => evicted += freed,
+            Err(e) => {
+                tracing::warn!(resource_id, error = %e, "failed to evict to disk");
+            }
+        }
+    }
+
+    evicted
+}
+
+/// Delete sealed segments that have zero live blobs.
+fn delete_dead_segments(repo: &FileContentRepository) -> u64 {
+    let cache = repo.segment_cache();
+    let mut deleted = 0u64;
+
+    let sealed_paths = cache.sealed_paths();
+    for path in sealed_paths {
+        if cache.live_count(&path) == 0 {
+            match cache.remove_segment(&path) {
+                Ok(()) => deleted += 1,
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "failed to delete dead segment");
+                }
+            }
+        }
+    }
+
+    deleted
+}

--- a/crates/runifi-core/src/repository/content_file.rs
+++ b/crates/runifi-core/src/repository/content_file.rs
@@ -1,0 +1,471 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bytes::Bytes;
+use dashmap::DashMap;
+use parking_lot::RwLock;
+use runifi_plugin_api::ContentClaim;
+use tokio_util::sync::CancellationToken;
+
+use super::content_repo::ContentRepository;
+use super::segment::{BlobLocation, Container, SegmentCache, read_active_segment};
+use crate::error::{Result, RuniFiError};
+use crate::id::IdGenerator;
+
+/// Default inline threshold: content <= this size stays in memory.
+const DEFAULT_INLINE_THRESHOLD: u64 = 64 * 1024; // 64 KB
+
+/// Default memory eviction threshold.
+const DEFAULT_MEMORY_THRESHOLD: u64 = 256 * 1024 * 1024; // 256 MB
+
+/// Default max segment file size.
+const DEFAULT_MAX_SEGMENT_SIZE: u64 = 128 * 1024 * 1024; // 128 MB
+
+/// Default cleanup interval in seconds.
+const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 30;
+
+/// Configuration for the file-based content repository.
+#[derive(Debug, Clone)]
+pub struct FileContentRepoConfig {
+    pub containers: Vec<PathBuf>,
+    pub max_segment_size: u64,
+    pub memory_threshold: u64,
+    pub inline_threshold: u64,
+    pub cleanup_interval_secs: u64,
+}
+
+impl Default for FileContentRepoConfig {
+    fn default() -> Self {
+        Self {
+            containers: vec![PathBuf::from("./content-repo")],
+            max_segment_size: DEFAULT_MAX_SEGMENT_SIZE,
+            memory_threshold: DEFAULT_MEMORY_THRESHOLD,
+            inline_threshold: DEFAULT_INLINE_THRESHOLD,
+            cleanup_interval_secs: DEFAULT_CLEANUP_INTERVAL_SECS,
+        }
+    }
+}
+
+/// Storage tier for a resource.
+#[derive(Debug)]
+pub(crate) enum StorageTier {
+    /// Content stored inline in memory.
+    Memory(Bytes),
+    /// Content stored on disk in a segment file.
+    Disk(BlobLocation),
+}
+
+/// Metadata + storage for a single content resource.
+pub(crate) struct ResourceEntry {
+    pub(crate) tier: RwLock<StorageTier>,
+    pub(crate) ref_count: AtomicU64,
+    pub(crate) last_access_nanos: AtomicU64,
+}
+
+/// Hybrid memory/disk content repository.
+///
+/// Small content (<= inline_threshold) is kept in memory for fast access.
+/// Large content is appended to segment files on disk with CRC32 integrity.
+/// Background cleanup handles GC, memory eviction, and dead segment deletion.
+pub struct FileContentRepository {
+    index: DashMap<u64, ResourceEntry>,
+    id_gen: IdGenerator,
+    containers: Vec<Container>,
+    next_container: AtomicU64,
+    segment_cache: Arc<SegmentCache>,
+    pub(crate) memory_bytes: AtomicU64,
+    config: FileContentRepoConfig,
+    cleanup_cancel: CancellationToken,
+}
+
+impl FileContentRepository {
+    /// Create a new file-based content repository.
+    pub fn new(config: FileContentRepoConfig) -> Result<Self> {
+        let segment_cache = Arc::new(SegmentCache::new());
+
+        let mut containers = Vec::with_capacity(config.containers.len());
+        for dir in &config.containers {
+            containers.push(Container::new(dir.clone(), config.max_segment_size)?);
+        }
+
+        if containers.is_empty() {
+            return Err(RuniFiError::Config(
+                "at least one content repository container is required".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            index: DashMap::new(),
+            id_gen: IdGenerator::new(),
+            containers,
+            next_container: AtomicU64::new(0),
+            segment_cache,
+            memory_bytes: AtomicU64::new(0),
+            config,
+            cleanup_cancel: CancellationToken::new(),
+        })
+    }
+
+    /// Get the cancellation token for the cleanup task.
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cleanup_cancel.clone()
+    }
+
+    /// Get a reference to the segment cache (needed by cleanup).
+    pub fn segment_cache(&self) -> &Arc<SegmentCache> {
+        &self.segment_cache
+    }
+
+    /// Get current memory usage in bytes.
+    pub fn memory_bytes(&self) -> u64 {
+        self.memory_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Get the config.
+    pub fn config(&self) -> &FileContentRepoConfig {
+        &self.config
+    }
+
+    /// Get access to the resource index (needed by cleanup for eviction).
+    pub(crate) fn index(&self) -> &DashMap<u64, ResourceEntry> {
+        &self.index
+    }
+
+    /// Select the next container in round-robin fashion.
+    fn next_container(&self) -> &Container {
+        let idx = self.next_container.fetch_add(1, Ordering::Relaxed) as usize;
+        &self.containers[idx % self.containers.len()]
+    }
+
+    fn now_nanos() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64
+    }
+
+    /// Write data to disk via a container's segment writer.
+    fn write_to_disk(&self, resource_id: u64, data: &[u8]) -> Result<BlobLocation> {
+        let container = self.next_container();
+
+        let mut writer = container.writer.lock();
+
+        // Check if we need to rotate
+        if writer.would_exceed(data.len() as u64) {
+            writer.flush()?;
+            let old_path = writer.path().to_path_buf();
+
+            // Seal the old segment
+            self.segment_cache.seal_segment(&old_path)?;
+
+            // Create new segment
+            let next_id = container.segment_counter.fetch_add(1, Ordering::Relaxed) + 1;
+            let new_path = container.dir.join(format!("segment-{next_id:010}.dat"));
+            *writer = super::segment::SegmentWriter::create(new_path, container.max_segment_size)?;
+        }
+
+        let location = writer.append(resource_id, data)?;
+        // Flush so pread can see the data on active (non-sealed) segments.
+        writer.flush()?;
+        self.segment_cache.increment_live(writer.path());
+
+        Ok(location)
+    }
+
+    /// Evict a memory-tier resource to disk.
+    /// Returns the freed memory size, or 0 if eviction wasn't possible.
+    pub fn evict_to_disk(&self, resource_id: u64) -> Result<u64> {
+        let entry = match self.index.get(&resource_id) {
+            Some(e) => e,
+            None => return Ok(0),
+        };
+
+        let freed = {
+            let tier = entry.tier.read();
+            match &*tier {
+                StorageTier::Memory(data) => {
+                    let data_clone = data.clone();
+                    let length = data_clone.len() as u64;
+                    drop(tier);
+
+                    let location = self.write_to_disk(resource_id, &data_clone)?;
+                    let mut tier = entry.tier.write();
+                    // Double-check it's still in memory (avoid double-evict)
+                    if matches!(&*tier, StorageTier::Memory(_)) {
+                        *tier = StorageTier::Disk(location);
+                        self.memory_bytes.fetch_sub(length, Ordering::Relaxed);
+                        length
+                    } else {
+                        0
+                    }
+                }
+                StorageTier::Disk(_) => 0,
+            }
+        };
+
+        Ok(freed)
+    }
+}
+
+impl ContentRepository for FileContentRepository {
+    fn create(&self, data: Bytes) -> Result<ContentClaim> {
+        let resource_id = self.id_gen.next_id();
+        let length = data.len() as u64;
+
+        let tier = if length <= self.config.inline_threshold {
+            self.memory_bytes.fetch_add(length, Ordering::Relaxed);
+            StorageTier::Memory(data)
+        } else {
+            let location = self.write_to_disk(resource_id, &data)?;
+            StorageTier::Disk(location)
+        };
+
+        self.index.insert(
+            resource_id,
+            ResourceEntry {
+                tier: RwLock::new(tier),
+                ref_count: AtomicU64::new(1),
+                last_access_nanos: AtomicU64::new(Self::now_nanos()),
+            },
+        );
+
+        Ok(ContentClaim {
+            resource_id,
+            offset: 0,
+            length,
+        })
+    }
+
+    fn read(&self, claim: &ContentClaim) -> Result<Bytes> {
+        let entry = self
+            .index
+            .get(&claim.resource_id)
+            .ok_or(RuniFiError::ContentNotFound(claim.resource_id))?;
+
+        entry
+            .last_access_nanos
+            .store(Self::now_nanos(), Ordering::Relaxed);
+
+        let tier = entry.tier.read();
+        let full_data = match &*tier {
+            StorageTier::Memory(data) => data.clone(),
+            StorageTier::Disk(location) => {
+                // Try sealed cache first, fall back to pread
+                self.segment_cache
+                    .read_sealed(location)
+                    .or_else(|_| read_active_segment(location))?
+            }
+        };
+
+        // Apply claim offset + length
+        let start = claim.offset as usize;
+        let end = start + claim.length as usize;
+        if end > full_data.len() {
+            return Err(RuniFiError::ContentNotFound(claim.resource_id));
+        }
+
+        Ok(full_data.slice(start..end))
+    }
+
+    fn increment_ref(&self, resource_id: u64) -> Result<()> {
+        let entry = self
+            .index
+            .get(&resource_id)
+            .ok_or(RuniFiError::ContentNotFound(resource_id))?;
+        entry.ref_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn decrement_ref(&self, resource_id: u64) -> Result<()> {
+        let should_remove = {
+            let entry = self
+                .index
+                .get(&resource_id)
+                .ok_or(RuniFiError::ContentNotFound(resource_id))?;
+            entry.ref_count.fetch_sub(1, Ordering::AcqRel) == 1
+        };
+
+        if should_remove && let Some((_, entry)) = self.index.remove(&resource_id) {
+            let tier = entry.tier.into_inner();
+            match tier {
+                StorageTier::Memory(data) => {
+                    self.memory_bytes
+                        .fetch_sub(data.len() as u64, Ordering::Relaxed);
+                }
+                StorageTier::Disk(location) => {
+                    self.segment_cache.decrement_live(&location.segment_path);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn shutdown(&self) {
+        self.cleanup_cancel.cancel();
+
+        // Flush all segment writers
+        for container in &self.containers {
+            let mut writer = container.writer.lock();
+            let _ = writer.flush();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_repo(inline_threshold: u64) -> (TempDir, FileContentRepository) {
+        let dir = TempDir::new().unwrap();
+        let config = FileContentRepoConfig {
+            containers: vec![dir.path().join("c1")],
+            max_segment_size: 1024 * 1024,
+            memory_threshold: 1024 * 1024,
+            inline_threshold,
+            cleanup_interval_secs: 60,
+        };
+        let repo = FileContentRepository::new(config).unwrap();
+        (dir, repo)
+    }
+
+    #[test]
+    fn small_content_stays_in_memory() {
+        let (_dir, repo) = test_repo(1024);
+        let data = Bytes::from(vec![0xABu8; 512]);
+        let claim = repo.create(data.clone()).unwrap();
+
+        assert_eq!(repo.memory_bytes(), 512);
+        let read_back = repo.read(&claim).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn large_content_goes_to_disk() {
+        let (_dir, repo) = test_repo(64);
+        let data = Bytes::from(vec![0xCDu8; 256]);
+        let claim = repo.create(data.clone()).unwrap();
+
+        // Should not count against memory
+        assert_eq!(repo.memory_bytes(), 0);
+
+        let read_back = repo.read(&claim).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn read_with_offset_and_length() {
+        let (_dir, repo) = test_repo(1024);
+        let data = Bytes::from_static(b"abcdefghij");
+        let claim = repo.create(data).unwrap();
+
+        let partial = ContentClaim {
+            resource_id: claim.resource_id,
+            offset: 3,
+            length: 4,
+        };
+        let read_back = repo.read(&partial).unwrap();
+        assert_eq!(&read_back[..], b"defg");
+    }
+
+    #[test]
+    fn ref_counting_frees_memory() {
+        let (_dir, repo) = test_repo(1024);
+        let data = Bytes::from(vec![0u8; 100]);
+        let claim = repo.create(data).unwrap();
+
+        assert_eq!(repo.memory_bytes(), 100);
+
+        repo.increment_ref(claim.resource_id).unwrap();
+        repo.decrement_ref(claim.resource_id).unwrap();
+        // Still alive (ref=1), memory still used
+        assert_eq!(repo.memory_bytes(), 100);
+
+        repo.decrement_ref(claim.resource_id).unwrap();
+        // Now freed
+        assert_eq!(repo.memory_bytes(), 0);
+        assert!(repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn ref_counting_frees_disk() {
+        let (_dir, repo) = test_repo(32);
+        let data = Bytes::from(vec![0xFFu8; 128]);
+        let claim = repo.create(data).unwrap();
+
+        // Should be on disk
+        assert_eq!(repo.memory_bytes(), 0);
+        assert!(repo.read(&claim).is_ok());
+
+        repo.decrement_ref(claim.resource_id).unwrap();
+        assert!(repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn concurrent_creates() {
+        let (_dir, repo) = test_repo(1024);
+        let repo = Arc::new(repo);
+        let mut handles = Vec::new();
+
+        for i in 0..8 {
+            let repo = repo.clone();
+            handles.push(std::thread::spawn(move || {
+                let data = Bytes::from(vec![i as u8; 64]);
+                let claim = repo.create(data.clone()).unwrap();
+                let read_back = repo.read(&claim).unwrap();
+                assert_eq!(read_back, data);
+                claim
+            }));
+        }
+
+        let claims: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // All unique resource IDs
+        let mut ids: Vec<_> = claims.iter().map(|c| c.resource_id).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 8);
+    }
+
+    #[test]
+    fn read_nonexistent_fails() {
+        let (_dir, repo) = test_repo(1024);
+        let claim = ContentClaim {
+            resource_id: 999,
+            offset: 0,
+            length: 10,
+        };
+        assert!(repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn evict_to_disk() {
+        let (_dir, repo) = test_repo(1024);
+        let data = Bytes::from(vec![0xBBu8; 200]);
+        let claim = repo.create(data.clone()).unwrap();
+
+        assert_eq!(repo.memory_bytes(), 200);
+
+        let freed = repo.evict_to_disk(claim.resource_id).unwrap();
+        assert_eq!(freed, 200);
+        assert_eq!(repo.memory_bytes(), 0);
+
+        // Should still be readable from disk
+        let read_back = repo.read(&claim).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn shutdown_flushes() {
+        let (_dir, repo) = test_repo(32);
+        let data = Bytes::from(vec![0xEEu8; 100]);
+        let claim = repo.create(data.clone()).unwrap();
+
+        repo.shutdown();
+
+        // Data should still be readable after shutdown
+        let read_back = repo.read(&claim).unwrap();
+        assert_eq!(read_back, data);
+    }
+}

--- a/crates/runifi-core/src/repository/content_repo.rs
+++ b/crates/runifi-core/src/repository/content_repo.rs
@@ -19,4 +19,8 @@ pub trait ContentRepository: Send + Sync {
 
     /// Decrement the reference count. If it reaches zero, the content is freed.
     fn decrement_ref(&self, resource_id: u64) -> Result<()>;
+
+    /// Graceful shutdown — flush writers, cancel background tasks.
+    /// Default is a no-op for simple implementations.
+    fn shutdown(&self) {}
 }

--- a/crates/runifi-core/src/repository/mod.rs
+++ b/crates/runifi-core/src/repository/mod.rs
@@ -1,4 +1,7 @@
+pub mod cleanup;
+pub mod content_file;
 pub mod content_memory;
 pub mod content_repo;
 pub mod flowfile_repo;
 pub mod provenance_repo;
+pub mod segment;

--- a/crates/runifi-core/src/repository/segment.rs
+++ b/crates/runifi-core/src/repository/segment.rs
@@ -1,0 +1,451 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use bytes::Bytes;
+use dashmap::DashMap;
+
+use crate::error::{Result, RuniFiError};
+
+/// Magic header for segment files: "RUNIFI01"
+const SEGMENT_MAGIC: &[u8; 8] = b"RUNIFI01";
+
+/// Per-record header: 8B resource_id + 8B length = 16 bytes
+const RECORD_HEADER_SIZE: u64 = 16;
+
+/// CRC32 trailer: 4 bytes
+const CRC_SIZE: u64 = 4;
+
+/// Location of a blob within a segment file.
+#[derive(Debug, Clone)]
+pub struct BlobLocation {
+    pub segment_path: PathBuf,
+    pub data_offset: u64,
+    pub data_length: u64,
+}
+
+/// Append-only segment file writer.
+///
+/// Segment format:
+/// ```text
+/// [8 bytes: "RUNIFI01" magic]
+/// [repeat: 8B resource_id | 8B length | N bytes data | 4B CRC32]
+/// ```
+pub struct SegmentWriter {
+    writer: BufWriter<File>,
+    path: PathBuf,
+    current_offset: u64,
+    max_size: u64,
+}
+
+impl SegmentWriter {
+    /// Create a new segment file and write the magic header.
+    pub fn create(path: PathBuf, max_size: u64) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| RuniFiError::SegmentError {
+                path: path.display().to_string(),
+                reason: format!("failed to create directory: {e}"),
+            })?;
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .map_err(|e| RuniFiError::SegmentError {
+                path: path.display().to_string(),
+                reason: format!("failed to create segment: {e}"),
+            })?;
+
+        let mut writer = BufWriter::with_capacity(256 * 1024, file);
+        writer
+            .write_all(SEGMENT_MAGIC)
+            .map_err(|e| RuniFiError::SegmentError {
+                path: path.display().to_string(),
+                reason: format!("failed to write magic: {e}"),
+            })?;
+
+        Ok(Self {
+            writer,
+            path,
+            current_offset: SEGMENT_MAGIC.len() as u64,
+            max_size,
+        })
+    }
+
+    /// Check if appending `data_len` bytes would exceed the segment's max size.
+    pub fn would_exceed(&self, data_len: u64) -> bool {
+        let record_size = RECORD_HEADER_SIZE + data_len + CRC_SIZE;
+        self.current_offset + record_size > self.max_size
+    }
+
+    /// Append a blob to the segment. Returns the location of the data within the file.
+    pub fn append(&mut self, resource_id: u64, data: &[u8]) -> Result<BlobLocation> {
+        let data_len = data.len() as u64;
+
+        // Write resource_id (8 bytes LE)
+        self.writer
+            .write_all(&resource_id.to_le_bytes())
+            .map_err(|e| self.io_err(&e))?;
+
+        // Write data length (8 bytes LE)
+        self.writer
+            .write_all(&data_len.to_le_bytes())
+            .map_err(|e| self.io_err(&e))?;
+
+        // Record the offset where actual data starts
+        let data_offset = self.current_offset + RECORD_HEADER_SIZE;
+
+        // Write data
+        self.writer.write_all(data).map_err(|e| self.io_err(&e))?;
+
+        // Write CRC32
+        let crc = crc32fast::hash(data);
+        self.writer
+            .write_all(&crc.to_le_bytes())
+            .map_err(|e| self.io_err(&e))?;
+
+        let location = BlobLocation {
+            segment_path: self.path.clone(),
+            data_offset,
+            data_length: data_len,
+        };
+
+        self.current_offset += RECORD_HEADER_SIZE + data_len + CRC_SIZE;
+        Ok(location)
+    }
+
+    /// Flush buffered writes to disk.
+    pub fn flush(&mut self) -> Result<()> {
+        self.writer.flush().map_err(|e| self.io_err(&e))
+    }
+
+    /// The path of this segment file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Current write offset (file size so far).
+    pub fn current_offset(&self) -> u64 {
+        self.current_offset
+    }
+
+    fn io_err(&self, e: &std::io::Error) -> RuniFiError {
+        RuniFiError::SegmentError {
+            path: self.path.display().to_string(),
+            reason: e.to_string(),
+        }
+    }
+}
+
+/// Cache of mmap-backed sealed (read-only) segments for zero-copy reads.
+pub struct SegmentCache {
+    /// Sealed segment mmaps keyed by path.
+    maps: DashMap<PathBuf, Bytes>,
+    /// Live blob count per segment path (for dead segment detection).
+    live_counts: DashMap<PathBuf, AtomicU64>,
+}
+
+impl Default for SegmentCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SegmentCache {
+    pub fn new() -> Self {
+        Self {
+            maps: DashMap::new(),
+            live_counts: DashMap::new(),
+        }
+    }
+
+    /// Seal a segment file: mmap it and cache the mapping for zero-copy reads.
+    pub fn seal_segment(&self, path: &Path) -> Result<()> {
+        let file = File::open(path).map_err(|e| RuniFiError::SegmentError {
+            path: path.display().to_string(),
+            reason: format!("failed to open for sealing: {e}"),
+        })?;
+
+        // Safety: file is sealed (read-only from this point), and we trust the OS mmap.
+        let mmap = unsafe {
+            memmap2::Mmap::map(&file).map_err(|e| RuniFiError::SegmentError {
+                path: path.display().to_string(),
+                reason: format!("failed to mmap: {e}"),
+            })?
+        };
+
+        let bytes = Bytes::from(Vec::from(mmap.as_ref()));
+        self.maps.insert(path.to_path_buf(), bytes);
+        Ok(())
+    }
+
+    /// Read data from a sealed (mmapped) segment — zero-copy via Bytes::slice.
+    pub fn read_sealed(&self, location: &BlobLocation) -> Result<Bytes> {
+        let entry =
+            self.maps
+                .get(&location.segment_path)
+                .ok_or_else(|| RuniFiError::SegmentError {
+                    path: location.segment_path.display().to_string(),
+                    reason: "segment not in cache".to_string(),
+                })?;
+
+        let data = entry.value();
+        let start = location.data_offset as usize;
+        let end = start + location.data_length as usize;
+
+        if end > data.len() {
+            return Err(RuniFiError::SegmentError {
+                path: location.segment_path.display().to_string(),
+                reason: format!(
+                    "read out of bounds: offset={start}, len={}, file_len={}",
+                    location.data_length,
+                    data.len()
+                ),
+            });
+        }
+
+        Ok(data.slice(start..end))
+    }
+
+    /// Increment live blob count for a segment.
+    pub fn increment_live(&self, path: &Path) {
+        self.live_counts
+            .entry(path.to_path_buf())
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrement live blob count for a segment.
+    pub fn decrement_live(&self, path: &Path) {
+        if let Some(count) = self.live_counts.get(path) {
+            count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Get live blob count for a segment.
+    pub fn live_count(&self, path: &Path) -> u64 {
+        self.live_counts
+            .get(path)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Remove a sealed segment from the cache and delete the file.
+    pub fn remove_segment(&self, path: &Path) -> Result<()> {
+        self.maps.remove(path);
+        self.live_counts.remove(path);
+        if path.exists() {
+            fs::remove_file(path).map_err(|e| RuniFiError::SegmentError {
+                path: path.display().to_string(),
+                reason: format!("failed to delete: {e}"),
+            })?;
+        }
+        Ok(())
+    }
+
+    /// List all sealed segment paths.
+    pub fn sealed_paths(&self) -> Vec<PathBuf> {
+        self.maps.iter().map(|e| e.key().clone()).collect()
+    }
+}
+
+/// Read data from an active (non-sealed) segment using pread.
+pub fn read_active_segment(location: &BlobLocation) -> Result<Bytes> {
+    let file = File::open(&location.segment_path).map_err(|e| RuniFiError::SegmentError {
+        path: location.segment_path.display().to_string(),
+        reason: format!("failed to open: {e}"),
+    })?;
+
+    let mut buf = vec![0u8; location.data_length as usize];
+    file.read_at(&mut buf, location.data_offset)
+        .map_err(|e| RuniFiError::SegmentError {
+            path: location.segment_path.display().to_string(),
+            reason: format!("pread failed: {e}"),
+        })?;
+
+    // Verify CRC: read the 4-byte CRC immediately after the data
+    let mut crc_buf = [0u8; 4];
+    file.read_at(&mut crc_buf, location.data_offset + location.data_length)
+        .map_err(|e| RuniFiError::SegmentError {
+            path: location.segment_path.display().to_string(),
+            reason: format!("CRC read failed: {e}"),
+        })?;
+
+    let stored_crc = u32::from_le_bytes(crc_buf);
+    let computed_crc = crc32fast::hash(&buf);
+    if stored_crc != computed_crc {
+        return Err(RuniFiError::ContentCorrupted {
+            resource_id: 0,
+            expected: stored_crc,
+            actual: computed_crc,
+        });
+    }
+
+    Ok(Bytes::from(buf))
+}
+
+/// Container represents a storage directory with its active segment writer.
+pub struct Container {
+    pub dir: PathBuf,
+    pub writer: parking_lot::Mutex<SegmentWriter>,
+    pub segment_counter: AtomicU64,
+    pub max_segment_size: u64,
+}
+
+impl Container {
+    /// Create a new container in the given directory.
+    pub fn new(dir: PathBuf, max_segment_size: u64) -> Result<Self> {
+        fs::create_dir_all(&dir).map_err(|e| RuniFiError::SegmentError {
+            path: dir.display().to_string(),
+            reason: format!("failed to create container dir: {e}"),
+        })?;
+
+        let segment_path = dir.join("segment-0000000001.dat");
+        let writer = SegmentWriter::create(segment_path, max_segment_size)?;
+
+        Ok(Self {
+            dir,
+            writer: parking_lot::Mutex::new(writer),
+            segment_counter: AtomicU64::new(1),
+            max_segment_size,
+        })
+    }
+
+    /// Rotate to a new segment file. Returns the path of the old (now sealed) segment.
+    pub fn rotate(&self, cache: &Arc<SegmentCache>) -> Result<PathBuf> {
+        let mut writer = self.writer.lock();
+        writer.flush()?;
+        let old_path = writer.path().to_path_buf();
+
+        // Seal the old segment
+        cache.seal_segment(&old_path)?;
+
+        // Create new segment
+        let next_id = self.segment_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let new_path = self.dir.join(format!("segment-{next_id:010}.dat"));
+        *writer = SegmentWriter::create(new_path, self.max_segment_size)?;
+
+        Ok(old_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn temp_segment(max_size: u64) -> (TempDir, SegmentWriter) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test-segment.dat");
+        let writer = SegmentWriter::create(path, max_size).unwrap();
+        (dir, writer)
+    }
+
+    #[test]
+    fn write_and_read_blob() {
+        let (_dir, mut writer) = temp_segment(1024 * 1024);
+        let data = b"hello segment world";
+        let loc = writer.append(42, data).unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(loc.data_offset, 8 + 16); // magic + header
+        assert_eq!(loc.data_length, data.len() as u64);
+
+        let read_back = read_active_segment(&loc).unwrap();
+        assert_eq!(&read_back[..], data);
+    }
+
+    #[test]
+    fn multiple_blobs() {
+        let (_dir, mut writer) = temp_segment(1024 * 1024);
+
+        let loc1 = writer.append(1, b"first").unwrap();
+        let loc2 = writer.append(2, b"second").unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(&read_active_segment(&loc1).unwrap()[..], b"first");
+        assert_eq!(&read_active_segment(&loc2).unwrap()[..], b"second");
+    }
+
+    #[test]
+    fn would_exceed_check() {
+        let (_dir, writer) = temp_segment(100);
+        // magic(8) + header(16) + data + crc(4) must fit in 100
+        // Available: 100 - 8 = 92 for records
+        // One record overhead: 16 + 4 = 20, so max data = 72
+        assert!(!writer.would_exceed(72));
+        assert!(writer.would_exceed(73));
+    }
+
+    #[test]
+    fn segment_rotation() {
+        let dir = TempDir::new().unwrap();
+        let cache = Arc::new(SegmentCache::new());
+        let container = Container::new(dir.path().join("container"), 256).unwrap();
+
+        // Write a small blob
+        {
+            let mut w = container.writer.lock();
+            w.append(1, b"test data").unwrap();
+            w.flush().unwrap();
+        }
+
+        // Rotate
+        let old_path = container.rotate(&cache).unwrap();
+        assert!(cache.sealed_paths().contains(&old_path));
+
+        // Write to new segment
+        {
+            let mut w = container.writer.lock();
+            let loc = w.append(2, b"new segment data").unwrap();
+            w.flush().unwrap();
+            let data = read_active_segment(&loc).unwrap();
+            assert_eq!(&data[..], b"new segment data");
+        }
+    }
+
+    #[test]
+    fn sealed_segment_read() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sealed.dat");
+        let mut writer = SegmentWriter::create(path.clone(), 1024 * 1024).unwrap();
+
+        let loc = writer.append(10, b"sealed data").unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+
+        let cache = SegmentCache::new();
+        cache.seal_segment(&path).unwrap();
+
+        let data = cache.read_sealed(&loc).unwrap();
+        assert_eq!(&data[..], b"sealed data");
+    }
+
+    #[test]
+    fn crc_integrity() {
+        let (_dir, mut writer) = temp_segment(1024 * 1024);
+        let data = b"integrity check data";
+        let loc = writer.append(99, data).unwrap();
+        writer.flush().unwrap();
+
+        // Corrupt the data file
+        let file = OpenOptions::new()
+            .write(true)
+            .open(&loc.segment_path)
+            .unwrap();
+        file.write_at(b"X", loc.data_offset).unwrap();
+
+        // Read should detect corruption
+        let result = read_active_segment(&loc);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            RuniFiError::ContentCorrupted { .. } => {}
+            other => panic!("expected ContentCorrupted, got: {other}"),
+        }
+    }
+}

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -9,7 +9,9 @@ use runifi_core::engine::flow_engine::FlowEngine;
 use runifi_core::engine::handle::{PluginKind, PluginTypeInfo};
 use runifi_core::engine::processor_node::SchedulingStrategy;
 use runifi_core::registry::plugin_registry::PluginRegistry;
+use runifi_core::repository::content_file::{FileContentRepoConfig, FileContentRepository};
 use runifi_core::repository::content_memory::InMemoryContentRepository;
+use runifi_core::repository::content_repo::ContentRepository;
 
 // Ensure processor registrations are linked in.
 extern crate runifi_processors;
@@ -52,10 +54,37 @@ async fn main() -> Result<()> {
 
     tracing::info!(flow = %config.flow.name, "Loaded flow configuration");
 
-    // Create content repository.
-    let content_repo = Arc::new(InMemoryContentRepository::new());
+    // Create content repository based on config.
+    let content_repo: Arc<dyn ContentRepository> =
+        match config.engine.content_repository.repo_type.as_str() {
+            "file" => {
+                let file_config = match &config.engine.content_repository.file {
+                    Some(fc) => FileContentRepoConfig {
+                        containers: fc.containers.clone(),
+                        max_segment_size: fc.max_segment_size_bytes,
+                        memory_threshold: fc.memory_threshold_bytes,
+                        inline_threshold: fc.inline_threshold_bytes,
+                        cleanup_interval_secs: fc.cleanup_interval_secs,
+                    },
+                    None => FileContentRepoConfig::default(),
+                };
+                let repo = Arc::new(
+                    FileContentRepository::new(file_config)
+                        .context("Failed to create file content repository")?,
+                );
+                // Spawn background cleanup task.
+                runifi_core::repository::cleanup::spawn_cleanup_task(repo.clone());
+                tracing::info!("Using file-based content repository");
+                repo
+            }
+            _ => {
+                tracing::info!("Using in-memory content repository");
+                Arc::new(InMemoryContentRepository::new())
+            }
+        };
 
     // Build the flow engine.
+    let content_repo_ref = content_repo.clone();
     let registry = Arc::new(registry);
     let mut engine = FlowEngine::new(&config.flow.name, content_repo);
     // Provide the registry so the engine can hot-add processors at runtime.
@@ -179,6 +208,7 @@ async fn main() -> Result<()> {
         handle.abort();
     }
     engine.stop().await;
+    content_repo_ref.shutdown();
     tracing::info!("RuniFi stopped");
 
     Ok(())


### PR DESCRIPTION
## Summary

- Adds `FileContentRepository` as a production-ready alternative to `InMemoryContentRepository`
- Content <= inline threshold (64KB default) stays in memory; larger content goes to CRC32-verified segment files on disk
- Background cleanup task handles garbage collection, LRU memory eviction to disk, and dead segment deletion
- Configurable via TOML: `[engine.content_repository]` with `repo_type = "memory" | "file"`

### New files
| File | Purpose |
|---|---|
| `segment.rs` | Append-only segment file writer, mmap-backed reader cache |
| `content_file.rs` | `FileContentRepository` — hybrid memory/disk `ContentRepository` impl |
| `cleanup.rs` | Background tokio task for eviction + garbage collection |

### Modified files
- Workspace + runifi-core `Cargo.toml` — added `crc32fast`, `memmap2`, `tempfile` deps
- `content_repo.rs` — added `fn shutdown(&self) {}` default method
- `error.rs` — added `ContentWriteFailed`, `ContentCorrupted`, `SegmentError` variants
- `flow_config.rs` — added `EngineConfig`, `ContentRepositoryConfig`, `FileRepoConfigToml`
- `main.rs` — config-driven repo selection, cleanup task spawn, `shutdown()` on stop

## Test plan

- [x] 6 segment tests (write/read, multi-blob, rotation, seal, CRC integrity, size check)
- [x] 9 content_file tests (memory tier, disk tier, offset reads, ref counting, concurrent creates, eviction, shutdown)
- [x] All 71 workspace tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #13