### PR TITLE
fix: dashboard crash when plugins API returns bare array

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
@@ -44,9 +44,9 @@ function ComponentToolbarInner({ plugins, loading, onDragStart }: ComponentToolb
     const q = search.toLowerCase();
     const filtered = plugins.filter(
       (p) =>
-        p.display_name.toLowerCase().includes(q) ||
-        p.type_name.toLowerCase().includes(q) ||
-        p.description.toLowerCase().includes(q),
+        (p.display_name ?? '').toLowerCase().includes(q) ||
+        (p.type_name ?? '').toLowerCase().includes(q) ||
+        (p.description ?? '').toLowerCase().includes(q),
     );
 
     const cats = new Map<string, PluginDescriptor[]>();

--- a/crates/runifi-api/dashboard-react/src/hooks/usePlugins.ts
+++ b/crates/runifi-api/dashboard-react/src/hooks/usePlugins.ts
@@ -1,7 +1,7 @@
 // Fetches available processor types from GET /api/v1/plugins
 
 import { useState, useEffect } from 'react';
-import type { PluginDescriptor, PluginsResponse } from '../types/api';
+import type { PluginDescriptor } from '../types/api';
 
 // Fallback plugins when the backend is not yet ready
 const FALLBACK_PLUGINS: PluginDescriptor[] = [
@@ -96,11 +96,25 @@ export function usePlugins(): UsePluginsResult {
     fetch('/api/v1/plugins')
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json() as Promise<PluginsResponse>;
+        return res.json();
       })
       .then((data) => {
         if (!cancelled) {
-          setPlugins(data.plugins);
+          // API may return bare array or { plugins: [...] }
+          const raw: unknown[] = Array.isArray(data) ? data : (data.plugins ?? []);
+          // Backend only returns type_name + kind — fill in display_name/description from fallbacks
+          const merged: PluginDescriptor[] = raw.map((item: any) => {
+            const fallback = FALLBACK_PLUGINS.find((f) => f.type_name === item.type_name);
+            return {
+              type_name: item.type_name ?? '',
+              display_name: item.display_name ?? fallback?.display_name ?? item.type_name ?? '',
+              description: item.description ?? fallback?.description ?? '',
+              kind: item.kind ?? 'processor',
+              relationships: item.relationships ?? fallback?.relationships ?? ['success'],
+              properties: item.properties ?? fallback?.properties ?? [],
+            };
+          });
+          setPlugins(merged);
           setLoading(false);
         }
       })


### PR DESCRIPTION
## Summary
- Fixed TypeError crash on dashboard load caused by plugins API returning a bare JSON array instead of `{ plugins: [...] }`
- Backend only returns `type_name` + `kind` per plugin — added fallback enrichment for `display_name`, `description`, `relationships`, and `properties` from hardcoded defaults
- Added defensive nullish coalescing in `ComponentToolbar` filter to prevent crashes on missing fields

## Root Cause
PR #174 introduced `ComponentToolbar` which calls `plugins.filter(p => p.display_name.toLowerCase()...)`, but `usePlugins` hook expected `data.plugins` from the API response. The API actually returns a bare array `[{type_name, kind}, ...]`, so `data.plugins` was `undefined`.

## Test plan
- [x] Dashboard loads without TypeError
- [x] Processor toolbar shows all 6 registered plugins with display names
- [x] Search/filter works in the Add Processor dialog