### PR TITLE
feat: runtime flow persistence across restarts (#40)

### DIFF
--- a/crates/runifi-core/src/config/flow_config.rs
+++ b/crates/runifi-core/src/config/flow_config.rs
@@ -122,10 +122,18 @@ pub struct BackPressureConfigToml {
 /// Engine-level configuration.
 #[derive(Debug, Default, Deserialize)]
 pub struct EngineConfig {
+    /// Directory for runtime flow state persistence.
+    /// Default: `./data/conf/`
+    #[serde(default = "default_conf_dir")]
+    pub conf_dir: PathBuf,
     #[serde(default)]
     pub content_repository: ContentRepositoryConfig,
     #[serde(default)]
     pub flowfile_repository: FlowFileRepositoryConfig,
+}
+
+fn default_conf_dir() -> PathBuf {
+    PathBuf::from("./data/conf")
 }
 
 /// Content repository type selection.

--- a/crates/runifi-core/src/connection/flow_connection.rs
+++ b/crates/runifi-core/src/connection/flow_connection.rs
@@ -134,6 +134,11 @@ impl FlowConnection {
         self.bytes.load(Ordering::Relaxed)
     }
 
+    /// Get the back-pressure configuration for this connection.
+    pub fn back_pressure_config(&self) -> BackPressureConfig {
+        self.config
+    }
+
     /// Get a handle to the notify for async wakeup.
     pub fn notifier(&self) -> Arc<Notify> {
         self.notify.clone()

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -17,6 +17,7 @@ use super::handle::{
 };
 use super::metrics::ProcessorMetrics;
 use super::mutation::{MutationCommand, MutationError};
+use super::persistence::FlowPersistence;
 use super::processor_node::{
     ProcessorNode, SchedulingStrategy, SharedInputConnections, SharedInputNotifiers,
     SharedOutputConnections,
@@ -48,6 +49,7 @@ pub struct FlowEngine {
     bulletin_board: Arc<BulletinBoard>,
     registry: Option<Arc<PluginRegistry>>,
     flowfile_repo: Arc<dyn FlowFileRepository>,
+    persistence: Option<FlowPersistence>,
 
     nodes: Vec<NodeBuilder>,
     connections: Vec<ConnBuilder>,
@@ -90,6 +92,7 @@ impl FlowEngine {
             bulletin_board: Arc::new(BulletinBoard::default()),
             registry: None,
             flowfile_repo,
+            persistence: None,
             nodes: Vec::new(),
             connections: Vec::new(),
             next_node_id: 0,
@@ -103,6 +106,11 @@ impl FlowEngine {
     /// Provide a plugin registry for hot-add type validation.
     pub fn set_registry(&mut self, registry: Arc<PluginRegistry>) {
         self.registry = Some(registry);
+    }
+
+    /// Set the flow persistence layer for runtime state saving.
+    pub fn set_persistence(&mut self, persistence: FlowPersistence) {
+        self.persistence = Some(persistence);
     }
 
     /// Add a processor to the engine. Returns a node ID for wiring connections.
@@ -383,7 +391,20 @@ impl FlowEngine {
             content_repo: self.content_repo.clone(),
             positions: Arc::new(DashMap::new()),
             mutation_tx,
+            persistence: self.persistence.clone(),
         };
+
+        // Wire persistence: give it the handle and spawn the background writer.
+        if let Some(ref persistence) = self.persistence {
+            persistence.set_handle(engine_handle.clone());
+            let persist_token = self.cancel_token.child_token();
+            let persist_clone = persistence.clone();
+            let persist_handle = tokio::spawn(async move {
+                persist_clone.run(persist_token).await;
+            });
+            self.task_handles.push(persist_handle);
+        }
+
         self.handle = Some(engine_handle);
 
         // Spawn processor tasks.

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -10,6 +10,7 @@ use tokio::sync::{mpsc, oneshot};
 use super::bulletin::BulletinBoard;
 use super::metrics::ProcessorMetrics;
 use super::mutation::{MutationCommand, MutationError};
+use super::persistence::FlowPersistence;
 use super::processor_node::{
     SchedulingStrategy, SharedInputConnections, SharedInputNotifiers, SharedOutputConnections,
 };
@@ -136,9 +137,19 @@ pub struct EngineHandle {
     pub positions: Arc<DashMap<String, Position>>,
     /// Sender half of the engine mutation command channel.
     pub(crate) mutation_tx: mpsc::Sender<MutationCommand>,
+    /// Flow persistence layer (debounced background writer).
+    pub(crate) persistence: Option<FlowPersistence>,
 }
 
 impl EngineHandle {
+    /// Notify the persistence layer that the flow state has changed.
+    /// Called internally after mutations and externally for initial persist.
+    pub fn notify_persist(&self) {
+        if let Some(ref p) = self.persistence {
+            p.notify_changed();
+        }
+    }
+
     // ── Lifecycle controls ───────────────────────────────────────────────────
 
     /// Request a circuit breaker reset for a processor by name.
@@ -291,6 +302,9 @@ impl EngineHandle {
         }
 
         *props = new_properties;
+        drop(props);
+        drop(processors);
+        self.notify_persist();
         Ok(())
     }
 
@@ -319,9 +333,13 @@ impl EngineHandle {
             })
             .await
             .map_err(|_| MutationError::EngineNotRunning)?;
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| MutationError::EngineNotRunning)?
+            .map_err(|_| MutationError::EngineNotRunning)?;
+        if result.is_ok() {
+            self.notify_persist();
+        }
+        result
     }
 
     /// Remove a processor at runtime (hot-remove).
@@ -336,9 +354,13 @@ impl EngineHandle {
             })
             .await
             .map_err(|_| MutationError::EngineNotRunning)?;
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| MutationError::EngineNotRunning)?
+            .map_err(|_| MutationError::EngineNotRunning)?;
+        if result.is_ok() {
+            self.notify_persist();
+        }
+        result
     }
 
     /// Add a new connection at runtime (hot-add).
@@ -362,9 +384,13 @@ impl EngineHandle {
             })
             .await
             .map_err(|_| MutationError::EngineNotRunning)?;
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| MutationError::EngineNotRunning)?
+            .map_err(|_| MutationError::EngineNotRunning)?;
+        if result.is_ok() {
+            self.notify_persist();
+        }
+        result
     }
 
     /// Remove a connection at runtime (hot-remove).
@@ -381,9 +407,13 @@ impl EngineHandle {
             })
             .await
             .map_err(|_| MutationError::EngineNotRunning)?;
-        reply_rx
+        let result = reply_rx
             .await
-            .map_err(|_| MutationError::EngineNotRunning)?
+            .map_err(|_| MutationError::EngineNotRunning)?;
+        if result.is_ok() {
+            self.notify_persist();
+        }
+        result
     }
 
     // ── Position metadata ────────────────────────────────────────────────────
@@ -391,6 +421,7 @@ impl EngineHandle {
     /// Store the canvas position for a processor (UI metadata).
     pub fn set_position(&self, name: &str, x: f64, y: f64) {
         self.positions.insert(name.to_string(), Position { x, y });
+        self.notify_persist();
     }
 
     /// Read the canvas position for a processor.

--- a/crates/runifi-core/src/engine/mod.rs
+++ b/crates/runifi-core/src/engine/mod.rs
@@ -3,5 +3,6 @@ pub mod flow_engine;
 pub mod handle;
 pub mod metrics;
 pub mod mutation;
+pub mod persistence;
 pub mod processor_node;
 pub mod supervisor;

--- a/crates/runifi-core/src/engine/persistence.rs
+++ b/crates/runifi-core/src/engine/persistence.rs
@@ -1,0 +1,436 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+
+use super::handle::EngineHandle;
+use super::processor_node::SchedulingStrategy;
+
+/// File names for persisted flow state.
+const FLOW_STATE_FILE: &str = "flow.json";
+const FLOW_STATE_BACKUP: &str = "flow.json.bak";
+const FLOW_STATE_TMP: &str = "flow.json.tmp";
+
+/// Debounce interval for writes — coalesces rapid mutations.
+const DEBOUNCE_DURATION: Duration = Duration::from_secs(2);
+
+// ── Serializable flow state types ─────────────────────────────────────────────
+
+/// The complete persisted flow state, serializable to/from JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedFlowState {
+    pub flow_name: String,
+    pub processors: Vec<PersistedProcessor>,
+    pub connections: Vec<PersistedConnection>,
+    pub positions: HashMap<String, PersistedPosition>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedProcessor {
+    pub name: String,
+    pub type_name: String,
+    pub scheduling: PersistedScheduling,
+    pub properties: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedScheduling {
+    pub strategy: String,
+    #[serde(default = "default_interval_ms")]
+    pub interval_ms: u64,
+}
+
+fn default_interval_ms() -> u64 {
+    100
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedConnection {
+    pub source: String,
+    pub relationship: String,
+    pub destination: String,
+    #[serde(default)]
+    pub back_pressure: Option<PersistedBackPressure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedBackPressure {
+    pub max_count: Option<usize>,
+    pub max_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct PersistedPosition {
+    pub x: f64,
+    pub y: f64,
+}
+
+// ── Snapshot from live engine state ───────────────────────────────────────────
+
+impl PersistedFlowState {
+    /// Capture a snapshot of the current flow state from the engine handle.
+    pub fn snapshot(handle: &EngineHandle) -> Self {
+        let processors: Vec<PersistedProcessor> = handle
+            .processors
+            .read()
+            .iter()
+            .map(|p| PersistedProcessor {
+                name: p.name.clone(),
+                type_name: p.type_name.clone(),
+                scheduling: scheduling_to_persisted(&p.scheduling),
+                properties: p.properties.read().clone(),
+            })
+            .collect();
+
+        let connections: Vec<PersistedConnection> = handle
+            .connections
+            .read()
+            .iter()
+            .map(|c| {
+                let bp = c.connection.back_pressure_config();
+                PersistedConnection {
+                    source: c.source_name.clone(),
+                    relationship: c.relationship.clone(),
+                    destination: c.dest_name.clone(),
+                    back_pressure: Some(PersistedBackPressure {
+                        max_count: Some(bp.max_count),
+                        max_bytes: Some(bp.max_bytes),
+                    }),
+                }
+            })
+            .collect();
+
+        let mut positions = HashMap::new();
+        for entry in handle.positions.iter() {
+            positions.insert(
+                entry.key().clone(),
+                PersistedPosition {
+                    x: entry.value().x,
+                    y: entry.value().y,
+                },
+            );
+        }
+
+        Self {
+            flow_name: handle.flow_name.clone(),
+            processors,
+            connections,
+            positions,
+        }
+    }
+}
+
+fn scheduling_to_persisted(s: &SchedulingStrategy) -> PersistedScheduling {
+    match s {
+        SchedulingStrategy::TimerDriven { interval_ms } => PersistedScheduling {
+            strategy: "timer".to_string(),
+            interval_ms: *interval_ms,
+        },
+        SchedulingStrategy::EventDriven => PersistedScheduling {
+            strategy: "event".to_string(),
+            interval_ms: 100,
+        },
+    }
+}
+
+// ── File I/O with atomic writes ──────────────────────────────────────────────
+
+/// Write the flow state to disk atomically.
+///
+/// 1. Serialize to JSON
+/// 2. Write to a temp file
+/// 3. fsync the temp file
+/// 4. If a current flow.json exists, rename it to flow.json.bak
+/// 5. Rename temp file to flow.json
+fn atomic_write(conf_dir: &Path, state: &PersistedFlowState) -> std::io::Result<()> {
+    fs::create_dir_all(conf_dir)?;
+
+    let flow_path = conf_dir.join(FLOW_STATE_FILE);
+    let tmp_path = conf_dir.join(FLOW_STATE_TMP);
+    let bak_path = conf_dir.join(FLOW_STATE_BACKUP);
+
+    let json = serde_json::to_string_pretty(state)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    // Write to temp file and fsync.
+    {
+        let mut file = fs::File::create(&tmp_path)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+    }
+
+    // Backup existing flow state if present.
+    if flow_path.exists() {
+        // Best-effort backup — don't fail the write if backup rename fails.
+        let _ = fs::rename(&flow_path, &bak_path);
+    }
+
+    // Atomic rename.
+    fs::rename(&tmp_path, &flow_path)?;
+
+    Ok(())
+}
+
+/// Load persisted flow state from the runtime config directory.
+///
+/// Returns `None` if no runtime flow file exists.
+pub fn load_runtime_flow(conf_dir: &Path) -> std::io::Result<Option<PersistedFlowState>> {
+    let flow_path = conf_dir.join(FLOW_STATE_FILE);
+    if !flow_path.exists() {
+        return Ok(None);
+    }
+
+    let json = fs::read_to_string(&flow_path)?;
+    let state: PersistedFlowState = serde_json::from_str(&json)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    Ok(Some(state))
+}
+
+// ── FlowPersistence — debounced background writer ────────────────────────────
+
+/// Handles debounced persistence of flow state to disk.
+///
+/// Shared via `Arc` between the engine handle and the background writer task.
+/// Call `notify_changed()` after any mutation; the background task will
+/// coalesce rapid changes and write at most once per `DEBOUNCE_DURATION`.
+#[derive(Clone)]
+pub struct FlowPersistence {
+    inner: Arc<FlowPersistenceInner>,
+}
+
+struct FlowPersistenceInner {
+    conf_dir: PathBuf,
+    notify: Notify,
+    handle: RwLock<Option<EngineHandle>>,
+}
+
+impl FlowPersistence {
+    /// Create a new persistence layer for the given config directory.
+    pub fn new(conf_dir: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(FlowPersistenceInner {
+                conf_dir,
+                notify: Notify::new(),
+                handle: RwLock::new(None),
+            }),
+        }
+    }
+
+    /// Set the engine handle. Called once after the engine starts.
+    pub fn set_handle(&self, handle: EngineHandle) {
+        *self.inner.handle.write() = Some(handle);
+    }
+
+    /// Notify that the flow state has changed.
+    /// The background task will debounce and write to disk.
+    pub fn notify_changed(&self) {
+        self.inner.notify.notify_one();
+    }
+
+    /// Get a reference to the conf_dir.
+    pub fn conf_dir(&self) -> &Path {
+        &self.inner.conf_dir
+    }
+
+    /// Run the background persistence loop. Call this from a spawned task.
+    /// Exits when `cancel` is triggered.
+    pub async fn run(&self, cancel: tokio_util::sync::CancellationToken) {
+        loop {
+            // Wait for a change notification or cancellation.
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    // Final persist before shutdown.
+                    self.persist_now();
+                    tracing::debug!("Flow persistence task shutting down");
+                    break;
+                }
+                _ = self.inner.notify.notified() => {
+                    // Debounce: wait a bit for more changes to arrive.
+                    tokio::select! {
+                        _ = cancel.cancelled() => {
+                            self.persist_now();
+                            break;
+                        }
+                        _ = tokio::time::sleep(DEBOUNCE_DURATION) => {
+                            self.persist_now();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Immediately persist the current flow state to disk.
+    fn persist_now(&self) {
+        let handle = self.inner.handle.read();
+        let Some(ref h) = *handle else {
+            return;
+        };
+
+        let state = PersistedFlowState::snapshot(h);
+
+        match atomic_write(&self.inner.conf_dir, &state) {
+            Ok(()) => {
+                tracing::debug!(
+                    conf_dir = %self.inner.conf_dir.display(),
+                    processors = state.processors.len(),
+                    connections = state.connections.len(),
+                    "Flow state persisted"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    conf_dir = %self.inner.conf_dir.display(),
+                    "Failed to persist flow state"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_deserialize_flow_state() {
+        let state = PersistedFlowState {
+            flow_name: "test-flow".to_string(),
+            processors: vec![
+                PersistedProcessor {
+                    name: "gen".to_string(),
+                    type_name: "GenerateFlowFile".to_string(),
+                    scheduling: PersistedScheduling {
+                        strategy: "timer".to_string(),
+                        interval_ms: 1000,
+                    },
+                    properties: HashMap::from([("File Size".to_string(), "5120".to_string())]),
+                },
+                PersistedProcessor {
+                    name: "log".to_string(),
+                    type_name: "LogAttribute".to_string(),
+                    scheduling: PersistedScheduling {
+                        strategy: "event".to_string(),
+                        interval_ms: 100,
+                    },
+                    properties: HashMap::new(),
+                },
+            ],
+            connections: vec![PersistedConnection {
+                source: "gen".to_string(),
+                relationship: "success".to_string(),
+                destination: "log".to_string(),
+                back_pressure: Some(PersistedBackPressure {
+                    max_count: Some(10_000),
+                    max_bytes: Some(1_073_741_824),
+                }),
+            }],
+            positions: HashMap::from([(
+                "gen".to_string(),
+                PersistedPosition { x: 100.0, y: 200.0 },
+            )]),
+        };
+
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        let deserialized: PersistedFlowState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.flow_name, "test-flow");
+        assert_eq!(deserialized.processors.len(), 2);
+        assert_eq!(deserialized.processors[0].name, "gen");
+        assert_eq!(deserialized.processors[0].type_name, "GenerateFlowFile");
+        assert_eq!(deserialized.processors[0].scheduling.strategy, "timer");
+        assert_eq!(deserialized.processors[0].scheduling.interval_ms, 1000);
+        assert_eq!(
+            deserialized.processors[0]
+                .properties
+                .get("File Size")
+                .unwrap(),
+            "5120"
+        );
+        assert_eq!(deserialized.connections.len(), 1);
+        assert_eq!(deserialized.connections[0].source, "gen");
+        assert_eq!(deserialized.positions.len(), 1);
+        assert_eq!(deserialized.positions["gen"].x, 100.0);
+    }
+
+    #[test]
+    fn test_atomic_write_and_load() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let conf_dir = tmp_dir.path().join("conf");
+
+        let state = PersistedFlowState {
+            flow_name: "atomic-test".to_string(),
+            processors: vec![PersistedProcessor {
+                name: "p1".to_string(),
+                type_name: "GenerateFlowFile".to_string(),
+                scheduling: PersistedScheduling {
+                    strategy: "timer".to_string(),
+                    interval_ms: 500,
+                },
+                properties: HashMap::new(),
+            }],
+            connections: vec![],
+            positions: HashMap::new(),
+        };
+
+        // Write.
+        atomic_write(&conf_dir, &state).unwrap();
+
+        // Load.
+        let loaded = load_runtime_flow(&conf_dir).unwrap().unwrap();
+        assert_eq!(loaded.flow_name, "atomic-test");
+        assert_eq!(loaded.processors.len(), 1);
+
+        // Write again — should create backup.
+        let state2 = PersistedFlowState {
+            flow_name: "atomic-test-v2".to_string(),
+            processors: vec![],
+            connections: vec![],
+            positions: HashMap::new(),
+        };
+        atomic_write(&conf_dir, &state2).unwrap();
+
+        // flow.json should be v2.
+        let loaded2 = load_runtime_flow(&conf_dir).unwrap().unwrap();
+        assert_eq!(loaded2.flow_name, "atomic-test-v2");
+
+        // Backup should be v1.
+        let bak_path = conf_dir.join(FLOW_STATE_BACKUP);
+        let bak_json = fs::read_to_string(bak_path).unwrap();
+        let bak: PersistedFlowState = serde_json::from_str(&bak_json).unwrap();
+        assert_eq!(bak.flow_name, "atomic-test");
+    }
+
+    #[test]
+    fn test_load_nonexistent_returns_none() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let conf_dir = tmp_dir.path().join("no-such-dir");
+        let result = load_runtime_flow(&conf_dir).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_missing_back_pressure() {
+        let json = r#"{
+            "flow_name": "test",
+            "processors": [],
+            "connections": [{
+                "source": "a",
+                "relationship": "success",
+                "destination": "b"
+            }],
+            "positions": {}
+        }"#;
+
+        let state: PersistedFlowState = serde_json::from_str(json).unwrap();
+        assert!(state.connections[0].back_pressure.is_none());
+    }
+}

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -7,6 +7,7 @@ use runifi_core::config::flow_config::FlowConfig;
 use runifi_core::connection::back_pressure::BackPressureConfig;
 use runifi_core::engine::flow_engine::FlowEngine;
 use runifi_core::engine::handle::{PluginKind, PluginTypeInfo};
+use runifi_core::engine::persistence::{self, FlowPersistence, PersistedFlowState};
 use runifi_core::engine::processor_node::SchedulingStrategy;
 use runifi_core::registry::plugin_registry::PluginRegistry;
 use runifi_core::repository::content_file::{FileContentRepoConfig, FileContentRepository};
@@ -39,7 +40,7 @@ async fn main() -> Result<()> {
         "Plugin registry initialized"
     );
 
-    // Load flow configuration.
+    // Load seed flow configuration (TOML).
     let config_path = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "config/flow.toml".to_string());
@@ -56,7 +57,36 @@ async fn main() -> Result<()> {
     let config: FlowConfig =
         toml::from_str(&config_str).context("Failed to parse flow configuration")?;
 
-    tracing::info!(flow = %config.flow.name, "Loaded flow configuration");
+    tracing::info!(flow = %config.flow.name, "Loaded seed flow configuration");
+
+    // Check for persisted runtime flow state.
+    let conf_dir = config.engine.conf_dir.clone();
+    let runtime_flow = match persistence::load_runtime_flow(&conf_dir) {
+        Ok(Some(state)) => {
+            tracing::info!(
+                conf_dir = %conf_dir.display(),
+                processors = state.processors.len(),
+                connections = state.connections.len(),
+                "Loaded persisted runtime flow state"
+            );
+            Some(state)
+        }
+        Ok(None) => {
+            tracing::info!(
+                conf_dir = %conf_dir.display(),
+                "No persisted flow state found, using seed config"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(
+                conf_dir = %conf_dir.display(),
+                error = %e,
+                "Failed to load persisted flow state, falling back to seed config"
+            );
+            None
+        }
+    };
 
     // Create content repository based on config.
     let content_repo: Arc<dyn ContentRepository> =
@@ -118,79 +148,49 @@ async fn main() -> Result<()> {
             }
         };
 
+    // Determine flow name — runtime state takes precedence.
+    let flow_name = runtime_flow
+        .as_ref()
+        .map(|s| s.flow_name.clone())
+        .unwrap_or_else(|| config.flow.name.clone());
+
     // Build the flow engine.
     let content_repo_ref = content_repo.clone();
     let registry = Arc::new(registry);
-    let mut engine = FlowEngine::new(&config.flow.name, content_repo, flowfile_repo);
-    // Provide the registry so the engine can hot-add processors at runtime.
+    let mut engine = FlowEngine::new(&flow_name, content_repo, flowfile_repo);
     engine.set_registry(registry.clone());
 
-    // Add processors from config.
-    let mut node_ids = std::collections::HashMap::new();
+    // Set up flow persistence.
+    let persistence_layer = FlowPersistence::new(conf_dir);
+    engine.set_persistence(persistence_layer);
 
-    for proc_config in &config.flow.processors {
-        let processor = registry
-            .create_processor(&proc_config.type_name)
-            .ok_or_else(|| anyhow::anyhow!("Unknown processor type: {}", proc_config.type_name))?;
-
-        let scheduling = match proc_config.scheduling.strategy.as_str() {
-            "event" => SchedulingStrategy::EventDriven,
-            _ => SchedulingStrategy::TimerDriven {
-                interval_ms: proc_config.scheduling.interval_ms,
-            },
-        };
-
-        let node_id = engine.add_processor(
-            &proc_config.name,
-            &proc_config.type_name,
-            processor,
-            scheduling,
-            proc_config.properties.clone(),
-        );
-        node_ids.insert(proc_config.name.clone(), node_id);
-
-        tracing::info!(
-            name = %proc_config.name,
-            type_name = %proc_config.type_name,
-            "Added processor"
-        );
-    }
-
-    // Wire connections.
-    for conn_config in &config.flow.connections {
-        let source_id = *node_ids
-            .get(&conn_config.source)
-            .ok_or_else(|| anyhow::anyhow!("Unknown source processor: {}", conn_config.source))?;
-        let dest_id = *node_ids.get(&conn_config.destination).ok_or_else(|| {
-            anyhow::anyhow!("Unknown destination processor: {}", conn_config.destination)
-        })?;
-
-        let bp_config = match &conn_config.back_pressure {
-            Some(bp) => BackPressureConfig::new(
-                bp.max_count
-                    .unwrap_or(BackPressureConfig::DEFAULT_MAX_COUNT),
-                bp.max_bytes
-                    .unwrap_or(BackPressureConfig::DEFAULT_MAX_BYTES),
-            ),
-            None => BackPressureConfig::default(),
-        };
-
-        // We need a &'static str for the relationship name.
-        // Leak is acceptable here since these live for the program's lifetime.
-        let rel_name: &'static str = Box::leak(conn_config.relationship.clone().into_boxed_str());
-        engine.connect(source_id, rel_name, dest_id, bp_config);
-
-        tracing::info!(
-            source = %conn_config.source,
-            relationship = %conn_config.relationship,
-            destination = %conn_config.destination,
-            "Added connection"
-        );
+    // Populate the engine from either runtime state or seed config.
+    if let Some(ref state) = runtime_flow {
+        load_from_persisted_state(&mut engine, state, &registry)?;
+    } else {
+        load_from_seed_config(&mut engine, &config, &registry)?;
     }
 
     // Start the engine.
     engine.start().await.context("Failed to start engine")?;
     tracing::info!("Flow engine is running");
+
+    // Restore positions from persisted state.
+    if let Some(ref state) = runtime_flow
+        && let Some(handle) = engine.handle()
+    {
+        for (name, pos) in &state.positions {
+            handle.set_position(name, pos.x, pos.y);
+        }
+    }
+
+    // On first startup (no runtime flow), trigger an initial persist so the
+    // seed config is saved as the runtime state.
+    if runtime_flow.is_none()
+        && let Some(handle) = engine.handle()
+    {
+        handle.notify_persist();
+    }
 
     // Set plugin types on the engine handle.
     let mut plugin_types: Vec<PluginTypeInfo> = Vec::new();
@@ -245,6 +245,153 @@ async fn main() -> Result<()> {
     engine.stop().await;
     content_repo_ref.shutdown();
     tracing::info!("RuniFi stopped");
+
+    Ok(())
+}
+
+/// Load processors and connections from a persisted runtime flow state.
+fn load_from_persisted_state(
+    engine: &mut FlowEngine,
+    state: &PersistedFlowState,
+    registry: &PluginRegistry,
+) -> Result<()> {
+    let mut node_ids = std::collections::HashMap::new();
+
+    for proc_state in &state.processors {
+        let processor = registry
+            .create_processor(&proc_state.type_name)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Unknown processor type in persisted state: {}",
+                    proc_state.type_name
+                )
+            })?;
+
+        let scheduling = match proc_state.scheduling.strategy.as_str() {
+            "event" => SchedulingStrategy::EventDriven,
+            _ => SchedulingStrategy::TimerDriven {
+                interval_ms: proc_state.scheduling.interval_ms,
+            },
+        };
+
+        let node_id = engine.add_processor(
+            &proc_state.name,
+            &proc_state.type_name,
+            processor,
+            scheduling,
+            proc_state.properties.clone(),
+        );
+        node_ids.insert(proc_state.name.clone(), node_id);
+
+        tracing::info!(
+            name = %proc_state.name,
+            type_name = %proc_state.type_name,
+            "Added processor (from persisted state)"
+        );
+    }
+
+    for conn_state in &state.connections {
+        let source_id = *node_ids.get(&conn_state.source).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown source processor in persisted state: {}",
+                conn_state.source
+            )
+        })?;
+        let dest_id = *node_ids.get(&conn_state.destination).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown destination processor in persisted state: {}",
+                conn_state.destination
+            )
+        })?;
+
+        let bp_config = match &conn_state.back_pressure {
+            Some(bp) => BackPressureConfig::new(
+                bp.max_count
+                    .unwrap_or(BackPressureConfig::DEFAULT_MAX_COUNT),
+                bp.max_bytes
+                    .unwrap_or(BackPressureConfig::DEFAULT_MAX_BYTES),
+            ),
+            None => BackPressureConfig::default(),
+        };
+
+        let rel_name: &'static str = Box::leak(conn_state.relationship.clone().into_boxed_str());
+        engine.connect(source_id, rel_name, dest_id, bp_config);
+
+        tracing::info!(
+            source = %conn_state.source,
+            relationship = %conn_state.relationship,
+            destination = %conn_state.destination,
+            "Added connection (from persisted state)"
+        );
+    }
+
+    Ok(())
+}
+
+/// Load processors and connections from the seed TOML config.
+fn load_from_seed_config(
+    engine: &mut FlowEngine,
+    config: &FlowConfig,
+    registry: &PluginRegistry,
+) -> Result<()> {
+    let mut node_ids = std::collections::HashMap::new();
+
+    for proc_config in &config.flow.processors {
+        let processor = registry
+            .create_processor(&proc_config.type_name)
+            .ok_or_else(|| anyhow::anyhow!("Unknown processor type: {}", proc_config.type_name))?;
+
+        let scheduling = match proc_config.scheduling.strategy.as_str() {
+            "event" => SchedulingStrategy::EventDriven,
+            _ => SchedulingStrategy::TimerDriven {
+                interval_ms: proc_config.scheduling.interval_ms,
+            },
+        };
+
+        let node_id = engine.add_processor(
+            &proc_config.name,
+            &proc_config.type_name,
+            processor,
+            scheduling,
+            proc_config.properties.clone(),
+        );
+        node_ids.insert(proc_config.name.clone(), node_id);
+
+        tracing::info!(
+            name = %proc_config.name,
+            type_name = %proc_config.type_name,
+            "Added processor"
+        );
+    }
+
+    for conn_config in &config.flow.connections {
+        let source_id = *node_ids
+            .get(&conn_config.source)
+            .ok_or_else(|| anyhow::anyhow!("Unknown source processor: {}", conn_config.source))?;
+        let dest_id = *node_ids.get(&conn_config.destination).ok_or_else(|| {
+            anyhow::anyhow!("Unknown destination processor: {}", conn_config.destination)
+        })?;
+
+        let bp_config = match &conn_config.back_pressure {
+            Some(bp) => BackPressureConfig::new(
+                bp.max_count
+                    .unwrap_or(BackPressureConfig::DEFAULT_MAX_COUNT),
+                bp.max_bytes
+                    .unwrap_or(BackPressureConfig::DEFAULT_MAX_BYTES),
+            ),
+            None => BackPressureConfig::default(),
+        };
+
+        let rel_name: &'static str = Box::leak(conn_config.relationship.clone().into_boxed_str());
+        engine.connect(source_id, rel_name, dest_id, bp_config);
+
+        tracing::info!(
+            source = %conn_config.source,
+            relationship = %conn_config.relationship,
+            destination = %conn_config.destination,
+            "Added connection"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements runtime flow persistence so that topology mutations (add/remove processors and connections, property changes, position updates) are automatically saved to disk and restored on restart.

- Adds `FlowPersistence` module with debounced (2-second) background writer using `tokio::sync::Notify`
- Atomic file writes: write to `.tmp`, `fsync`, rename; previous state backed up as `.bak`
- Configurable `conf_dir` in `[engine]` config (default: `./data/conf/`)
- On startup: loads `flow.json` from `conf_dir` if present, otherwise falls back to seed TOML config
- Hooks into all `EngineHandle` mutation methods (add/remove processor/connection, property update, position update)
- Serialization format: JSON via serde with `PersistedFlowState` capturing processors, connections, positions, and back-pressure config

## Key Changes

- **New file**: `crates/runifi-core/src/engine/persistence.rs` — `FlowPersistence`, `PersistedFlowState`, atomic writes, debounced background task
- **Modified**: `crates/runifi-core/src/config/flow_config.rs` — `conf_dir` field on `EngineConfig`
- **Modified**: `crates/runifi-core/src/connection/flow_connection.rs` — `back_pressure_config()` getter
- **Modified**: `crates/runifi-core/src/engine/handle.rs` — persistence field, `notify_persist()` hook
- **Modified**: `crates/runifi-core/src/engine/flow_engine.rs` — persistence field, setter, background task spawn
- **Modified**: `crates/runifi-server/src/main.rs` — runtime flow loading on startup

## Test plan

- [x] Unit tests for serialization/deserialization round-trip
- [x] Unit tests for atomic write and load
- [x] Unit test for missing file returns None
- [x] Unit test for missing back_pressure defaults
- [x] All 178 workspace tests pass
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt` clean
- [ ] Manual test: start server, add processor via API, restart, verify flow restored

Closes #40