### PR TITLE
feat: NiFi UI layout alignment

### DIFF
--- a/crates/runifi-api/dashboard-react/src/App.tsx
+++ b/crates/runifi-api/dashboard-react/src/App.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Header } from './components/Header';
 import { SummaryBar } from './components/SummaryBar';
 import { FlowCanvas } from './components/FlowCanvas';
-import { ProcessorPalette } from './components/ProcessorPalette';
+import { ComponentToolbar } from './components/ComponentToolbar';
 import { ToastNotifier } from './components/ToastNotifier';
 import { BulletinBoard } from './components/BulletinBoard';
 import { useFlowTopology } from './hooks/useFlowTopology';
@@ -17,7 +17,6 @@ export function App() {
   const { plugins, loading: pluginsLoading } = usePlugins();
   const { toasts, push: pushToast, dismiss: dismissToast } = useToast();
 
-  const [paletteCollapsed, setPaletteCollapsed] = useState(false);
   const [draggedPlugin, setDraggedPlugin] = useState<PluginDescriptor | null>(null);
   const [bulletinOpen, setBulletinOpen] = useState(false);
 
@@ -39,23 +38,16 @@ export function App() {
   return (
     <div className="app-layout" onDragEnd={handleDragEnd}>
       <Header flowName={flowName} uptimeSecs={uptimeSecs} sseStatus={sseStatus} />
-      <SummaryBar
-        metrics={liveMetrics}
-        onOpenBulletins={() => setBulletinOpen((v) => !v)}
+      <ComponentToolbar
+        plugins={plugins}
+        loading={pluginsLoading}
+        onDragStart={setDraggedPlugin}
       />
 
       <div className="app-body">
-        <ProcessorPalette
-          plugins={plugins}
-          loading={pluginsLoading}
-          collapsed={paletteCollapsed}
-          onToggle={() => setPaletteCollapsed((c) => !c)}
-          onDragStart={setDraggedPlugin}
-        />
-
         <main className="app-main">
           <section className="dag-section" aria-labelledby="dag-heading">
-            <h2 id="dag-heading">Flow Topology</h2>
+            <h2 id="dag-heading" className="sr-only">Flow Topology</h2>
 
             {loading && (
               <div className="canvas-placeholder" role="status" aria-live="polite">
@@ -89,6 +81,11 @@ export function App() {
           )}
         </main>
       </div>
+
+      <SummaryBar
+        metrics={liveMetrics}
+        onOpenBulletins={() => setBulletinOpen((v) => !v)}
+      />
 
       <ToastNotifier toasts={toasts} onDismiss={dismissToast} />
     </div>

--- a/crates/runifi-api/dashboard-react/src/components/ColorPickerDialog.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ColorPickerDialog.tsx
@@ -1,0 +1,83 @@
+import { memo, useEffect, useRef } from 'react';
+
+const PRESET_COLORS = [
+  { name: 'Default', value: '' },
+  { name: 'Blue', value: '#4f8ff7' },
+  { name: 'Green', value: '#34d399' },
+  { name: 'Yellow', value: '#fbbf24' },
+  { name: 'Red', value: '#f87171' },
+  { name: 'Purple', value: '#a78bfa' },
+  { name: 'Orange', value: '#fb923c' },
+  { name: 'Pink', value: '#f472b6' },
+  { name: 'Teal', value: '#2dd4bf' },
+];
+
+interface ColorPickerDialogProps {
+  processorName: string;
+  currentColor: string;
+  onSelect: (color: string) => void;
+  onClose: () => void;
+}
+
+function ColorPickerDialogInner({
+  processorName,
+  currentColor,
+  onSelect,
+  onClose,
+}: ColorPickerDialogProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="color-picker-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal-panel color-picker-panel" ref={panelRef}>
+        <h3 id="color-picker-title" className="modal-title">
+          Change Color: {processorName}
+        </h3>
+
+        <div className="color-grid">
+          {PRESET_COLORS.map((c) => (
+            <button
+              key={c.name}
+              className={`color-swatch${currentColor === c.value ? ' active' : ''}`}
+              style={{
+                backgroundColor: c.value || 'var(--bg)',
+                borderColor: c.value || 'var(--border)',
+              }}
+              onClick={() => onSelect(c.value)}
+              title={c.name}
+              aria-label={`${c.name}${currentColor === c.value ? ' (current)' : ''}`}
+            >
+              {currentColor === c.value && (
+                <span className="color-check" aria-hidden="true">&#x2713;</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="modal-actions">
+          <button className="btn btn-ghost" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const ColorPickerDialog = memo(ColorPickerDialogInner);

--- a/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
@@ -1,0 +1,225 @@
+import { memo, useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import type { PluginDescriptor, PluginKind } from '../types/api';
+
+interface ComponentToolbarProps {
+  plugins: PluginDescriptor[];
+  loading: boolean;
+  onDragStart: (plugin: PluginDescriptor) => void;
+}
+
+const COMPONENT_TYPES = [
+  { id: 'processor', label: 'Processor', icon: '\u25C6' },
+  { id: 'input-port', label: 'Input Port', icon: '\u25B6' },
+  { id: 'output-port', label: 'Output Port', icon: '\u25C0' },
+  { id: 'funnel', label: 'Funnel', icon: '\u25BD' },
+  { id: 'label', label: 'Label', icon: '\u25A1' },
+] as const;
+
+const CATEGORY_MAP: Record<string, string> = {
+  GenerateFlowFile: 'Data Generation',
+  GetFile: 'File System',
+  PutFile: 'File System',
+  LogAttribute: 'Debug',
+  RouteOnAttribute: 'Routing',
+  UpdateAttribute: 'Attribute Manipulation',
+};
+
+function getCategory(typeName: string, kind: PluginKind): string {
+  if (CATEGORY_MAP[typeName]) return CATEGORY_MAP[typeName];
+  switch (kind) {
+    case 'source': return 'Data Sources';
+    case 'sink': return 'Data Sinks';
+    default: return 'General';
+  }
+}
+
+function ComponentToolbarInner({ plugins, loading, onDragStart }: ComponentToolbarProps) {
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [search, setSearch] = useState('');
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const categorized = useMemo(() => {
+    const q = search.toLowerCase();
+    const filtered = plugins.filter(
+      (p) =>
+        p.display_name.toLowerCase().includes(q) ||
+        p.type_name.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q),
+    );
+
+    const cats = new Map<string, PluginDescriptor[]>();
+    for (const p of filtered) {
+      const cat = getCategory(p.type_name, p.kind);
+      if (!cats.has(cat)) cats.set(cat, []);
+      cats.get(cat)!.push(p);
+    }
+
+    return new Map([...cats.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+  }, [plugins, search]);
+
+  // Expand all categories when search is active
+  useEffect(() => {
+    if (search) {
+      setExpandedCategories(new Set(categorized.keys()));
+    }
+  }, [search, categorized]);
+
+  // Focus search input when dialog opens
+  useEffect(() => {
+    if (showAddDialog) {
+      setTimeout(() => searchRef.current?.focus(), 50);
+    }
+  }, [showAddDialog]);
+
+  // Close dialog on click outside
+  useEffect(() => {
+    if (!showAddDialog) return;
+    const handler = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) {
+        setShowAddDialog(false);
+        setSearch('');
+      }
+    };
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowAddDialog(false);
+        setSearch('');
+      }
+    };
+    window.addEventListener('mousedown', handler);
+    window.addEventListener('keydown', keyHandler);
+    return () => {
+      window.removeEventListener('mousedown', handler);
+      window.removeEventListener('keydown', keyHandler);
+    };
+  }, [showAddDialog]);
+
+  const toggleCategory = useCallback((cat: string) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  }, []);
+
+  const handleToolbarDrag = useCallback(
+    (e: React.DragEvent, componentType: string) => {
+      if (componentType === 'processor') {
+        setShowAddDialog(true);
+        e.preventDefault();
+        return;
+      }
+      e.dataTransfer.effectAllowed = 'copy';
+      e.dataTransfer.setData('application/runifi-component', componentType);
+    },
+    [],
+  );
+
+  return (
+    <div className="component-toolbar">
+      <div className="toolbar-items">
+        {COMPONENT_TYPES.map((ct) => (
+          <button
+            key={ct.id}
+            className="toolbar-item"
+            draggable={ct.id !== 'processor'}
+            onDragStart={(e) => handleToolbarDrag(e, ct.id)}
+            onClick={ct.id === 'processor' ? () => setShowAddDialog(!showAddDialog) : undefined}
+            title={ct.id === 'processor' ? 'Click to add a processor' : `Drag to add ${ct.label}`}
+            aria-label={ct.label}
+          >
+            <span className="toolbar-item-icon" aria-hidden="true">
+              {ct.icon}
+            </span>
+            <span className="toolbar-item-label">{ct.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {showAddDialog && (
+        <div className="toolbar-add-dialog" ref={dialogRef}>
+          <div className="toolbar-add-header">
+            <span className="toolbar-add-title">Add Processor</span>
+            <button
+              className="toolbar-add-close"
+              onClick={() => { setShowAddDialog(false); setSearch(''); }}
+              aria-label="Close"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div className="toolbar-add-search-wrap">
+            <input
+              ref={searchRef}
+              className="toolbar-add-search"
+              type="search"
+              placeholder="Filter processors..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              aria-label="Filter processors"
+            />
+          </div>
+
+          <div className="toolbar-add-list" role="list">
+            {loading && <div className="toolbar-add-empty">Loading plugins...</div>}
+
+            {!loading && categorized.size === 0 && (
+              <div className="toolbar-add-empty">No processors match your filter.</div>
+            )}
+
+            {[...categorized.entries()].map(([cat, items]) => (
+              <div key={cat} className="toolbar-add-category">
+                <button
+                  className="toolbar-add-category-header"
+                  onClick={() => toggleCategory(cat)}
+                  aria-expanded={expandedCategories.has(cat)}
+                >
+                  <span className="toolbar-add-category-arrow">
+                    {expandedCategories.has(cat) ? '\u25BC' : '\u25B6'}
+                  </span>
+                  <span className="toolbar-add-category-name">{cat}</span>
+                  <span className="toolbar-add-category-count">{items.length}</span>
+                </button>
+
+                {expandedCategories.has(cat) && (
+                  <div className="toolbar-add-category-items">
+                    {items.map((plugin) => (
+                      <div
+                        key={plugin.type_name}
+                        className="toolbar-add-item"
+                        draggable
+                        onDragStart={(e) => {
+                          e.dataTransfer.effectAllowed = 'copy';
+                          e.dataTransfer.setData('application/runifi-plugin', plugin.type_name);
+                          onDragStart(plugin);
+                          setShowAddDialog(false);
+                          setSearch('');
+                        }}
+                        role="listitem"
+                        aria-label={`Drag to add ${plugin.display_name}`}
+                      >
+                        <div className="toolbar-add-item-info">
+                          <span className="toolbar-add-item-name">{plugin.display_name}</span>
+                          <span className="toolbar-add-item-desc">{plugin.description}</span>
+                        </div>
+                        <span className={`toolbar-add-item-kind kind-${plugin.kind}`}>
+                          {plugin.kind}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const ComponentToolbar = memo(ComponentToolbarInner);

--- a/crates/runifi-api/dashboard-react/src/components/ContextMenu.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ContextMenu.tsx
@@ -6,6 +6,8 @@ export interface ContextMenuState {
   nodeId: string | null;
   edgeId: string | null;
   nodeState?: string;
+  isCanvas?: boolean;
+  selectedNodeIds?: string[];
 }
 
 interface ContextMenuProps {
@@ -17,6 +19,13 @@ interface ContextMenuProps {
   onPause?: () => void;
   onResume?: () => void;
   onResetCircuit?: () => void;
+  onViewStatus?: () => void;
+  onChangeColor?: () => void;
+  onViewQueue?: () => void;
+  onSelectAll?: () => void;
+  onStartSelected?: () => void;
+  onStopSelected?: () => void;
+  onDeleteSelected?: () => void;
   onClose: () => void;
 }
 
@@ -29,6 +38,13 @@ function ContextMenuInner({
   onPause,
   onResume,
   onResetCircuit,
+  onViewStatus,
+  onChangeColor,
+  onViewQueue,
+  onSelectAll,
+  onStartSelected,
+  onStopSelected,
+  onDeleteSelected,
   onClose,
 }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -52,20 +68,122 @@ function ContextMenuInner({
   }, [onClose]);
 
   const isNode = menu.nodeId !== null;
+  const isEdge = menu.edgeId !== null;
+  const isCanvas = menu.isCanvas === true;
+  const hasMultiSelect = (menu.selectedNodeIds?.length ?? 0) > 1;
   const state = menu.nodeState ?? 'stopped';
   const isRunning = state === 'running';
   const isPaused = state === 'paused';
   const isStopped = state === 'stopped';
   const isCircuitOpen = state === 'circuit-open';
-  const deleteLabel = isNode ? 'Delete Processor' : 'Delete Connection';
 
+  // Canvas context menu
+  if (isCanvas) {
+    return (
+      <div
+        ref={menuRef}
+        className="context-menu"
+        style={{ left: menu.x, top: menu.y }}
+        role="menu"
+        aria-label="Canvas context menu"
+      >
+        {onSelectAll && (
+          <button
+            className="context-menu-item"
+            onClick={() => { onSelectAll(); onClose(); }}
+            role="menuitem"
+          >
+            Select All
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Multi-select context menu
+  if (hasMultiSelect && isNode) {
+    const count = menu.selectedNodeIds!.length;
+    return (
+      <div
+        ref={menuRef}
+        className="context-menu"
+        style={{ left: menu.x, top: menu.y }}
+        role="menu"
+        aria-label="Multi-select context menu"
+      >
+        <div className="context-menu-header">{count} processors selected</div>
+        <div className="context-menu-separator" aria-hidden="true" />
+        {onStartSelected && (
+          <button
+            className="context-menu-item"
+            onClick={() => { onStartSelected(); onClose(); }}
+            role="menuitem"
+          >
+            Start Selected
+          </button>
+        )}
+        {onStopSelected && (
+          <button
+            className="context-menu-item"
+            onClick={() => { onStopSelected(); onClose(); }}
+            role="menuitem"
+          >
+            Stop Selected
+          </button>
+        )}
+        <div className="context-menu-separator" aria-hidden="true" />
+        {onDeleteSelected && (
+          <button
+            className="context-menu-item context-menu-item-danger"
+            onClick={() => { onDeleteSelected(); onClose(); }}
+            role="menuitem"
+          >
+            Delete Selected
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Edge context menu
+  if (isEdge && !isNode) {
+    return (
+      <div
+        ref={menuRef}
+        className="context-menu"
+        style={{ left: menu.x, top: menu.y }}
+        role="menu"
+        aria-label="Connection context menu"
+      >
+        {onViewQueue && (
+          <button
+            className="context-menu-item"
+            onClick={() => { onViewQueue(); onClose(); }}
+            role="menuitem"
+          >
+            View Queue
+          </button>
+        )}
+        <div className="context-menu-separator" aria-hidden="true" />
+        <button
+          className="context-menu-item context-menu-item-danger"
+          onClick={onDelete}
+          role="menuitem"
+        >
+          Delete Connection
+        </button>
+      </div>
+    );
+  }
+
+  // Node context menu (single processor)
   return (
     <div
       ref={menuRef}
       className="context-menu"
       style={{ left: menu.x, top: menu.y }}
       role="menu"
-      aria-label="Context menu"
+      aria-label="Processor context menu"
     >
       {isNode && onConfigure && (
         <button
@@ -77,7 +195,17 @@ function ContextMenuInner({
         </button>
       )}
 
-      {isNode && (onStart || onStop || onPause || onResume || onResetCircuit) && (
+      {isNode && onViewStatus && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onViewStatus(); onClose(); }}
+          role="menuitem"
+        >
+          View Status
+        </button>
+      )}
+
+      {isNode && (
         <div className="context-menu-separator" aria-hidden="true" />
       )}
 
@@ -141,6 +269,20 @@ function ContextMenuInner({
         <div className="context-menu-separator" aria-hidden="true" />
       )}
 
+      {isNode && onChangeColor && (
+        <button
+          className="context-menu-item"
+          onClick={() => { onChangeColor(); onClose(); }}
+          role="menuitem"
+        >
+          Change Color
+        </button>
+      )}
+
+      {isNode && onChangeColor && (
+        <div className="context-menu-separator" aria-hidden="true" />
+      )}
+
       <button
         className="context-menu-item context-menu-item-danger"
         onClick={onDelete}
@@ -148,7 +290,7 @@ function ContextMenuInner({
         title={isNode && isRunning ? 'Stop the processor before deleting' : undefined}
         role="menuitem"
       >
-        {deleteLabel}
+        {isNode ? 'Delete Processor' : 'Delete Connection'}
         {isNode && isRunning && <span className="context-menu-hint"> (stop first)</span>}
       </button>
     </div>

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -30,6 +30,7 @@ import { ConfirmDialog } from './ConfirmDialog';
 import { ContextMenu, type ContextMenuState } from './ContextMenu';
 import { ProcessorConfigModal } from './ProcessorConfigModal';
 import { QueueInspectorModal } from './QueueInspectorModal';
+import { ColorPickerDialog } from './ColorPickerDialog';
 import { computeLayout } from '../utils/layout';
 import { stateColor } from '../utils/format';
 import type { FlowResponse, SseMetricsEvent, PluginDescriptor } from '../types/api';
@@ -43,7 +44,6 @@ type ConnEdge = Edge<ConnectionEdgeData, 'connectionEdge'>;
 const nodeTypes = { processorNode: ProcessorNode } as const;
 const edgeTypes = { connectionEdge: ConnectionEdge } as const;
 
-// Debounce delay for position persistence (ms)
 const POSITION_DEBOUNCE_MS = 800;
 
 interface PendingDrop {
@@ -52,15 +52,21 @@ interface PendingDrop {
 }
 
 interface DeleteTarget {
-  kind: 'node' | 'edge';
+  kind: 'node' | 'edge' | 'multi';
   id: string;
   label: string;
   nodeState?: string;
+  nodeIds?: string[];
 }
 
 interface QueueInspectTarget {
   connectionId: string;
   label: string;
+}
+
+interface ColorPickerTarget {
+  nodeId: string;
+  currentColor: string;
 }
 
 export interface FlowCanvasProps {
@@ -127,7 +133,6 @@ function FlowCanvasInner({
 }: FlowCanvasProps) {
   const { screenToFlowPosition } = useReactFlow();
 
-  // Queue click handler — defined before buildEdges use
   const [queueInspectTarget, setQueueInspectTarget] = useState<QueueInspectTarget | null>(null);
   const handleQueueClick = useCallback((connectionId: string, label: string) => {
     setQueueInspectTarget({ connectionId, label });
@@ -143,6 +148,7 @@ function FlowCanvasInner({
             'success',
           ],
           pending: false,
+          customColor: '',
         },
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,7 +163,6 @@ function FlowCanvasInner({
   const [nodes, setNodes, onNodesChange] = useNodesState<ProcNode>(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState<ConnEdge>(initialEdges);
 
-  // Modal state
   const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
@@ -168,8 +173,8 @@ function FlowCanvasInner({
     existingRels: string[];
   } | null>(null);
   const [configTarget, setConfigTarget] = useState<{ name: string; state: string } | null>(null);
+  const [colorPickerTarget, setColorPickerTarget] = useState<ColorPickerTarget | null>(null);
 
-  // Guard to prevent re-layout on first metrics update
   const topologyKey = useRef(topology.name);
 
   useEffect(() => {
@@ -183,13 +188,13 @@ function FlowCanvasInner({
           'success',
         ],
         pending: false,
+        customColor: '',
       },
     }));
     setNodes(newNodes);
     setEdges(buildEdges(topology, liveMetrics, handleQueueClick));
   }, [topology, liveMetrics, setNodes, setEdges, plugins, handleQueueClick]);
 
-  // Update node data from live metrics without touching positions
   useEffect(() => {
     if (!liveMetrics) return;
 
@@ -260,7 +265,6 @@ function FlowCanvasInner({
     );
   }, [liveMetrics, setNodes, setEdges, handleQueueClick]);
 
-  // ── Position persistence (debounced) ──────────────────────────────────────
   const positionTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   const persistPosition = useCallback((nodeId: string, x: number, y: number) => {
@@ -273,9 +277,7 @@ function FlowCanvasInner({
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ x, y }),
-      }).catch(() => {
-        // Position save is best-effort — do not surface to user
-      });
+      }).catch(() => {});
     }, POSITION_DEBOUNCE_MS);
 
     positionTimers.current.set(nodeId, timer);
@@ -300,7 +302,6 @@ function FlowCanvasInner({
     };
   }, []);
 
-  // ── Drag-and-drop from palette ────────────────────────────────────────────
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
@@ -321,7 +322,6 @@ function FlowCanvasInner({
     [plugins, screenToFlowPosition],
   );
 
-  // ── Add processor on modal confirm ───────────────────────────────────────
   const handleAddProcessor = useCallback(
     (name: string) => {
       if (!pendingDrop) return;
@@ -340,6 +340,7 @@ function FlowCanvasInner({
           bulletin: null,
           relationships: plugin.relationships,
           pending: true,
+          customColor: '',
         },
       };
 
@@ -375,7 +376,6 @@ function FlowCanvasInner({
     [pendingDrop, setNodes, onToast],
   );
 
-  // ── Connection creation ───────────────────────────────────────────────────
   const handleConnect: OnConnect = useCallback(
     (connection: Connection) => {
       const { source, target } = connection;
@@ -448,7 +448,7 @@ function FlowCanvasInner({
                 : e,
             ),
           );
-          onToast('success', `Connection ${sourceId} → ${targetId} (${relationship}) created.`);
+          onToast('success', `Connection ${sourceId} \u2192 ${targetId} (${relationship}) created.`);
         })
         .catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
@@ -461,7 +461,6 @@ function FlowCanvasInner({
     [pendingConnectionContext, setEdges, onToast, handleQueueClick],
   );
 
-  // ── Deletion ──────────────────────────────────────────────────────────────
   const initiateDelete = useCallback(
     (kind: 'node' | 'edge', id: string) => {
       if (kind === 'node') {
@@ -479,7 +478,7 @@ function FlowCanvasInner({
         setDeleteTarget({
           kind: 'edge',
           id,
-          label: `${edge.source} → ${edge.target} (${edge.data?.relationship ?? ''})`,
+          label: `${edge.source} \u2192 ${edge.target} (${edge.data?.relationship ?? ''})`,
         });
       }
     },
@@ -489,6 +488,27 @@ function FlowCanvasInner({
   const handleDeleteConfirm = useCallback(() => {
     if (!deleteTarget) return;
     setDeleteTarget(null);
+
+    if (deleteTarget.kind === 'multi') {
+      const nodeIds = deleteTarget.nodeIds ?? [];
+      const runningIds = nodes
+        .filter((n) => nodeIds.includes(n.id) && n.data.state === 'running')
+        .map((n) => n.id);
+
+      if (runningIds.length > 0) {
+        onToast('error', `Cannot delete running processors: ${runningIds.join(', ')}. Stop them first.`);
+        return;
+      }
+
+      setNodes((prev) => prev.filter((n) => !nodeIds.includes(n.id)));
+      setEdges((prev) => prev.filter((e) => !nodeIds.includes(e.source) && !nodeIds.includes(e.target)));
+
+      for (const id of nodeIds) {
+        fetch(`/api/v1/processors/${encodeURIComponent(id)}`, { method: 'DELETE' }).catch(() => {});
+      }
+      onToast('success', `Deleted ${nodeIds.length} processors.`);
+      return;
+    }
 
     if (deleteTarget.kind === 'node') {
       const { id, nodeState } = deleteTarget;
@@ -533,7 +553,6 @@ function FlowCanvasInner({
     }
   }, [deleteTarget, nodes, edges, setNodes, setEdges, onToast]);
 
-  // ── Processor controls ────────────────────────────────────────────────────
   const controlProcessor = useCallback(
     (name: string, action: 'start' | 'stop' | 'pause' | 'resume' | 'reset-circuit') => {
       fetch(`/api/v1/processors/${encodeURIComponent(name)}/${action}`, { method: 'POST' })
@@ -556,7 +575,47 @@ function FlowCanvasInner({
     [onToast],
   );
 
-  // ── Keyboard shortcuts ────────────────────────────────────────────────────
+  // Multi-select operations
+  const getSelectedNodeIds = useCallback((): string[] => {
+    return nodes.filter((n) => n.selected).map((n) => n.id);
+  }, [nodes]);
+
+  const handleStartSelected = useCallback(() => {
+    const selectedIds = getSelectedNodeIds();
+    for (const id of selectedIds) {
+      const node = nodes.find((n) => n.id === id);
+      if (node && node.data.state === 'stopped') {
+        controlProcessor(id, 'start');
+      }
+    }
+  }, [getSelectedNodeIds, nodes, controlProcessor]);
+
+  const handleStopSelected = useCallback(() => {
+    const selectedIds = getSelectedNodeIds();
+    for (const id of selectedIds) {
+      const node = nodes.find((n) => n.id === id);
+      if (node && node.data.state === 'running') {
+        controlProcessor(id, 'stop');
+      }
+    }
+  }, [getSelectedNodeIds, nodes, controlProcessor]);
+
+  const handleDeleteSelected = useCallback(() => {
+    const selectedIds = getSelectedNodeIds();
+    if (selectedIds.length === 0) return;
+    setDeleteTarget({
+      kind: 'multi',
+      id: 'multi',
+      label: `${selectedIds.length} processors`,
+      nodeIds: selectedIds,
+    });
+  }, [getSelectedNodeIds]);
+
+  const handleSelectAll = useCallback(() => {
+    setNodes((prev) => prev.map((n) => ({ ...n, selected: true })));
+    setContextMenu(null);
+  }, [setNodes]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Delete' || e.key === 'Backspace') {
@@ -565,6 +624,12 @@ function FlowCanvasInner({
           document.activeElement?.tagName === 'TEXTAREA'
         )
           return;
+
+        const selectedIds = nodes.filter((n) => n.selected).map((n) => n.id);
+        if (selectedIds.length > 1) {
+          handleDeleteSelected();
+          return;
+        }
 
         const selectedNode = nodes.find((n) => n.selected);
         const selectedEdge = edges.find((edge) => edge.selected);
@@ -580,24 +645,35 @@ function FlowCanvasInner({
         setPendingDrop(null);
         setPendingConnectionContext(null);
         setDeleteTarget(null);
+        setColorPickerTarget(null);
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+        if (
+          document.activeElement?.tagName === 'INPUT' ||
+          document.activeElement?.tagName === 'TEXTAREA'
+        )
+          return;
+        e.preventDefault();
+        handleSelectAll();
       }
     },
-    [nodes, edges, initiateDelete],
+    [nodes, edges, initiateDelete, handleDeleteSelected, handleSelectAll],
   );
 
-  // ── Context menu ──────────────────────────────────────────────────────────
   const handleNodeContextMenu: NodeMouseHandler<ProcNode> = useCallback(
     (event, node) => {
       event.preventDefault();
+      const selectedIds = nodes.filter((n) => n.selected).map((n) => n.id);
       setContextMenu({
         x: event.clientX,
         y: event.clientY,
         nodeId: node.id,
         edgeId: null,
         nodeState: node.data.state,
+        selectedNodeIds: selectedIds.length > 1 ? selectedIds : undefined,
       });
     },
-    [],
+    [nodes],
   );
 
   const handleEdgeContextMenu: EdgeMouseHandler<ConnEdge> = useCallback(
@@ -608,6 +684,20 @@ function FlowCanvasInner({
         y: event.clientY,
         nodeId: null,
         edgeId: edge.id,
+      });
+    },
+    [],
+  );
+
+  const handleCanvasContextMenu = useCallback(
+    (event: MouseEvent | React.MouseEvent) => {
+      event.preventDefault();
+      setContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        nodeId: null,
+        edgeId: null,
+        isCanvas: true,
       });
     },
     [],
@@ -631,7 +721,56 @@ function FlowCanvasInner({
     }
   }, [contextMenu, nodes]);
 
-  // ── Double-click to configure ─────────────────────────────────────────────
+  const handleContextViewStatus = useCallback(() => {
+    if (!contextMenu?.nodeId) return;
+    const nodeId = contextMenu.nodeId;
+    const node = nodes.find((n) => n.id === nodeId);
+    setContextMenu(null);
+    if (node) {
+      setConfigTarget({ name: node.id, state: node.data.state });
+    }
+  }, [contextMenu, nodes]);
+
+  const handleContextChangeColor = useCallback(() => {
+    if (!contextMenu?.nodeId) return;
+    const nodeId = contextMenu.nodeId;
+    const node = nodes.find((n) => n.id === nodeId);
+    setContextMenu(null);
+    if (node) {
+      setColorPickerTarget({
+        nodeId: node.id,
+        currentColor: node.data.customColor ?? '',
+      });
+    }
+  }, [contextMenu, nodes]);
+
+  const handleContextViewQueue = useCallback(() => {
+    if (!contextMenu?.edgeId) return;
+    const edgeId = contextMenu.edgeId;
+    const edge = edges.find((e) => e.id === edgeId);
+    setContextMenu(null);
+    if (edge && edge.data?.connectionId) {
+      const label = `${edge.source} \u2192 ${edge.data.relationship} \u2192 ${edge.target}`;
+      setQueueInspectTarget({ connectionId: edge.data.connectionId, label });
+    }
+  }, [contextMenu, edges]);
+
+  const handleColorSelect = useCallback(
+    (color: string) => {
+      if (!colorPickerTarget) return;
+      const { nodeId } = colorPickerTarget;
+      setColorPickerTarget(null);
+      setNodes((prev) =>
+        prev.map((n) =>
+          n.id === nodeId
+            ? { ...n, data: { ...n.data, customColor: color } }
+            : n,
+        ),
+      );
+    },
+    [colorPickerTarget, setNodes],
+  );
+
   const handleNodeDoubleClick: NodeMouseHandler<ProcNode> = useCallback(
     (_event, node) => {
       setConfigTarget({ name: node.id, state: node.data.state });
@@ -639,9 +778,9 @@ function FlowCanvasInner({
     [],
   );
 
-  // ── MiniMap color ─────────────────────────────────────────────────────────
-  const nodeColor = useCallback((node: ProcNode) => {
+  const nodeColor = useCallback((node: ProcNode): string => {
     if (node.data?.pending) return 'var(--warning)';
+    if (node.data?.customColor) return String(node.data.customColor);
     return stateColor(node.data?.state ?? 'stopped');
   }, []);
 
@@ -664,11 +803,13 @@ function FlowCanvasInner({
         onConnect={handleConnect}
         onNodeContextMenu={handleNodeContextMenu}
         onEdgeContextMenu={handleEdgeContextMenu}
+        onPaneContextMenu={handleCanvasContextMenu}
         onNodeDoubleClick={handleNodeDoubleClick}
         onPaneClick={() => setContextMenu(null)}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         connectOnClick={false}
+        selectionOnDrag
         fitView
         fitViewOptions={{ padding: 0.15 }}
         minZoom={0.3}
@@ -676,6 +817,7 @@ function FlowCanvasInner({
         attributionPosition="bottom-right"
         colorMode="dark"
         deleteKeyCode={null}
+        multiSelectionKeyCode="Shift"
       >
         <Background
           variant={BackgroundVariant.Dots}
@@ -725,11 +867,19 @@ function FlowCanvasInner({
 
       {deleteTarget && (
         <ConfirmDialog
-          title={deleteTarget.kind === 'node' ? 'Delete Processor' : 'Delete Connection'}
+          title={
+            deleteTarget.kind === 'multi'
+              ? 'Delete Selected Processors'
+              : deleteTarget.kind === 'node'
+                ? 'Delete Processor'
+                : 'Delete Connection'
+          }
           message={
-            deleteTarget.kind === 'node'
-              ? `Delete processor "${deleteTarget.label}"? This will also remove all its connections.`
-              : `Delete connection ${deleteTarget.label}?`
+            deleteTarget.kind === 'multi'
+              ? `Delete ${deleteTarget.nodeIds?.length ?? 0} selected processors? This will also remove all their connections.`
+              : deleteTarget.kind === 'node'
+                ? `Delete processor "${deleteTarget.label}"? This will also remove all its connections.`
+                : `Delete connection ${deleteTarget.label}?`
           }
           confirmLabel="Delete"
           destructive
@@ -743,6 +893,7 @@ function FlowCanvasInner({
           menu={contextMenu}
           onDelete={handleContextDelete}
           onConfigure={contextMenu.nodeId ? handleContextConfigure : undefined}
+          onViewStatus={contextMenu.nodeId ? handleContextViewStatus : undefined}
           onStart={
             contextMenu.nodeId
               ? () => controlProcessor(contextMenu.nodeId!, 'start')
@@ -768,6 +919,12 @@ function FlowCanvasInner({
               ? () => controlProcessor(contextMenu.nodeId!, 'reset-circuit')
               : undefined
           }
+          onChangeColor={contextMenu.nodeId ? handleContextChangeColor : undefined}
+          onViewQueue={contextMenu.edgeId ? handleContextViewQueue : undefined}
+          onSelectAll={contextMenu.isCanvas ? handleSelectAll : undefined}
+          onStartSelected={handleStartSelected}
+          onStopSelected={handleStopSelected}
+          onDeleteSelected={handleDeleteSelected}
           onClose={() => setContextMenu(null)}
         />
       )}
@@ -787,6 +944,15 @@ function FlowCanvasInner({
           connectionLabel={queueInspectTarget.label}
           onToast={onToast}
           onClose={() => setQueueInspectTarget(null)}
+        />
+      )}
+
+      {colorPickerTarget && (
+        <ColorPickerDialog
+          processorName={colorPickerTarget.nodeId}
+          currentColor={colorPickerTarget.currentColor}
+          onSelect={handleColorSelect}
+          onClose={() => setColorPickerTarget(null)}
         />
       )}
     </div>

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
@@ -2,7 +2,7 @@ import { memo, useState, useEffect, useCallback, type FormEvent } from 'react';
 import type { ProcessorConfigResponse, PropertyDescriptorFull } from '../types/api';
 import type { ToastKind } from '../hooks/useToast';
 
-type ActiveTab = 'properties' | 'scheduling' | 'relationships';
+type ActiveTab = 'settings' | 'scheduling' | 'properties' | 'comments';
 
 interface ProcessorConfigModalProps {
   processorName: string;
@@ -29,7 +29,8 @@ function ProcessorConfigModalInner({
   onToast,
   onClose,
 }: ProcessorConfigModalProps) {
-  const [activeTab, setActiveTab] = useState<ActiveTab>('properties');
+  const [activeTab, setActiveTab] = useState<ActiveTab>('settings');
+  const [comments, setComments] = useState('');
   const [config, setConfig] = useState<ProcessorConfigResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [formValues, setFormValues] = useState<Record<string, string>>({});
@@ -172,7 +173,7 @@ function ProcessorConfigModalInner({
         {config && (
           <form onSubmit={handleSave} noValidate>
             <div className="config-tabs" role="tablist">
-              {(['properties', 'scheduling', 'relationships'] as ActiveTab[]).map((tab) => (
+              {(['settings', 'scheduling', 'properties', 'comments'] as ActiveTab[]).map((tab) => (
                 <button
                   key={tab}
                   type="button"
@@ -185,6 +186,111 @@ function ProcessorConfigModalInner({
                 </button>
               ))}
             </div>
+
+            {/* Settings tab */}
+            {activeTab === 'settings' && (
+              <div className="config-tab-content" role="tabpanel">
+                <div className="config-settings-section">
+                  <h4 className="config-section-heading">Processor Details</h4>
+                  <div className="config-field">
+                    <label className="config-label">Name</label>
+                    <input
+                      className="form-input"
+                      type="text"
+                      value={processorName}
+                      disabled
+                      readOnly
+                    />
+                  </div>
+                  <div className="config-field">
+                    <label className="config-label">Type</label>
+                    <input
+                      className="form-input"
+                      type="text"
+                      value={config.type_name}
+                      disabled
+                      readOnly
+                    />
+                  </div>
+                </div>
+
+                <div className="config-settings-section">
+                  <h4 className="config-section-heading">Relationships</h4>
+                  {config.relationships.length === 0 ? (
+                    <p className="config-empty">This processor has no relationships.</p>
+                  ) : (
+                    <table className="rel-table">
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Description</th>
+                          <th>Auto-Terminated</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {config.relationships.map((rel) => (
+                          <tr key={rel.name}>
+                            <td>
+                              <strong>{rel.name}</strong>
+                            </td>
+                            <td>{rel.description}</td>
+                            <td>
+                              <span
+                                className={`rel-auto-term ${rel.auto_terminated ? 'yes' : 'no'}`}
+                              >
+                                {rel.auto_terminated ? 'Yes' : 'No'}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Scheduling tab */}
+            {activeTab === 'scheduling' && (
+              <div className="config-tab-content" role="tabpanel">
+                <div className="config-field">
+                  <label className="config-label">Scheduling Strategy</label>
+                  <span className="config-description">How the processor is triggered</span>
+                  <input
+                    className="form-input"
+                    type="text"
+                    value={config.scheduling.strategy}
+                    disabled
+                    readOnly
+                  />
+                </div>
+                {config.scheduling.interval_ms !== null &&
+                  config.scheduling.interval_ms !== undefined && (
+                    <div className="config-field">
+                      <label className="config-label">Run Schedule</label>
+                      <span className="config-description">Trigger interval in milliseconds</span>
+                      <input
+                        className="form-input"
+                        type="text"
+                        value={`${config.scheduling.interval_ms} ms`}
+                        disabled
+                        readOnly
+                      />
+                    </div>
+                  )}
+                <div className="config-field">
+                  <label className="config-label">Concurrent Tasks</label>
+                  <span className="config-description">Number of concurrent tasks for this processor</span>
+                  <input
+                    className="form-input"
+                    type="text"
+                    value="1"
+                    disabled
+                    readOnly
+                  />
+                </div>
+              </div>
+            )}
 
             {/* Properties tab */}
             {activeTab === 'properties' && (
@@ -242,70 +348,26 @@ function ProcessorConfigModalInner({
               </div>
             )}
 
-            {/* Scheduling tab */}
-            {activeTab === 'scheduling' && (
+            {/* Comments tab */}
+            {activeTab === 'comments' && (
               <div className="config-tab-content" role="tabpanel">
                 <div className="config-field">
-                  <label className="config-label">Strategy</label>
-                  <span className="config-description">How the processor is triggered</span>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={config.scheduling.strategy}
-                    disabled
-                    readOnly
+                  <label className="config-label" htmlFor="proc-comments">
+                    Processor Comments
+                  </label>
+                  <span className="config-description">
+                    Add notes or documentation for this processor. Comments are stored locally.
+                  </span>
+                  <textarea
+                    id="proc-comments"
+                    className="form-textarea"
+                    rows={6}
+                    value={comments}
+                    onChange={(e) => setComments(e.target.value)}
+                    placeholder="Enter comments about this processor..."
+                    spellCheck={true}
                   />
                 </div>
-                {config.scheduling.interval_ms !== null &&
-                  config.scheduling.interval_ms !== undefined && (
-                    <div className="config-field">
-                      <label className="config-label">Interval</label>
-                      <span className="config-description">Trigger interval in milliseconds</span>
-                      <input
-                        className="form-input"
-                        type="text"
-                        value={`${config.scheduling.interval_ms} ms`}
-                        disabled
-                        readOnly
-                      />
-                    </div>
-                  )}
-              </div>
-            )}
-
-            {/* Relationships tab */}
-            {activeTab === 'relationships' && (
-              <div className="config-tab-content" role="tabpanel">
-                {config.relationships.length === 0 ? (
-                  <p className="config-empty">This processor has no relationships.</p>
-                ) : (
-                  <table className="rel-table">
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                        <th>Auto-Terminated</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {config.relationships.map((rel) => (
-                        <tr key={rel.name}>
-                          <td>
-                            <strong>{rel.name}</strong>
-                          </td>
-                          <td>{rel.description}</td>
-                          <td>
-                            <span
-                              className={`rel-auto-term ${rel.auto_terminated ? 'yes' : 'no'}`}
-                            >
-                              {rel.auto_terminated ? 'Yes' : 'No'}
-                            </span>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                )}
               </div>
             )}
 
@@ -329,7 +391,7 @@ function ProcessorConfigModalInner({
                 disabled={!isStopped || saving || activeTab !== 'properties'}
                 title={!isStopped ? 'Stop the processor to save configuration' : undefined}
               >
-                {saving ? 'Saving...' : 'Save'}
+                {saving ? 'Applying...' : 'Apply'}
               </button>
             </div>
           </form>

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, type CSSProperties } from 'react';
 import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
 import type { ProcessorNodeData } from '../types/flow';
 import { stateColor } from '../utils/format';
@@ -23,7 +23,6 @@ function stateLabel(state: string): string {
   return state.charAt(0).toUpperCase() + state.slice(1);
 }
 
-// Distribute multiple source handles evenly along the right edge
 function handleTopPercent(index: number, total: number): string {
   if (total <= 1) return '50%';
   const step = 100 / (total + 1);
@@ -31,9 +30,15 @@ function handleTopPercent(index: number, total: number): string {
 }
 
 function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
-  const { label, typeName, state, metrics, bulletin, relationships, pending } = data;
-  const borderColor = pending ? 'var(--warning)' : stateColor(state);
+  const { label, typeName, state, metrics, bulletin, relationships, pending, customColor } = data;
+  const borderColor: string = pending
+    ? 'var(--warning)'
+    : (customColor || stateColor(state));
   const rels = relationships && relationships.length > 0 ? relationships : ['success'];
+
+  const headerStyle: CSSProperties | undefined = customColor
+    ? { borderBottomColor: customColor as string, borderBottomWidth: '2px', borderBottomStyle: 'solid' }
+    : undefined;
 
   return (
     <div
@@ -42,7 +47,6 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
       role="article"
       aria-label={`Processor ${label}${pending ? ' (pending)' : ''}`}
     >
-      {/* Target handle — left side, centered */}
       <Handle
         type="target"
         position={Position.Left}
@@ -50,7 +54,7 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         style={{ top: '50%' }}
       />
 
-      <div className="proc-node-header">
+      <div className="proc-node-header" style={headerStyle}>
         <div className="proc-node-identity">
           <span className="proc-node-name" title={label}>
             {label}
@@ -108,7 +112,6 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         </div>
       )}
 
-      {/* Source handles — right side, one per relationship */}
       {rels.map((rel, idx) => (
         <Handle
           key={rel}

--- a/crates/runifi-api/dashboard-react/src/components/SummaryBar.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/SummaryBar.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo } from 'react';
 import type { SseMetricsEvent } from '../types/api';
-import { formatRate, formatBytes } from '../utils/format';
+import { formatBytes } from '../utils/format';
 
 interface SummaryBarProps {
   metrics: SseMetricsEvent | null;
@@ -19,39 +19,32 @@ function SummaryBarInner({ metrics, onOpenBulletins }: SummaryBarProps) {
     }
 
     const totalQueued = metrics.connections.reduce((s, c) => s + c.queued_count, 0);
+    const totalQueuedBytes = metrics.connections.reduce((s, c) => s + c.queued_bytes, 0);
     const backPressureCount = metrics.connections.filter((c) => c.back_pressured).length;
 
-    const totalFFOutRate = procs.reduce((s, p) => s + p.metrics.flowfiles_out_rate, 0);
+    const totalBytesInRate = procs.reduce((s, p) => s + p.metrics.bytes_in_rate, 0);
     const totalBytesOutRate = procs.reduce((s, p) => s + p.metrics.bytes_out_rate, 0);
 
     const warnCount = metrics.bulletins.filter((b) => b.severity === 'warn').length;
     const errorCount = metrics.bulletins.filter((b) => b.severity === 'error').length;
 
-    const hasUnhealthy = counts['circuit-open'] > 0;
-    const hasWarning = counts.stopped > 0 || counts.paused > 0 || backPressureCount > 0;
-    const procHealth = hasUnhealthy ? 'danger' : hasWarning ? 'warning' : 'healthy';
-    const bpHealth = backPressureCount > 0 ? 'danger' : 'healthy';
-    const bulletinHealth = errorCount > 0 ? 'danger' : warnCount > 0 ? 'warning' : 'healthy';
-
     return {
       counts,
       totalQueued,
+      totalQueuedBytes,
       backPressureCount,
-      totalFFOutRate,
+      totalBytesInRate,
       totalBytesOutRate,
       warnCount,
       errorCount,
-      procHealth,
-      bpHealth,
-      bulletinHealth,
     };
   }, [metrics]);
 
   if (!stats) {
     return (
-      <section className="summary-bar" aria-label="System summary">
-        <div className="summary-item">
-          <span className="summary-label">Loading...</span>
+      <section className="nifi-status-bar" aria-label="System status">
+        <div className="status-bar-group">
+          <span className="status-bar-item">Loading...</span>
         </div>
       </section>
     );
@@ -60,76 +53,54 @@ function SummaryBarInner({ metrics, onOpenBulletins }: SummaryBarProps) {
   const {
     counts,
     totalQueued,
+    totalQueuedBytes,
     backPressureCount,
-    totalFFOutRate,
+    totalBytesInRate,
     totalBytesOutRate,
     warnCount,
     errorCount,
-    procHealth,
-    bpHealth,
-    bulletinHealth,
   } = stats;
-  const procTotal = Object.values(counts).reduce((a, b) => a + b, 0);
 
   return (
-    <section className="summary-bar" aria-label="System summary">
-      <div className="summary-item">
-        <span className="summary-label">Processors</span>
-        <span className="summary-value">
-          {counts.running} / {procTotal} Running
+    <section className="nifi-status-bar" aria-label="System status">
+      <div className="status-bar-group">
+        <span className="status-bar-item" title="Active threads (running processors)">
+          {counts.running} active threads
         </span>
-        <span
-          className={`summary-indicator ${procHealth}`}
-          aria-label={`Processor health: ${procHealth}`}
-        />
-      </div>
-
-      <div className="summary-item">
-        <span className="summary-label">Queued FlowFiles</span>
-        <span className="summary-value">{totalQueued.toLocaleString()}</span>
-      </div>
-
-      <div className="summary-item">
-        <span className="summary-label">Throughput</span>
-        <span className="summary-value">
-          {formatRate(totalFFOutRate, 'FF')} &middot; {formatBytes(Math.round(totalBytesOutRate))}/s
+        <span className="status-bar-item" title={`${totalQueued} queued, ${formatBytes(totalQueuedBytes)}`}>
+          {totalQueued.toLocaleString()} / {formatBytes(totalQueuedBytes)} queued
         </span>
       </div>
 
-      <div className="summary-item">
-        <span className="summary-label">States</span>
-        <div className="summary-state-pills">
-          {counts.running > 0 && (
-            <span className="state-pill running">{counts.running} running</span>
-          )}
-          {counts.paused > 0 && (
-            <span className="state-pill paused">{counts.paused} paused</span>
-          )}
-          {counts.stopped > 0 && (
-            <span className="state-pill stopped">{counts.stopped} stopped</span>
-          )}
-          {counts['circuit-open'] > 0 && (
-            <span className="state-pill circuit-open">{counts['circuit-open']} open</span>
-          )}
-        </div>
+      <div className="status-bar-group">
+        <span className="status-bar-item" title="Bytes transferred in last 5 minutes">
+          {formatBytes(Math.round(totalBytesInRate))}/s in
+        </span>
+        <span className="status-bar-item" title="Bytes transferred out last 5 minutes">
+          {formatBytes(Math.round(totalBytesOutRate))}/s out
+        </span>
       </div>
 
-      <div className="summary-item">
-        <span className="summary-label">Back-Pressure</span>
-        <span className="summary-value">{backPressureCount}</span>
-        <span
-          className={`summary-indicator ${bpHealth}`}
-          aria-label={`Back-pressure: ${bpHealth}`}
-        />
-      </div>
-
-      <div className="summary-item">
-        <span className="summary-label">Bulletins</span>
+      <div className="status-bar-group">
+        {counts.running > 0 && (
+          <span className="state-pill running">{counts.running} running</span>
+        )}
+        {counts.stopped > 0 && (
+          <span className="state-pill stopped">{counts.stopped} stopped</span>
+        )}
+        {counts.paused > 0 && (
+          <span className="state-pill paused">{counts.paused} paused</span>
+        )}
+        {counts['circuit-open'] > 0 && (
+          <span className="state-pill circuit-open">{counts['circuit-open']} open</span>
+        )}
+        {backPressureCount > 0 && (
+          <span className="state-pill stopped">{backPressureCount} back-pressured</span>
+        )}
         <button
-          className={`summary-bulletins-btn${onOpenBulletins ? ' clickable' : ''}`}
+          className={`status-bar-bulletins${onOpenBulletins ? ' clickable' : ''}`}
           onClick={onOpenBulletins}
           disabled={!onOpenBulletins}
-          aria-label={`Bulletins: ${warnCount} warnings, ${errorCount} errors`}
           title="Open bulletin board"
         >
           {errorCount > 0 && (
@@ -139,13 +110,9 @@ function SummaryBarInner({ metrics, onOpenBulletins }: SummaryBarProps) {
             <span className="bulletin-count warn">{warnCount} warn</span>
           )}
           {errorCount === 0 && warnCount === 0 && (
-            <span className="bulletin-count ok">Clear</span>
+            <span className="bulletin-count ok">0 bulletins</span>
           )}
         </button>
-        <span
-          className={`summary-indicator ${bulletinHealth}`}
-          aria-label={`Bulletin health: ${bulletinHealth}`}
-        />
       </div>
     </section>
   );

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -32,6 +32,19 @@ body {
   min-height: 100vh;
 }
 
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ── App layout ─────────────────────────────────────────────── */
 
 .app-layout {
@@ -41,7 +54,7 @@ body {
   overflow: hidden;
 }
 
-/* Body row: palette + canvas */
+/* Body row: canvas */
 .app-body {
   flex: 1;
   display: flex;
@@ -51,7 +64,7 @@ body {
 
 .app-main {
   flex: 1;
-  padding: 1.5rem 2rem;
+  padding: 0;
   min-width: 0;
   overflow: auto;
 }
@@ -62,14 +75,14 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 2rem;
+  padding: 0.6rem 1.5rem;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
 .header-left h1 {
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   font-weight: 700;
   color: var(--accent);
 }
@@ -78,7 +91,7 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--text-dim);
 }
 
@@ -107,107 +120,432 @@ body {
   color: var(--text-dim);
 }
 
-/* ── Summary bar ─────────────────────────────────────────────── */
+/* ── Component Toolbar (NiFi-style top toolbar) ─────────────── */
 
-.summary-bar {
+.component-toolbar {
   display: flex;
-  gap: 1px;
-  background: var(--border);
+  align-items: center;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  position: relative;
+  z-index: 100;
+}
+
+.toolbar-items {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 0 0.5rem;
+}
+
+.toolbar-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.85rem;
+  background: none;
+  border: none;
+  border-right: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.toolbar-item:first-child {
+  border-left: 1px solid var(--border);
+}
+
+.toolbar-item:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.toolbar-item:active {
+  background: rgba(79, 143, 247, 0.1);
+}
+
+.toolbar-item-icon {
+  font-size: 0.9rem;
+}
+
+.toolbar-item-label {
+  font-size: 0.75rem;
+}
+
+/* ── Toolbar Add Processor Dialog ──────────────────────────── */
+
+.toolbar-add-dialog {
+  position: absolute;
+  top: 100%;
+  left: 0.5rem;
+  width: 380px;
+  max-height: 480px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  z-index: 200;
+  overflow: hidden;
+}
+
+.toolbar-add-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
-.summary-item {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1rem;
-  background: var(--surface);
-  gap: 0.25rem;
-  min-width: 0;
-}
-
-.summary-label {
-  font-size: 0.65rem;
-  color: var(--text-dim);
+.toolbar-add-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  white-space: nowrap;
 }
 
-.summary-value {
+.toolbar-add-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
   font-size: 1.1rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+  cursor: pointer;
+  padding: 0 0.2rem;
+  line-height: 1;
+  transition: color 0.12s;
 }
 
-.summary-indicator {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--text-dim);
+.toolbar-add-close:hover {
+  color: var(--text);
+}
+
+.toolbar-add-search-wrap {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
-.summary-indicator.healthy {
-  background: var(--success);
-  box-shadow: 0 0 6px rgba(52, 211, 153, 0.5);
+.toolbar-add-search {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 0.8rem;
+  font-family: var(--font);
+  padding: 0.35rem 0.5rem;
+  outline: none;
+  transition: border-color 0.15s;
 }
 
-.summary-indicator.warning {
-  background: var(--warning);
-  box-shadow: 0 0 6px rgba(251, 191, 36, 0.5);
+.toolbar-add-search:focus {
+  border-color: var(--accent);
 }
 
-.summary-indicator.danger {
-  background: var(--danger);
-  box-shadow: 0 0 6px rgba(248, 113, 113, 0.5);
+.toolbar-add-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.25rem 0;
 }
 
-.summary-state-pills {
+.toolbar-add-empty {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  padding: 1rem;
+  text-align: center;
+}
+
+.toolbar-add-category {
+  margin-bottom: 0.15rem;
+}
+
+.toolbar-add-category-header {
   display: flex;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-  justify-content: center;
-  font-variant-numeric: tabular-nums;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.35rem 0.6rem;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-family: var(--font);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.12s;
+  text-align: left;
 }
 
-.state-pill {
+.toolbar-add-category-header:hover {
+  background: var(--surface-hover);
+}
+
+.toolbar-add-category-arrow {
+  font-size: 0.55rem;
+  flex-shrink: 0;
+  width: 0.75rem;
+}
+
+.toolbar-add-category-name {
+  flex: 1;
+}
+
+.toolbar-add-category-count {
   font-size: 0.65rem;
-  font-weight: 600;
-  padding: 0.15rem 0.45rem;
+  color: var(--text-dim);
+  background: rgba(139, 144, 160, 0.12);
+  padding: 0 0.3rem;
   border-radius: 3px;
+}
+
+.toolbar-add-category-items {
+  padding-left: 0.5rem;
+}
+
+.toolbar-add-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem 0.4rem 1.25rem;
+  cursor: grab;
+  border-radius: 4px;
+  margin: 0 0.25rem;
+  transition: background 0.12s;
+  user-select: none;
+}
+
+.toolbar-add-item:hover {
+  background: var(--surface-hover);
+}
+
+.toolbar-add-item:active {
+  cursor: grabbing;
+}
+
+.toolbar-add-item-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.toolbar-add-item-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.toolbar-add-item-desc {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.toolbar-add-item-kind {
+  font-size: 0.6rem;
+  font-weight: 700;
   text-transform: uppercase;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.kind-source {
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--success);
+}
+
+.kind-processor {
+  background: rgba(79, 143, 247, 0.12);
+  color: var(--accent);
+}
+
+.kind-sink {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--warning);
+}
+
+/* ── NiFi Status Bar (bottom) ──────────────────────────────── */
+
+.nifi-status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  padding: 0 0.75rem;
+  height: 32px;
+  font-size: 0.72rem;
+  color: var(--text-dim);
+}
+
+.status-bar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.status-bar-left {
+  flex: 1;
+}
+
+.status-bar-center {
+  flex: 0 0 auto;
+}
+
+.status-bar-right {
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.status-bar-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
   white-space: nowrap;
 }
 
-.state-pill.running {
+.status-bar-icon {
+  font-size: 0.65rem;
+}
+
+.status-bar-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+}
+
+.status-bar-text {
+  font-variant-numeric: tabular-nums;
+}
+
+.status-bar-separator {
+  width: 1px;
+  height: 14px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.status-bar-bp {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.status-bar-states {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.status-bar-state-pill {
+  font-size: 0.62rem;
+  font-weight: 700;
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.status-bar-state-pill.running {
   background: rgba(52, 211, 153, 0.15);
   color: var(--success);
 }
 
-.state-pill.paused {
-  background: rgba(251, 191, 36, 0.15);
-  color: var(--warning);
-}
-
-.state-pill.stopped {
+.status-bar-state-pill.stopped {
   background: rgba(248, 113, 113, 0.15);
   color: var(--danger);
 }
 
-.state-pill.circuit-open {
+.status-bar-state-pill.paused {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--warning);
+}
+
+.status-bar-state-pill.circuit-open {
   background: rgba(248, 113, 113, 0.25);
   color: var(--danger);
+}
+
+.status-bar-bulletin-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: none;
+  border: none;
+  cursor: default;
+  font-family: var(--font);
+  font-size: 0.72rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  transition: background 0.12s;
+}
+
+.status-bar-bulletin-btn.clickable {
+  cursor: pointer;
+}
+
+.status-bar-bulletin-btn.clickable:hover {
+  background: var(--surface-hover);
+}
+
+.status-bar-bulletin-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-bar-bulletin-dot.healthy {
+  background: var(--success);
+}
+
+.status-bar-bulletin-dot.warning {
+  background: var(--warning);
+}
+
+.status-bar-bulletin-dot.danger {
+  background: var(--danger);
+}
+
+.status-bar-bulletin-count {
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.status-bar-bulletin-count.error {
+  color: var(--danger);
+}
+
+.status-bar-bulletin-count.warn {
+  color: var(--warning);
+}
+
+.status-bar-bulletin-count.ok {
+  color: var(--success);
 }
 
 /* ── DAG section ────────────────────────────────────────────── */
 
 .dag-section {
-  height: calc(100vh - 180px);
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -218,7 +556,7 @@ body {
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
   flex-shrink: 0;
 }
 
@@ -226,8 +564,6 @@ body {
 
 .flow-canvas-wrapper {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
   flex: 1;
   overflow: hidden;
   position: relative;
@@ -299,6 +635,17 @@ body {
 
 .react-flow__attribution a {
   color: var(--text-dim) !important;
+}
+
+/* React Flow selection box */
+.react-flow__selection {
+  background: rgba(79, 143, 247, 0.08) !important;
+  border: 1px solid rgba(79, 143, 247, 0.4) !important;
+}
+
+.react-flow__nodesselection-rect {
+  background: rgba(79, 143, 247, 0.06) !important;
+  border: 1px dashed rgba(79, 143, 247, 0.4) !important;
 }
 
 /* ── Processor node ─────────────────────────────────────────── */
@@ -473,174 +820,6 @@ body {
   background: var(--accent) !important;
 }
 
-/* ── Processor Palette sidebar ──────────────────────────────── */
-
-.palette-sidebar {
-  width: 220px;
-  min-width: 220px;
-  background: var(--surface);
-  border-right: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  transition: width 0.2s ease, min-width 0.2s ease;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.palette-sidebar-collapsed {
-  width: 36px;
-  min-width: 36px;
-  align-items: center;
-  padding-top: 0.75rem;
-}
-
-.palette-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.75rem 0.75rem 0.5rem;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-
-.palette-title {
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-dim);
-}
-
-.palette-toggle {
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  cursor: pointer;
-  padding: 0.2rem 0.35rem;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  line-height: 1;
-  transition: color 0.15s, background 0.15s;
-}
-
-.palette-toggle:hover {
-  color: var(--text);
-  background: var(--surface-hover);
-}
-
-.palette-search-wrap {
-  padding: 0.5rem 0.6rem;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-
-.palette-search {
-  width: 100%;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text);
-  font-size: 0.8rem;
-  font-family: var(--font);
-  padding: 0.3rem 0.5rem;
-  outline: none;
-  transition: border-color 0.15s;
-}
-
-.palette-search:focus {
-  border-color: var(--accent);
-}
-
-.palette-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 0.4rem 0;
-}
-
-.palette-group {
-  margin-bottom: 0.25rem;
-}
-
-.palette-group-label {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-dim);
-  padding: 0.4rem 0.75rem 0.15rem;
-}
-
-.palette-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.45rem 0.75rem;
-  cursor: grab;
-  border-radius: 4px;
-  margin: 0 0.25rem;
-  transition: background 0.12s;
-  user-select: none;
-}
-
-.palette-item:hover {
-  background: var(--surface-hover);
-}
-
-.palette-item:active {
-  cursor: grabbing;
-}
-
-.palette-item-icon {
-  font-size: 0.65rem;
-  flex-shrink: 0;
-  margin-top: 0.15rem;
-}
-
-.palette-item-source .palette-item-icon { color: var(--success); }
-.palette-item-processor .palette-item-icon { color: var(--accent); }
-.palette-item-sink .palette-item-icon { color: var(--warning); }
-
-.palette-item-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  min-width: 0;
-}
-
-.palette-item-name {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.palette-item-desc {
-  font-size: 0.65rem;
-  color: var(--text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.palette-loading,
-.palette-empty {
-  font-size: 0.75rem;
-  color: var(--text-dim);
-  padding: 0.75rem;
-  text-align: center;
-}
-
-.palette-hint {
-  font-size: 0.62rem;
-  color: var(--text-dim);
-  text-align: center;
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid var(--border);
-  flex-shrink: 0;
-}
-
 /* ── Canvas drop hint ───────────────────────────────────────── */
 
 .canvas-drop-hint {
@@ -785,6 +964,25 @@ body {
   border-color: var(--accent);
 }
 
+.form-textarea {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text);
+  font-size: 0.85rem;
+  font-family: var(--font);
+  padding: 0.5rem 0.7rem;
+  outline: none;
+  transition: border-color 0.15s;
+  resize: vertical;
+  min-height: 100px;
+}
+
+.form-textarea:focus {
+  border-color: var(--accent);
+}
+
 .form-error {
   font-size: 0.75rem;
   color: var(--danger);
@@ -847,22 +1045,31 @@ body {
   border: 1px solid var(--border);
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
-  min-width: 160px;
+  min-width: 180px;
   z-index: 500;
   overflow: hidden;
   padding: 0.2rem 0;
+}
+
+.context-menu-header {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .context-menu-item {
   display: flex;
   align-items: center;
   width: 100%;
-  padding: 0.5rem 0.85rem;
+  padding: 0.45rem 0.85rem;
   background: none;
   border: none;
   text-align: left;
   font-family: var(--font);
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   color: var(--text);
   cursor: pointer;
   transition: background 0.12s;
@@ -891,7 +1098,7 @@ body {
 
 .toast-container {
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 2.5rem;
   right: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -952,50 +1159,6 @@ body {
   height: 1px;
   background: var(--border);
   margin: 0.2rem 0;
-}
-
-/* ── Summary bar bulletin button ────────────────────────────── */
-
-.summary-bulletins-btn {
-  background: none;
-  border: none;
-  cursor: default;
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0;
-  font-family: var(--font);
-}
-
-.summary-bulletins-btn.clickable {
-  cursor: pointer;
-}
-
-.summary-bulletins-btn.clickable:hover .bulletin-count {
-  opacity: 0.8;
-}
-
-.bulletin-count {
-  font-size: 0.72rem;
-  font-weight: 700;
-  padding: 0.1rem 0.4rem;
-  border-radius: 3px;
-}
-
-.bulletin-count.error {
-  background: rgba(248, 113, 113, 0.2);
-  color: var(--danger);
-}
-
-.bulletin-count.warn {
-  background: rgba(251, 191, 36, 0.15);
-  color: var(--warning);
-}
-
-.bulletin-count.ok {
-  background: rgba(52, 211, 153, 0.1);
-  color: var(--success);
-  font-size: 0.68rem;
 }
 
 /* ── Processor config modal ─────────────────────────────────── */
@@ -1157,6 +1320,19 @@ body {
 .config-save-status.error {
   color: var(--danger);
   background: rgba(248, 113, 113, 0.08);
+}
+
+.config-settings-section {
+  margin-top: 1.25rem;
+}
+
+.config-section-heading {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin-bottom: 0.5rem;
 }
 
 /* ── Relationship table (shared by config + queue) ──────────── */
@@ -1540,7 +1716,7 @@ body {
   text-overflow: ellipsis;
 }
 
-/* ── Connection edge labels (CSS classes over inline styles) ── */
+/* ── Connection edge labels ─────────────────────────────────── */
 
 .conn-edge-label {
   display: flex;
@@ -1590,31 +1766,146 @@ body {
   text-underline-offset: 2px;
 }
 
+/* ── Color picker dialog ────────────────────────────────────── */
+
+.color-picker-panel {
+  max-width: 320px;
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.color-swatch {
+  width: 100%;
+  aspect-ratio: 1;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.12s, box-shadow 0.12s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+}
+
+.color-swatch:hover {
+  transform: scale(1.1);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+}
+
+.color-swatch.active {
+  border-width: 3px;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.color-check {
+  color: #fff;
+  font-weight: 700;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* ── State pills (used in status bar + summary) ─────────────── */
+
+.state-pill {
+  font-size: 0.62rem;
+  font-weight: 700;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.state-pill.running {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--success);
+}
+
+.state-pill.stopped {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+}
+
+.state-pill.paused {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--warning);
+}
+
+.state-pill.circuit-open {
+  background: rgba(248, 113, 113, 0.25);
+  color: var(--danger);
+}
+
+/* ── Status bar bulletins button ────────────────────────────── */
+
+.status-bar-bulletins {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: none;
+  border: none;
+  cursor: default;
+  font-family: var(--font);
+  font-size: 0.72rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  transition: background 0.12s;
+}
+
+.status-bar-bulletins.clickable {
+  cursor: pointer;
+}
+
+.status-bar-bulletins.clickable:hover {
+  background: var(--surface-hover);
+}
+
+.bulletin-count {
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.bulletin-count.error {
+  color: var(--danger);
+}
+
+.bulletin-count.warn {
+  color: var(--warning);
+}
+
+.bulletin-count.ok {
+  color: var(--text-dim);
+}
+
 /* ── Responsive ─────────────────────────────────────────────── */
 
 @media (max-width: 768px) {
   .app-header {
     flex-direction: column;
     gap: 0.5rem;
-    padding: 0.75rem 1rem;
-  }
-
-  .summary-bar {
-    flex-direction: column;
-    gap: 1px;
-  }
-
-  .summary-item {
-    flex-direction: row;
-    justify-content: space-between;
     padding: 0.5rem 1rem;
   }
 
-  .app-main {
-    padding: 1rem;
+  .component-toolbar {
+    overflow-x: auto;
   }
 
-  .palette-sidebar {
-    display: none;
+  .nifi-status-bar {
+    flex-direction: column;
+    height: auto;
+    padding: 0.35rem 0.75rem;
+    gap: 0.25rem;
+  }
+
+  .status-bar-group {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .app-main {
+    padding: 0;
   }
 }

--- a/crates/runifi-api/dashboard-react/src/types/flow.ts
+++ b/crates/runifi-api/dashboard-react/src/types/flow.ts
@@ -13,6 +13,8 @@ export interface ProcessorNodeData extends Record<string, unknown> {
   relationships: string[];
   // True when created optimistically before the backend confirms
   pending: boolean;
+  // Custom color for visual grouping (hex string, empty = default)
+  customColor: string;
 }
 
 export interface ConnectionEdgeData extends Record<string, unknown> {

--- a/crates/runifi-api/dashboard-react/src/utils/layout.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/layout.ts
@@ -99,6 +99,7 @@ export function computeLayout(
       bulletin: null,
       relationships: ['success'], // overridden by caller once plugins are loaded
       pending: false,
+      customColor: '',
     },
   }));
 }


### PR DESCRIPTION
## Summary

Closes #51

Aligns the RuniFi dashboard with Apache NiFi's UI layout and interaction patterns:

- **Top component toolbar**: Replaces left sidebar palette with a NiFi-style horizontal toolbar for dragging components onto the canvas, including a category-based processor browser with search/filter
- **Right-click context menus**: Processor menu (configure, view status, start/stop/pause/resume, change color, delete), connection menu (view queue, delete), canvas menu (select all), and multi-select menu (start/stop/delete selected)
- **Config dialog tabs**: Updated from [Properties, Scheduling, Relationships] to NiFi's [Settings, Scheduling, Properties, Comments] pattern
- **Bottom status bar**: Compact 32px bar matching NiFi format — active threads, queued items/bytes, bytes in/out rates, state pills, and bulletin counts
- **Multi-select**: Region select on canvas, Shift+click, Ctrl+A select all, with bulk start/stop/delete operations
- **Processor color customization**: 9 preset colors via right-click "Change Color" menu for visual grouping

### Files changed

- `ComponentToolbar.tsx` (new) — horizontal top toolbar with processor browser
- `ColorPickerDialog.tsx` (new) — color picker modal with 9 presets
- `ContextMenu.tsx` — canvas, multi-select, edge, and node context menu modes
- `FlowCanvas.tsx` — multi-select, canvas context menu, color picker integration
- `ProcessorConfigModal.tsx` — NiFi tab layout (Settings, Scheduling, Properties, Comments)
- `ProcessorNode.tsx` — custom color border and header highlight
- `SummaryBar.tsx` — NiFi-style bottom status bar
- `App.tsx` — toolbar and bottom status bar layout
- `types/flow.ts` — customColor field on ProcessorNodeData
- `utils/layout.ts` — customColor default in layout computation
- `styles/global.css` — all new component styles

## Test plan

- [ ] Verify top toolbar renders with all component types (Processor, Input Port, Output Port, Funnel, Label)
- [ ] Click "Processor" to open the add processor dialog with category grouping and search
- [ ] Drag a processor from the dialog onto the canvas
- [ ] Right-click a processor node to see context menu (Configure, View Status, Start, Stop, Change Color, Delete)
- [ ] Right-click a connection edge to see context menu (View Queue, Delete Connection)
- [ ] Right-click empty canvas to see "Select All" option
- [ ] Select multiple nodes (Shift+click or drag select), right-click to see bulk operations
- [ ] Double-click processor to open config dialog — verify 4 tabs: Settings, Scheduling, Properties, Comments
- [ ] Use "Change Color" from context menu to set a processor's custom color
- [ ] Verify bottom status bar shows active threads, queued items, bytes in/out, state pills, bulletins
- [ ] Verify Ctrl+A selects all nodes
- [ ] Verify Delete/Backspace key works for selected nodes/edges
- [ ] Run `npm run build` — passes with no TypeScript errors