### PR TITLE
fix: allow processor creation with empty properties

### DIFF
--- a/crates/runifi-api/src/routes/processors.rs
+++ b/crates/runifi-api/src/routes/processors.rs
@@ -102,7 +102,9 @@ fn validate_processor_name(name: &str) -> Result<(), ApiError> {
 }
 
 /// Validate properties against the processor type's property descriptors.
-/// Rejects unknown property keys, missing required properties, and invalid allowed values.
+/// Rejects unknown property keys and invalid allowed values.
+/// Required-property checks are deferred to start time (matching NiFi behavior:
+/// create → configure → start).
 fn validate_properties(
     properties: &std::collections::HashMap<String, String>,
     descriptors: &[runifi_plugin_api::PropertyDescriptor],
@@ -117,16 +119,6 @@ fn validate_properties(
                 "Unknown property '{}'. Valid properties: {:?}",
                 key,
                 known_names.iter().collect::<Vec<_>>()
-            )));
-        }
-    }
-
-    // Validate required properties are present (or have defaults).
-    for desc in descriptors {
-        if desc.required && desc.default_value.is_none() && !properties.contains_key(desc.name) {
-            return Err(ApiError::BadRequest(format!(
-                "Required property '{}' is missing",
-                desc.name
             )));
         }
     }


### PR DESCRIPTION
## Summary
- Defer required-property validation from creation time to start time
- Matches NiFi's create → configure → start workflow
- Fixes processors with required properties (RouteOnAttribute, GetFile, PutFile) being immediately rolled back on creation

## Root Cause
`validate_properties()` rejected missing required properties at creation time. The frontend correctly sends `properties: {}` on drag-and-drop, expecting the user to configure after.

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Manual test: POST RouteOnAttribute with empty properties → 201
- [x] Manual test: GET config endpoint returns property descriptors

Closes #194