### PR TITLE
feat: NiFi-style connection creation with center drag (#179)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
@@ -54,6 +54,19 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         style={{ top: '50%' }}
       />
 
+      {/* NiFi-style center connection handle — visible on hover */}
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="center-source"
+        className="center-connect-handle"
+      />
+      <div className="center-connect-indicator" aria-label="Drag to connect">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M3 8H13M13 8L9 4M13 8L9 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </div>
+
       <div className="proc-node-header" style={headerStyle}>
         <div className="proc-node-identity">
           <span className="proc-node-name" title={label}>
@@ -112,14 +125,15 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         </div>
       )}
 
+      {/* Hidden per-relationship handles for edge anchoring */}
       {rels.map((rel, idx) => (
         <Handle
           key={rel}
           type="source"
           position={Position.Right}
           id={rel}
+          className="edge-anchor-handle"
           style={{ top: handleTopPercent(idx, rels.length) }}
-          title={rel}
         />
       ))}
     </div>

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -820,6 +820,78 @@ body {
   background: var(--accent) !important;
 }
 
+/* ── NiFi-style center connection handle ───────────────────── */
+
+/* Per-relationship handles: invisible but present for edge anchoring */
+.react-flow__handle.edge-anchor-handle {
+  width: 1px !important;
+  height: 1px !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+/* Center connection handle: invisible by default, drag point on hover */
+.react-flow__handle.center-connect-handle {
+  width: 28px !important;
+  height: 28px !important;
+  top: 50% !important;
+  right: 50% !important;
+  transform: translate(50%, -50%) !important;
+  background: transparent !important;
+  border: none !important;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10;
+  transition: opacity 0.15s;
+  border-radius: 50% !important;
+}
+
+.processor-node:hover .react-flow__handle.center-connect-handle {
+  opacity: 1;
+  pointer-events: all;
+  background: rgba(79, 143, 247, 0.15) !important;
+  border: 2px solid var(--accent) !important;
+}
+
+.processor-node:hover .react-flow__handle.center-connect-handle:hover {
+  background: rgba(79, 143, 247, 0.3) !important;
+  box-shadow: 0 0 8px rgba(79, 143, 247, 0.4);
+  cursor: crosshair;
+}
+
+/* Center connection indicator (arrow icon overlay) */
+.center-connect-indicator {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 11;
+  color: var(--accent);
+}
+
+.processor-node:hover .center-connect-indicator {
+  opacity: 1;
+}
+
+/* Connection line style during drag */
+.react-flow__connection-path {
+  stroke: var(--accent) !important;
+  stroke-width: 2 !important;
+  stroke-dasharray: 6 3 !important;
+}
+
+.react-flow__connection {
+  z-index: 1001 !important;
+}
+
 /* ── Canvas drop hint ───────────────────────────────────────── */
 
 .canvas-drop-hint {


### PR DESCRIPTION
## Summary
- Replace edge-handle connection creation with NiFi-style center drag
- Hovering a processor shows a connection drag indicator (arrow icon in center)
- Dragging from indicator to another processor creates a connection
- Relationship selection dialog shown when source has multiple relationships
- Per-relationship handles remain hidden for edge anchoring but are no longer interactive

## Changes
- `ProcessorNode.tsx`: Added center source Handle with `center-source` id and arrow SVG overlay; per-relationship handles get `edge-anchor-handle` class to hide them
- `global.css`: Added styles for center connection handle (hover reveal), arrow indicator overlay, hidden edge-anchor handles, and dashed connection line during drag

## Test plan
- [ ] Hover processor node -- connection indicator (arrow icon) appears in center
- [ ] Drag from center indicator to target processor -- rubber-band connection line follows cursor
- [ ] Drop on target -- relationship selection dialog appears
- [ ] Select relationship and confirm -- connection edge created with correct relationship
- [ ] Multi-relationship processor -- dialog shows all available relationships
- [ ] Single-relationship processor -- dialog shows the single relationship for confirmation
- [ ] Existing connections still render correctly (edge anchoring via hidden handles)
- [ ] Self-connection attempt still blocked with warning toast

Closes #179