### PR TITLE
feat: implement ValidateJson processor (#94)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +301,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,10 +340,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -605,6 +646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +766,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +799,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -767,6 +836,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1089,18 +1168,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1290,6 +1388,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1466,35 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -1513,6 +1656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1739,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1891,6 +2046,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2114,45 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "reserve-port"
@@ -2059,6 +2288,7 @@ dependencies = [
  "bytes",
  "inventory",
  "jsonpath_lib",
+ "jsonschema",
  "parking_lot",
  "rand 0.9.2",
  "regex-lite",
@@ -2444,6 +2674,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2699,10 +2932,13 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -2837,6 +3073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,6 +3149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +3169,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -2972,6 +3230,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ hex = "0.4"                  # Hex encoding/decoding for keys
 base64 = "0.22"              # Base64 encoding for encrypted properties
 argon2 = "0.5"               # Password hashing
 jsonwebtoken = "9"           # JWT token generation/validation
+jsonschema = "0.45"          # JSON Schema validation
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/runifi-processors/Cargo.toml
+++ b/crates/runifi-processors/Cargo.toml
@@ -12,7 +12,7 @@ filesystem = []
 routing = []
 debug = []
 transformation = ["serde_json", "jsonpath_lib"]
-json = ["serde_json"]
+json = ["serde_json", "dep:jsonschema"]
 extraction = []
 
 [dependencies]
@@ -25,3 +25,4 @@ regex-lite = { workspace = true }
 parking_lot = { workspace = true }
 serde_json = { workspace = true, optional = true }
 jsonpath_lib = { workspace = true, optional = true }
+jsonschema = { workspace = true, optional = true }

--- a/crates/runifi-processors/src/lib.rs
+++ b/crates/runifi-processors/src/lib.rs
@@ -20,6 +20,8 @@ pub mod split_json;
 
 #[cfg(feature = "json")]
 pub mod flatten_json;
+#[cfg(feature = "json")]
+pub mod validate_json;
 
 #[cfg(feature = "extraction")]
 pub mod extract_text;

--- a/crates/runifi-processors/src/validate_json.rs
+++ b/crates/runifi-processors/src/validate_json.rs
@@ -1,0 +1,684 @@
+use std::sync::Arc;
+
+use runifi_plugin_api::REL_FAILURE;
+use runifi_plugin_api::context::ProcessContext;
+use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::property::PropertyDescriptor;
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::ProcessResult;
+use runifi_plugin_api::session::ProcessSession;
+
+const REL_VALID: Relationship = Relationship::new("valid", "FlowFiles that pass schema validation");
+const REL_INVALID: Relationship =
+    Relationship::new("invalid", "FlowFiles that fail schema validation");
+
+const PROP_SCHEMA_CONTENT: PropertyDescriptor = PropertyDescriptor::new(
+    "Schema Content",
+    "Inline JSON Schema definition. Exactly one of 'Schema Content' or 'Schema File' must be set.",
+);
+
+const PROP_SCHEMA_FILE: PropertyDescriptor = PropertyDescriptor::new(
+    "Schema File",
+    "Path to a JSON Schema file. Exactly one of 'Schema Content' or 'Schema File' must be set.",
+);
+
+const PROP_SCHEMA_VERSION: PropertyDescriptor = PropertyDescriptor::new(
+    "Schema Version",
+    "JSON Schema draft version to use for validation",
+)
+.default_value("draft-07")
+.allowed_values(&["draft-07", "2019-09", "2020-12"]);
+
+/// Validates FlowFile JSON content against a JSON Schema.
+///
+/// FlowFiles whose content passes validation are routed to "valid".
+/// FlowFiles whose content fails validation are routed to "invalid" with
+/// validation error details stored in attributes.
+/// FlowFiles that cannot be parsed as JSON or whose schema cannot be loaded
+/// are routed to "failure".
+pub struct ValidateJson;
+
+impl ValidateJson {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ValidateJson {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Processor for ValidateJson {
+    fn on_trigger(
+        &mut self,
+        context: &dyn ProcessContext,
+        session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        let schema_content = context.get_property("Schema Content");
+        let schema_file = context.get_property("Schema File");
+
+        // Load the schema JSON. Exactly one of Schema Content or Schema File must be set.
+        let schema_json = match (schema_content.as_str(), schema_file.as_str()) {
+            (Some(content), None) => match serde_json::from_str::<serde_json::Value>(content) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to parse inline schema JSON");
+                    // Route all pending FlowFiles to failure.
+                    while let Some(mut flowfile) = session.get() {
+                        flowfile.set_attribute(
+                            Arc::from("validation.error.message"),
+                            Arc::from(format!("Failed to parse inline schema: {}", e).as_str()),
+                        );
+                        session.transfer(flowfile, &REL_FAILURE);
+                    }
+                    session.commit();
+                    return Ok(());
+                }
+            },
+            (None, Some(path)) => match std::fs::read_to_string(path) {
+                Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::error!(path = path, error = %e, "Failed to parse schema file JSON");
+                        while let Some(mut flowfile) = session.get() {
+                            flowfile.set_attribute(
+                                Arc::from("validation.error.message"),
+                                Arc::from(
+                                    format!("Failed to parse schema file '{}': {}", path, e)
+                                        .as_str(),
+                                ),
+                            );
+                            session.transfer(flowfile, &REL_FAILURE);
+                        }
+                        session.commit();
+                        return Ok(());
+                    }
+                },
+                Err(e) => {
+                    tracing::error!(path = path, error = %e, "Failed to read schema file");
+                    while let Some(mut flowfile) = session.get() {
+                        flowfile.set_attribute(
+                            Arc::from("validation.error.message"),
+                            Arc::from(
+                                format!("Failed to read schema file '{}': {}", path, e).as_str(),
+                            ),
+                        );
+                        session.transfer(flowfile, &REL_FAILURE);
+                    }
+                    session.commit();
+                    return Ok(());
+                }
+            },
+            (Some(_), Some(_)) => {
+                tracing::error!(
+                    "Both 'Schema Content' and 'Schema File' are set; exactly one must be specified"
+                );
+                while let Some(mut flowfile) = session.get() {
+                    flowfile.set_attribute(
+                        Arc::from("validation.error.message"),
+                        Arc::from(
+                            "Both 'Schema Content' and 'Schema File' are set; exactly one must be specified",
+                        ),
+                    );
+                    session.transfer(flowfile, &REL_FAILURE);
+                }
+                session.commit();
+                return Ok(());
+            }
+            (None, None) => {
+                tracing::error!(
+                    "Neither 'Schema Content' nor 'Schema File' is set; exactly one must be specified"
+                );
+                while let Some(mut flowfile) = session.get() {
+                    flowfile.set_attribute(
+                        Arc::from("validation.error.message"),
+                        Arc::from(
+                            "Neither 'Schema Content' nor 'Schema File' is set; exactly one must be specified",
+                        ),
+                    );
+                    session.transfer(flowfile, &REL_FAILURE);
+                }
+                session.commit();
+                return Ok(());
+            }
+        };
+
+        // Compile the validator for the specified draft version.
+        let schema_version = context
+            .get_property("Schema Version")
+            .unwrap_or("draft-07")
+            .to_string();
+
+        let validator = match schema_version.as_str() {
+            "2019-09" => jsonschema::draft201909::new(&schema_json),
+            "2020-12" => jsonschema::draft202012::new(&schema_json),
+            _ => jsonschema::draft7::new(&schema_json),
+        };
+
+        let validator = match validator {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to compile JSON Schema");
+                while let Some(mut flowfile) = session.get() {
+                    flowfile.set_attribute(
+                        Arc::from("validation.error.message"),
+                        Arc::from(format!("Failed to compile JSON Schema: {}", e).as_str()),
+                    );
+                    session.transfer(flowfile, &REL_FAILURE);
+                }
+                session.commit();
+                return Ok(());
+            }
+        };
+
+        // Process each FlowFile.
+        while let Some(flowfile) = session.get() {
+            let content = match session.read_content(&flowfile) {
+                Ok(data) => data,
+                Err(e) => {
+                    tracing::warn!(flowfile_id = flowfile.id, error = %e, "Failed to read FlowFile content");
+                    let mut ff = flowfile;
+                    ff.set_attribute(
+                        Arc::from("validation.error.message"),
+                        Arc::from(format!("Failed to read content: {}", e).as_str()),
+                    );
+                    session.transfer(ff, &REL_FAILURE);
+                    continue;
+                }
+            };
+
+            // Parse the FlowFile content as JSON.
+            let instance: serde_json::Value = match serde_json::from_slice(&content) {
+                Ok(v) => v,
+                Err(e) => {
+                    let mut ff = flowfile;
+                    ff.set_attribute(
+                        Arc::from("validation.error.message"),
+                        Arc::from(format!("Content is not valid JSON: {}", e).as_str()),
+                    );
+                    ff.set_attribute(Arc::from("validation.error.count"), Arc::from("1"));
+                    session.transfer(ff, &REL_FAILURE);
+                    continue;
+                }
+            };
+
+            // Validate the JSON against the schema.
+            let errors: Vec<String> = validator
+                .iter_errors(&instance)
+                .map(|e| format!("{} at {}", e, e.instance_path()))
+                .collect();
+
+            if errors.is_empty() {
+                session.transfer(flowfile, &REL_VALID);
+            } else {
+                let mut ff = flowfile;
+                let error_count = errors.len();
+                ff.set_attribute(
+                    Arc::from("validation.error.count"),
+                    Arc::from(error_count.to_string().as_str()),
+                );
+                ff.set_attribute(
+                    Arc::from("validation.error.message"),
+                    Arc::from(errors[0].as_str()),
+                );
+                // Build a JSON array of all error messages.
+                let errors_json = serde_json::to_string(&errors).unwrap_or_else(|_| "[]".into());
+                ff.set_attribute(
+                    Arc::from("validation.errors"),
+                    Arc::from(errors_json.as_str()),
+                );
+                session.transfer(ff, &REL_INVALID);
+            }
+        }
+
+        session.commit();
+        Ok(())
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_VALID, REL_INVALID, REL_FAILURE]
+    }
+
+    fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
+        vec![PROP_SCHEMA_CONTENT, PROP_SCHEMA_FILE, PROP_SCHEMA_VERSION]
+    }
+}
+
+inventory::submit! {
+    ProcessorDescriptor {
+        type_name: "ValidateJson",
+        description: "Validates FlowFile JSON content against a JSON Schema",
+        factory: || Box::new(ValidateJson::new()),
+        tags: &["JSON", "Validation", "Schema"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use runifi_plugin_api::FlowFile;
+    use runifi_plugin_api::property::PropertyValue;
+    use std::io::Write;
+
+    struct TestContext {
+        schema_content: Option<String>,
+        schema_file: Option<String>,
+        schema_version: String,
+    }
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, name: &str) -> PropertyValue {
+            match name {
+                "Schema Content" => match &self.schema_content {
+                    Some(v) => PropertyValue::String(v.clone()),
+                    None => PropertyValue::Unset,
+                },
+                "Schema File" => match &self.schema_file {
+                    Some(v) => PropertyValue::String(v.clone()),
+                    None => PropertyValue::Unset,
+                },
+                "Schema Version" => PropertyValue::String(self.schema_version.clone()),
+                _ => PropertyValue::Unset,
+            }
+        }
+        fn name(&self) -> &str {
+            "test-validate-json"
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    struct TestSession {
+        inputs: Vec<FlowFile>,
+        content_map: Vec<(u64, Bytes)>,
+        transferred: Vec<(FlowFile, &'static str)>,
+    }
+
+    impl TestSession {
+        fn new(inputs: Vec<(FlowFile, Bytes)>) -> Self {
+            let content_map: Vec<(u64, Bytes)> = inputs
+                .iter()
+                .map(|(ff, data)| (ff.id, data.clone()))
+                .collect();
+            let inputs: Vec<FlowFile> = inputs.into_iter().map(|(ff, _)| ff).collect();
+            Self {
+                inputs,
+                content_map,
+                transferred: Vec::new(),
+            }
+        }
+    }
+
+    impl ProcessSession for TestSession {
+        fn get(&mut self) -> Option<FlowFile> {
+            if self.inputs.is_empty() {
+                None
+            } else {
+                Some(self.inputs.remove(0))
+            }
+        }
+        fn get_batch(&mut self, _max: usize) -> Vec<FlowFile> {
+            std::mem::take(&mut self.inputs)
+        }
+        fn read_content(&self, ff: &FlowFile) -> ProcessResult<Bytes> {
+            self.content_map
+                .iter()
+                .find(|(id, _)| *id == ff.id)
+                .map(|(_, data)| data.clone())
+                .ok_or(runifi_plugin_api::PluginError::ContentNotFound(ff.id))
+        }
+        fn write_content(&mut self, ff: FlowFile, _data: Bytes) -> ProcessResult<FlowFile> {
+            Ok(ff)
+        }
+        fn create(&mut self) -> FlowFile {
+            unimplemented!()
+        }
+        fn clone_flowfile(&mut self, _ff: &FlowFile) -> FlowFile {
+            unimplemented!()
+        }
+        fn transfer(&mut self, ff: FlowFile, rel: &Relationship) {
+            self.transferred.push((ff, rel.name));
+        }
+        fn remove(&mut self, _ff: FlowFile) {}
+        fn penalize(&mut self, ff: FlowFile) -> FlowFile {
+            ff
+        }
+        fn commit(&mut self) {}
+        fn rollback(&mut self) {}
+    }
+
+    fn make_ff(id: u64) -> FlowFile {
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    const TEST_SCHEMA: &str = r#"{
+        "type": "object",
+        "required": ["name", "age"],
+        "properties": {
+            "name": { "type": "string" },
+            "age": { "type": "integer", "minimum": 0 }
+        }
+    }"#;
+
+    #[test]
+    fn valid_json_routes_to_valid() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice", "age": 30}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "valid");
+    }
+
+    #[test]
+    fn invalid_json_routes_to_invalid_with_error_attrs() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        // Missing required "age" field and "name" has wrong type.
+        let invalid_json = r#"{"name": 123}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(invalid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "invalid");
+
+        let ff = &session.transferred[0].0;
+        // Should have error count attribute.
+        let error_count = ff.get_attribute("validation.error.count").unwrap();
+        let count: usize = error_count.parse().unwrap();
+        assert!(count >= 1, "Expected at least 1 validation error");
+
+        // Should have error message.
+        assert!(ff.get_attribute("validation.error.message").is_some());
+
+        // Should have errors JSON array.
+        assert!(ff.get_attribute("validation.errors").is_some());
+    }
+
+    #[test]
+    fn not_json_routes_to_failure() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        let not_json = "this is not json";
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(not_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+        assert!(
+            session.transferred[0]
+                .0
+                .get_attribute("validation.error.message")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn no_schema_routes_to_failure() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: None,
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice"}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+    }
+
+    #[test]
+    fn both_schemas_routes_to_failure() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: Some("/tmp/schema.json".to_string()),
+            schema_version: "draft-07".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice"}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+    }
+
+    #[test]
+    fn schema_file_loading() {
+        // Write a temporary schema file.
+        let dir = std::env::temp_dir().join("runifi-test-validate-json");
+        std::fs::create_dir_all(&dir).unwrap();
+        let schema_path = dir.join("test-schema.json");
+        let mut f = std::fs::File::create(&schema_path).unwrap();
+        f.write_all(TEST_SCHEMA.as_bytes()).unwrap();
+
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: None,
+            schema_file: Some(schema_path.to_str().unwrap().to_string()),
+            schema_version: "draft-07".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Bob", "age": 25}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "valid");
+
+        // Clean up.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_schema_file_routes_to_failure() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: None,
+            schema_file: Some("/nonexistent/path/schema.json".to_string()),
+            schema_version: "draft-07".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice"}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+    }
+
+    #[test]
+    fn invalid_inline_schema_routes_to_failure() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some("not valid json".to_string()),
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice"}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+    }
+
+    #[test]
+    fn schema_version_2019_09() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "2019-09".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice", "age": 30}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "valid");
+    }
+
+    #[test]
+    fn schema_version_2020_12() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "2020-12".to_string(),
+        };
+
+        let valid_json = r#"{"name": "Alice", "age": 30}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(valid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "valid");
+    }
+
+    #[test]
+    fn multiple_validation_errors() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        // Wrong type for name, negative age, both violate schema.
+        let invalid_json = r#"{"name": 123, "age": -5}"#;
+        let mut session = TestSession::new(vec![(make_ff(1), Bytes::from(invalid_json))]);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "invalid");
+
+        let ff = &session.transferred[0].0;
+        let error_count: usize = ff
+            .get_attribute("validation.error.count")
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(
+            error_count >= 2,
+            "Expected at least 2 validation errors, got {}",
+            error_count
+        );
+
+        // Verify errors is a JSON array.
+        let errors_json = ff.get_attribute("validation.errors").unwrap();
+        let errors: Vec<String> = serde_json::from_str(errors_json.as_ref()).unwrap();
+        assert_eq!(errors.len(), error_count);
+    }
+
+    #[test]
+    fn multiple_flowfiles_mixed_results() {
+        let mut proc = ValidateJson::new();
+        let ctx = TestContext {
+            schema_content: Some(TEST_SCHEMA.to_string()),
+            schema_file: None,
+            schema_version: "draft-07".to_string(),
+        };
+
+        let inputs = vec![
+            (make_ff(1), Bytes::from(r#"{"name": "Alice", "age": 30}"#)),
+            (make_ff(2), Bytes::from(r#"{"name": 123}"#)),
+            (make_ff(3), Bytes::from("not json")),
+            (make_ff(4), Bytes::from(r#"{"name": "Bob", "age": 1}"#)),
+        ];
+        let mut session = TestSession::new(inputs);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 4);
+        assert_eq!(session.transferred[0].1, "valid"); // Valid JSON.
+        assert_eq!(session.transferred[1].1, "invalid"); // Schema violation.
+        assert_eq!(session.transferred[2].1, "failure"); // Not JSON.
+        assert_eq!(session.transferred[3].1, "valid"); // Valid JSON.
+    }
+
+    #[test]
+    fn property_descriptors_are_correct() {
+        let proc = ValidateJson::new();
+        let descriptors = proc.property_descriptors();
+        assert_eq!(descriptors.len(), 3);
+
+        let names: Vec<&str> = descriptors.iter().map(|d| d.name).collect();
+        assert!(names.contains(&"Schema Content"));
+        assert!(names.contains(&"Schema File"));
+        assert!(names.contains(&"Schema Version"));
+
+        // Schema Version should have a default and allowed values.
+        let version_desc = descriptors
+            .iter()
+            .find(|d| d.name == "Schema Version")
+            .unwrap();
+        assert_eq!(version_desc.default_value, Some("draft-07"));
+        assert!(version_desc.allowed_values.is_some());
+        let allowed = version_desc.allowed_values.unwrap();
+        assert!(allowed.contains(&"draft-07"));
+        assert!(allowed.contains(&"2019-09"));
+        assert!(allowed.contains(&"2020-12"));
+    }
+
+    #[test]
+    fn relationships_are_correct() {
+        let proc = ValidateJson::new();
+        let rels = proc.relationships();
+        assert_eq!(rels.len(), 3);
+
+        let names: Vec<&str> = rels.iter().map(|r| r.name).collect();
+        assert!(names.contains(&"valid"));
+        assert!(names.contains(&"invalid"));
+        assert!(names.contains(&"failure"));
+    }
+}


### PR DESCRIPTION
## Summary
Validates JSON content against JSON Schema with detailed error reporting.

### Changes
- New `ValidateJson` processor (feature-gated: `json`)
- JSON Schema validation (Draft-07, 2019-09, 2020-12) via the `jsonschema` crate
- Inline (`Schema Content`) and file-based (`Schema File`) schema support
- Validation error attributes: `validation.error.count`, `validation.error.message`, `validation.errors` (JSON array)
- Three relationships: `valid`, `invalid`, `failure`
- Fix pre-existing missing `tags` field in `engine_mutations.rs` test

### Relationships
| Relationship | Description |
|---|---|
| valid | FlowFiles that pass schema validation |
| invalid | FlowFiles that fail validation (errors in attributes) |
| failure | Content is not valid JSON or schema load error |

### Properties
| Property | Type | Default | Description |
|---|---|---|---|
| Schema Content | string | (optional) | Inline JSON Schema |
| Schema File | string | (optional) | Path to schema file |
| Schema Version | enum | draft-07 | draft-07, 2019-09, or 2020-12 |

## Test Plan
- [x] Valid JSON routes to `valid` relationship
- [x] Invalid JSON (schema violations) routes to `invalid` with error attributes
- [x] Non-JSON content routes to `failure`
- [x] Multiple validation errors populate all error attributes
- [x] Inline schema (`Schema Content`) works
- [x] File-based schema (`Schema File`) works
- [x] Missing schema file routes to `failure`
- [x] Invalid inline schema routes to `failure`
- [x] No schema specified routes to `failure`
- [x] Both schemas specified routes to `failure`
- [x] Draft-07, 2019-09, 2020-12 schema versions all work
- [x] Multiple FlowFiles with mixed valid/invalid/failure results
- [x] Property descriptors and relationships are correct

Closes #94