### PR TITLE
fix: processor drag-and-drop from toolbar to canvas (#184)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/App.tsx
+++ b/crates/runifi-api/dashboard-react/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Header } from './components/Header';
 import { SummaryBar } from './components/SummaryBar';
 import { FlowCanvas } from './components/FlowCanvas';
@@ -18,6 +18,7 @@ export function App() {
   const { toasts, push: pushToast, dismiss: dismissToast } = useToast();
 
   const [draggedPlugin, setDraggedPlugin] = useState<PluginDescriptor | null>(null);
+  const [addPluginAtCenter, setAddPluginAtCenter] = useState<PluginDescriptor | null>(null);
   const [bulletinOpen, setBulletinOpen] = useState(false);
 
   const uptimeSecs = liveMetrics?.uptime_secs ?? 0;
@@ -34,6 +35,7 @@ export function App() {
   );
 
   const handleDragEnd = () => setDraggedPlugin(null);
+  const handleAddPluginHandled = useCallback(() => setAddPluginAtCenter(null), []);
 
   return (
     <div className="app-layout" onDragEnd={handleDragEnd}>
@@ -42,6 +44,7 @@ export function App() {
         plugins={plugins}
         loading={pluginsLoading}
         onDragStart={setDraggedPlugin}
+        onAddProcessor={setAddPluginAtCenter}
       />
 
       <div className="app-body">
@@ -69,6 +72,8 @@ export function App() {
                 plugins={plugins}
                 onToast={pushToast}
                 draggedPlugin={draggedPlugin}
+                addPluginAtCenter={addPluginAtCenter}
+                onAddPluginHandled={handleAddPluginHandled}
               />
             )}
           </section>

--- a/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
@@ -5,6 +5,7 @@ interface ComponentToolbarProps {
   plugins: PluginDescriptor[];
   loading: boolean;
   onDragStart: (plugin: PluginDescriptor) => void;
+  onAddProcessor?: (plugin: PluginDescriptor) => void;
 }
 
 const COMPONENT_TYPES = [
@@ -33,7 +34,7 @@ function getCategory(typeName: string, kind: PluginKind): string {
   }
 }
 
-function ComponentToolbarInner({ plugins, loading, onDragStart }: ComponentToolbarProps) {
+function ComponentToolbarInner({ plugins, loading, onDragStart, onAddProcessor }: ComponentToolbarProps) {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [search, setSearch] = useState('');
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
@@ -196,11 +197,19 @@ function ComponentToolbarInner({ plugins, loading, onDragStart }: ComponentToolb
                           e.dataTransfer.effectAllowed = 'copy';
                           e.dataTransfer.setData('application/runifi-plugin', plugin.type_name);
                           onDragStart(plugin);
+                        }}
+                        onDragEnd={() => {
+                          setShowAddDialog(false);
+                          setSearch('');
+                        }}
+                        onClick={() => {
+                          onAddProcessor?.(plugin);
                           setShowAddDialog(false);
                           setSearch('');
                         }}
                         role="listitem"
-                        aria-label={`Drag to add ${plugin.display_name}`}
+                        aria-label={`Click or drag to add ${plugin.display_name}`}
+                        style={{ cursor: 'pointer' }}
                       >
                         <div className="toolbar-add-item-info">
                           <span className="toolbar-add-item-name">{plugin.display_name}</span>

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -75,6 +75,8 @@ export interface FlowCanvasProps {
   plugins: PluginDescriptor[];
   onToast: (kind: ToastKind, message: string) => void;
   draggedPlugin: PluginDescriptor | null;
+  addPluginAtCenter?: PluginDescriptor | null;
+  onAddPluginHandled?: () => void;
 }
 
 function buildEdges(
@@ -130,8 +132,10 @@ function FlowCanvasInner({
   plugins,
   onToast,
   draggedPlugin,
+  addPluginAtCenter,
+  onAddPluginHandled,
 }: FlowCanvasProps) {
-  const { screenToFlowPosition } = useReactFlow();
+  const { screenToFlowPosition, getViewport } = useReactFlow();
 
   const [queueInspectTarget, setQueueInspectTarget] = useState<QueueInspectTarget | null>(null);
   const handleQueueClick = useCallback((connectionId: string, label: string) => {
@@ -301,6 +305,15 @@ function FlowCanvasInner({
       for (const t of timers.values()) clearTimeout(t);
     };
   }, []);
+
+  useEffect(() => {
+    if (!addPluginAtCenter) return;
+    const { x, y, zoom } = getViewport();
+    const centerX = (-x + window.innerWidth / 2) / zoom;
+    const centerY = (-y + window.innerHeight / 2) / zoom;
+    setPendingDrop({ plugin: addPluginAtCenter, position: { x: centerX, y: centerY } });
+    onAddPluginHandled?.();
+  }, [addPluginAtCenter, getViewport, onAddPluginHandled]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fix drag-and-drop: move dialog close from `onDragStart` to `onDragEnd` so the DOM element persists during drag
- Add click-to-add: clicking a processor in the dialog places it at viewport center
- Both workflows trigger the existing name dialog and processor creation flow

## Changes
- `ComponentToolbar.tsx`: Fixed drag lifecycle, added `onAddProcessor` prop and click handler
- `FlowCanvas.tsx`: Added viewport-center placement for click-to-add via `addPluginAtCenter` prop
- `App.tsx`: Wired state between toolbar and canvas

## Test Plan
- [x] `cargo test --workspace` — 188 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Dashboard builds clean (`npm run build`)
- [ ] Manual: drag processor from dialog to canvas — processor created at drop position
- [ ] Manual: click processor in dialog — processor created at viewport center
- [ ] Manual: drag processor but drop outside canvas — dialog closes, no processor created

Closes #184