### PR TITLE
feat: implement user management — core identity and local auth (#183)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,10 +281,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -582,6 +618,17 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1308,6 +1355,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1612,27 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1893,6 +1976,7 @@ dependencies = [
  "axum-server",
  "axum-test",
  "bytes",
+ "chrono",
  "governor",
  "include_dir",
  "rand 0.9.2",
@@ -1908,6 +1992,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -1926,6 +2011,7 @@ name = "runifi-core"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "argon2",
  "base64",
  "bytes",
  "chrono",
@@ -1935,8 +2021,10 @@ dependencies = [
  "futures",
  "hex",
  "inventory",
+ "jsonwebtoken",
  "memmap2",
  "parking_lot",
+ "rand 0.9.2",
  "regex-lite",
  "runifi-plugin-api",
  "runifi-processors",
@@ -1950,6 +2038,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "uuid",
  "zeroize",
 ]
 
@@ -2270,6 +2359,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ aes-gcm = "0.10"             # AES-256-GCM authenticated encryption
 zeroize = { version = "1", features = ["derive"] }  # Secure memory zeroing
 hex = "0.4"                  # Hex encoding/decoding for keys
 base64 = "0.22"              # Base64 encoding for encrypted properties
+argon2 = "0.5"               # Password hashing
+jsonwebtoken = "9"           # JWT token generation/validation
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/runifi-api/Cargo.toml
+++ b/crates/runifi-api/Cargo.toml
@@ -24,6 +24,8 @@ bytes = { workspace = true }
 subtle = { workspace = true }
 rand = { workspace = true }
 urlencoding = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 axum-test = "19"

--- a/crates/runifi-api/src/auth.rs
+++ b/crates/runifi-api/src/auth.rs
@@ -1,9 +1,15 @@
-//! API key authentication and CSRF protection middleware.
+//! API key authentication, JWT authentication, and CSRF protection middleware.
 //!
-//! When API keys are configured in `[api.security]`, all API endpoints require
-//! a valid bearer token in the `Authorization` header or an `api_key` query
-//! parameter. Dashboard static files (`/`, `/assets/*`) are always exempt from
-//! authentication.
+//! Supports two authentication modes:
+//!
+//! 1. **API key auth** (legacy): Bearer token or `api_key` query param matched
+//!    against configured API keys. Enabled when `[api.security].api_keys` is non-empty.
+//!
+//! 2. **JWT user auth**: Bearer token containing a JWT signed by the server.
+//!    Enabled when `[auth].enabled = true`. Takes precedence over API key auth.
+//!
+//! Dashboard static files (`/`, `/assets/*`) and auth endpoints
+//! (`/api/v1/auth/*`) are always exempt from authentication.
 //!
 //! CSRF protection uses the double-submit cookie pattern: mutating requests
 //! (POST, PUT, DELETE) must include an `X-CSRF-Token` header whose value matches
@@ -39,8 +45,9 @@ const CSRF_TOKEN_HEX_LEN: usize = 64; // 32 bytes -> 64 hex chars
 /// Exempt paths are:
 ///   - `/` (dashboard index)
 ///   - `/assets/*` (dashboard static assets)
+///   - `/api/v1/auth/login` (login endpoint)
 pub fn is_exempt_path(path: &str) -> bool {
-    path == "/" || path.starts_with("/assets/")
+    path == "/" || path.starts_with("/assets/") || path == "/api/v1/auth/login"
 }
 
 /// Generate a cryptographically random CSRF token (hex-encoded).
@@ -54,39 +61,75 @@ pub fn generate_csrf_token() -> String {
 // Authentication middleware
 // ---------------------------------------------------------------------------
 
-/// Axum middleware that enforces API key authentication and attaches the
-/// caller's [`Role`] to request extensions for downstream permission checks.
+/// Axum middleware that enforces authentication (API key or JWT) and attaches
+/// the caller's [`Role`] to request extensions for downstream permission checks.
 ///
-/// If no API keys are configured, all requests are allowed through (no role
-/// is attached — handlers default to `Admin`).
-/// Dashboard static paths (`/`, `/assets/*`) are always exempt.
+/// Authentication order:
+/// 1. If JWT user auth is enabled, try JWT validation first.
+/// 2. Fall back to API key validation if configured.
+/// 3. If neither auth mode is enabled, pass through (defaults to Admin).
 ///
-/// Valid authentication methods:
-///   1. `Authorization: Bearer <key>` header
-///   2. `?api_key=<key>` query parameter (useful for SSE EventSource)
+/// Dashboard static paths (`/`, `/assets/*`) and `/api/v1/auth/login` are
+/// always exempt.
 pub async fn auth_middleware(
     State(state): State<ApiState>,
     mut req: Request,
     next: Next,
 ) -> Response {
-    // If auth is not enabled, pass through (no role set — defaults to Admin).
-    if !state.security.auth_enabled() {
-        return next.run(req).await;
-    }
-
     let path = req.uri().path().to_string();
 
-    // Dashboard static assets are always exempt.
+    // Dashboard static assets and auth login are always exempt.
     if is_exempt_path(&path) {
         return next.run(req).await;
     }
 
-    // Try to extract API key from Authorization header or query param.
+    // --- JWT user auth ---
+    if state.user_auth_enabled()
+        && let Some(jwt_config) = &state.jwt_config
+    {
+        if let Some(token) = extract_bearer_token(&req) {
+            match jwt_config.validate_token(&token) {
+                Ok(claims) => {
+                    // Check token revocation.
+                    if state.user_store.is_token_revoked(&claims.jti) {
+                        let body = serde_json::json!({ "error": "Token has been revoked" });
+                        return (StatusCode::UNAUTHORIZED, axum::Json(body)).into_response();
+                    }
+                    // JWT-authenticated users get Admin role for now.
+                    // Phase 2 will add per-user role resolution.
+                    req.extensions_mut().insert(Role::Admin);
+                    // Store claims for downstream use (e.g., /auth/me).
+                    req.extensions_mut().insert(claims);
+                    return next.run(req).await;
+                }
+                Err(_) => {
+                    // If JWT auth is the primary mode and the bearer token
+                    // is present but invalid, reject immediately.
+                    let body = serde_json::json!({ "error": "Invalid or expired token" });
+                    return (StatusCode::UNAUTHORIZED, axum::Json(body)).into_response();
+                }
+            }
+        }
+
+        // No bearer token present — if API key auth is also not enabled,
+        // reject the request.
+        if !state.security.auth_enabled() {
+            let body = serde_json::json!({ "error": "Authentication required" });
+            return (StatusCode::UNAUTHORIZED, axum::Json(body)).into_response();
+        }
+        // Fall through to API key auth below.
+    }
+
+    // --- API key auth (legacy) ---
+    if !state.security.auth_enabled() {
+        // Neither auth mode is active — pass through.
+        return next.run(req).await;
+    }
+
     let provided_key = extract_api_key(&req);
 
     match provided_key {
         Some(ref key) if validate_api_key(key, &state.security) => {
-            // Look up the role for this key and attach it to extensions.
             if let Some(role) = resolve_role(key, &state.security) {
                 req.extensions_mut().insert(role);
             }
@@ -104,21 +147,9 @@ pub async fn auth_middleware(
 // ---------------------------------------------------------------------------
 
 /// Axum middleware that enforces CSRF double-submit cookie protection.
-///
-/// For mutating HTTP methods (POST, PUT, DELETE), the request must include
-/// both:
-///   - A `runifi_csrf` cookie
-///   - An `X-CSRF-Token` header with a value that matches the cookie
-///
-/// Requests that already carry a valid `Authorization: Bearer` header are
-/// exempt from CSRF checks, because bearer tokens are never sent
-/// automatically by browsers.
-///
-/// GET/HEAD/OPTIONS requests are always exempt (safe methods).
-/// If auth is disabled entirely, CSRF is also disabled.
 pub async fn csrf_middleware(State(state): State<ApiState>, req: Request, next: Next) -> Response {
-    // CSRF only matters when auth is enabled.
-    if !state.security.auth_enabled() {
+    // CSRF only matters when some form of auth is enabled.
+    if !state.security.auth_enabled() && !state.user_auth_enabled() {
         return next.run(req).await;
     }
 
@@ -127,7 +158,6 @@ pub async fn csrf_middleware(State(state): State<ApiState>, req: Request, next: 
     // Safe methods and exempt paths skip CSRF.
     if is_safe_method(&method) || is_exempt_path(req.uri().path()) {
         let mut response = next.run(req).await;
-        // Set CSRF cookie on safe-method responses so the browser has it.
         ensure_csrf_cookie(&mut response);
         return response;
     }
@@ -158,6 +188,19 @@ pub async fn csrf_middleware(State(state): State<ApiState>, req: Request, next: 
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/// Extract a bearer token from the Authorization header.
+fn extract_bearer_token(req: &Request) -> Option<String> {
+    let auth = req.headers().get(header::AUTHORIZATION)?;
+    let value = auth.to_str().ok()?;
+    let trimmed = value.trim();
+    let token = trimmed.strip_prefix("Bearer ")?.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
 /// Extract the API key from the request (header or query param).
 fn extract_api_key(req: &Request) -> Option<String> {
     // 1. Check Authorization: Bearer <key>
@@ -179,7 +222,6 @@ fn extract_api_key(req: &Request) -> Option<String> {
             if let Some((key, value)) = pair.split_once('=')
                 && key == "api_key"
             {
-                // URL-decode the value (e.g. %20 -> space).
                 let decoded = urlencoding::decode(value).unwrap_or_default();
                 let decoded = decoded.trim();
                 if !decoded.is_empty() {
@@ -208,9 +250,6 @@ fn validate_api_key(
 }
 
 /// Resolve the [`Role`] for a validated API key.
-///
-/// Simple string keys (backward compat) are treated as `Admin`.
-/// Structured keys use the configured role. Unknown role strings default to `Viewer`.
 fn resolve_role(
     provided: &str,
     security: &runifi_core::config::flow_config::SecurityConfig,
@@ -258,7 +297,6 @@ fn extract_csrf_cookie(req: &Request) -> Option<String> {
 
 /// Ensure the response has a CSRF cookie set.
 fn ensure_csrf_cookie(response: &mut Response) {
-    // Only set if not already present in the response.
     let has_csrf_cookie = response
         .headers()
         .get_all(header::SET_COOKIE)
@@ -299,8 +337,11 @@ mod tests {
         assert!(is_exempt_path("/"));
         assert!(is_exempt_path("/assets/main.js"));
         assert!(is_exempt_path("/assets/css/style.css"));
+        assert!(is_exempt_path("/api/v1/auth/login"));
         assert!(!is_exempt_path("/api/v1/processors"));
         assert!(!is_exempt_path("/api/v1/events"));
+        assert!(!is_exempt_path("/api/v1/auth/me"));
+        assert!(!is_exempt_path("/api/v1/auth/logout"));
     }
 
     #[test]
@@ -326,7 +367,7 @@ mod tests {
         assert!(validate_api_key("key-def456", &security));
         assert!(!validate_api_key("key-invalid", &security));
         assert!(!validate_api_key("", &security));
-        assert!(!validate_api_key("key-abc12", &security)); // partial match
+        assert!(!validate_api_key("key-abc12", &security));
     }
 
     #[test]
@@ -357,7 +398,6 @@ mod tests {
             api_keys: vec![ApiKeyEntry::Simple("key-abc123".to_string())],
             ..SecurityConfig::default()
         };
-        // Simple keys default to Admin.
         assert_eq!(resolve_role("key-abc123", &security), Some(Role::Admin));
         assert_eq!(resolve_role("unknown", &security), None);
     }
@@ -398,7 +438,6 @@ mod tests {
             })],
             ..SecurityConfig::default()
         };
-        // Unknown role strings default to Viewer for safety.
         assert_eq!(resolve_role("bad-role-key", &security), Some(Role::Viewer));
     }
 
@@ -406,9 +445,7 @@ mod tests {
     fn test_generate_csrf_token() {
         let token = generate_csrf_token();
         assert_eq!(token.len(), CSRF_TOKEN_HEX_LEN);
-        // Should be valid hex.
         assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
-        // Two tokens should be different.
         let token2 = generate_csrf_token();
         assert_ne!(token, token2);
     }
@@ -431,7 +468,6 @@ mod tests {
 
     #[test]
     fn test_extract_csrf_cookie_exact_name() {
-        // Should match "runifi_csrf=token" exactly, not "runifi_csrf_other=token".
         let mut req = Request::builder()
             .header(header::COOKIE, "runifi_csrf_other=bad; runifi_csrf=good")
             .body(axum::body::Body::empty())
@@ -439,7 +475,6 @@ mod tests {
         let token = extract_csrf_cookie(&req);
         assert_eq!(token.as_deref(), Some("good"));
 
-        // Only the prefixed name should NOT match.
         req = Request::builder()
             .header(header::COOKIE, "runifi_csrf_other=bad")
             .body(axum::body::Body::empty())
@@ -449,28 +484,24 @@ mod tests {
 
     #[test]
     fn test_extract_api_key_from_query() {
-        // Basic query parameter.
         let req = Request::builder()
             .uri("/api/v1/events?api_key=my-secret")
             .body(axum::body::Body::empty())
             .unwrap();
         assert_eq!(extract_api_key(&req).as_deref(), Some("my-secret"));
 
-        // With other params before and after.
         let req = Request::builder()
             .uri("/api/v1/events?foo=bar&api_key=my-key&baz=qux")
             .body(axum::body::Body::empty())
             .unwrap();
         assert_eq!(extract_api_key(&req).as_deref(), Some("my-key"));
 
-        // URL-encoded value.
         let req = Request::builder()
             .uri("/api/v1/events?api_key=key%20with%20spaces")
             .body(axum::body::Body::empty())
             .unwrap();
         assert_eq!(extract_api_key(&req).as_deref(), Some("key with spaces"));
 
-        // No api_key param.
         let req = Request::builder()
             .uri("/api/v1/events?other=val")
             .body(axum::body::Body::empty())
@@ -486,11 +517,28 @@ mod tests {
             .unwrap();
         assert_eq!(extract_api_key(&req).as_deref(), Some("my-token"));
 
-        // Empty bearer should return None.
         let req = Request::builder()
             .header(header::AUTHORIZATION, "Bearer ")
             .body(axum::body::Body::empty())
             .unwrap();
         assert!(extract_api_key(&req).is_none());
+    }
+
+    #[test]
+    fn test_extract_bearer_token() {
+        let req = Request::builder()
+            .header(header::AUTHORIZATION, "Bearer eyJ0eXA...")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_bearer_token(&req).as_deref(), Some("eyJ0eXA..."));
+
+        let req = Request::builder()
+            .header(header::AUTHORIZATION, "Bearer ")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert!(extract_bearer_token(&req).is_none());
+
+        let req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        assert!(extract_bearer_token(&req).is_none());
     }
 }

--- a/crates/runifi-api/src/lib.rs
+++ b/crates/runifi-api/src/lib.rs
@@ -17,7 +17,9 @@ use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DashMapSta
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 
-use runifi_core::config::flow_config::ApiConfig;
+use runifi_core::auth::jwt::JwtConfig;
+use runifi_core::auth::store::UserStore;
+use runifi_core::config::flow_config::{ApiConfig, AuthConfig};
 use runifi_core::engine::handle::EngineHandle;
 use runifi_core::registry::plugin_registry::PluginRegistry;
 use state::ApiState;
@@ -28,7 +30,7 @@ type IpRateLimiter =
 
 /// Create the API router with all routes and security middleware.
 pub fn create_router(handle: EngineHandle, api_config: &ApiConfig) -> Router {
-    create_router_with_registry(handle, api_config, None)
+    create_router_with_registry(handle, api_config, None, None, None, None)
 }
 
 /// Create the API router with an optional plugin registry for service creation.
@@ -36,6 +38,9 @@ pub fn create_router_with_registry(
     handle: EngineHandle,
     api_config: &ApiConfig,
     plugin_registry: Option<Arc<PluginRegistry>>,
+    user_store: Option<Arc<UserStore>>,
+    jwt_config: Option<JwtConfig>,
+    auth_config: Option<AuthConfig>,
 ) -> Router {
     let mut state = ApiState::with_config(
         handle,
@@ -45,6 +50,12 @@ pub fn create_router_with_registry(
     );
     if let Some(registry) = plugin_registry {
         state.set_plugin_registry(registry);
+    }
+    if let Some(store) = user_store
+        && let Some(jwt) = jwt_config
+    {
+        let ac = auth_config.unwrap_or_default();
+        state.set_auth(store, jwt, ac);
     }
 
     // -- CORS --
@@ -70,6 +81,9 @@ pub fn create_router_with_registry(
         .merge(routes::events::routes())
         .merge(routes::bulletins::routes())
         .merge(routes::services::routes())
+        .merge(routes::auth_routes::routes())
+        .merge(routes::users::routes())
+        .merge(routes::user_groups::routes())
         .merge(dashboard::routes())
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
@@ -208,19 +222,29 @@ fn validate_security_config(api_config: &ApiConfig) -> Result<(), std::io::Error
 /// When TLS is configured, the server uses `axum-server` with rustls. Otherwise
 /// it falls back to plain-text HTTP via `tokio::net::TcpListener`.
 pub async fn start_api_server(handle: EngineHandle, api_config: &ApiConfig) -> std::io::Result<()> {
-    start_api_server_with_registry(handle, api_config, None).await
+    start_api_server_with_registry(handle, api_config, None, None, None, None).await
 }
 
-/// Start the API server with an optional plugin registry for service creation.
+/// Start the API server with optional plugin registry and auth support.
 pub async fn start_api_server_with_registry(
     handle: EngineHandle,
     api_config: &ApiConfig,
     plugin_registry: Option<Arc<PluginRegistry>>,
+    user_store: Option<Arc<UserStore>>,
+    jwt_config: Option<JwtConfig>,
+    auth_config: Option<AuthConfig>,
 ) -> std::io::Result<()> {
     // Validate security posture before binding.
     validate_security_config(api_config)?;
 
-    let app = create_router_with_registry(handle, api_config, plugin_registry);
+    let app = create_router_with_registry(
+        handle,
+        api_config,
+        plugin_registry,
+        user_store,
+        jwt_config,
+        auth_config,
+    );
     let addr: SocketAddr = format!("{}:{}", api_config.bind_address, api_config.port)
         .parse()
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;

--- a/crates/runifi-api/src/routes/auth_routes.rs
+++ b/crates/runifi-api/src/routes/auth_routes.rs
@@ -1,0 +1,166 @@
+//! Authentication API routes: login, logout, get current user.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use runifi_core::auth::jwt::Claims;
+
+use crate::state::ApiState;
+
+pub fn routes() -> Router<ApiState> {
+    Router::new()
+        .route("/api/v1/auth/login", post(login))
+        .route("/api/v1/auth/logout", post(logout))
+        .route("/api/v1/auth/me", get(get_current_user))
+}
+
+/// Request body for login.
+#[derive(Deserialize)]
+struct LoginRequest {
+    username: String,
+    password: String,
+}
+
+/// Response for a successful login.
+#[derive(Serialize)]
+struct LoginResponse {
+    token: String,
+    token_type: String,
+    expires_in: i64,
+    user: UserSummary,
+}
+
+/// Minimal user info returned in auth responses.
+#[derive(Serialize)]
+struct UserSummary {
+    id: String,
+    username: String,
+    enabled: bool,
+}
+
+/// Response for GET /api/v1/auth/me.
+#[derive(Serialize)]
+struct CurrentUserResponse {
+    id: String,
+    username: String,
+    enabled: bool,
+    created_at: String,
+}
+
+/// POST /api/v1/auth/login
+///
+/// Authenticate with username and password, receive a JWT.
+async fn login(State(state): State<ApiState>, Json(body): Json<LoginRequest>) -> impl IntoResponse {
+    let jwt_config = match &state.jwt_config {
+        Some(config) => config,
+        None => {
+            let body = serde_json::json!({ "error": "User authentication is not enabled" });
+            return (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+        }
+    };
+
+    // Authenticate against the user store.
+    let user = match state
+        .user_store
+        .authenticate(&body.username, &body.password)
+    {
+        Ok(user) => user,
+        Err(e) => {
+            tracing::warn!(username = %body.username, error = %e, "Login failed");
+            let body = serde_json::json!({ "error": "Invalid credentials" });
+            return (StatusCode::UNAUTHORIZED, Json(body)).into_response();
+        }
+    };
+
+    // Generate JWT.
+    let token = match jwt_config.generate_token(user.id, &user.username) {
+        Ok(token) => token,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to generate JWT");
+            let body = serde_json::json!({ "error": "Internal server error" });
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response();
+        }
+    };
+
+    tracing::info!(username = %user.username, "User logged in");
+
+    let response = LoginResponse {
+        token,
+        token_type: "Bearer".to_string(),
+        expires_in: state.auth_config.jwt_expiry_secs,
+        user: UserSummary {
+            id: user.id.to_string(),
+            username: user.username,
+            enabled: user.enabled,
+        },
+    };
+
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(response).unwrap()),
+    )
+        .into_response()
+}
+
+/// POST /api/v1/auth/logout
+///
+/// Revoke the current JWT token. Requires a valid JWT in the Authorization header.
+async fn logout(State(state): State<ApiState>, req: axum::extract::Request) -> impl IntoResponse {
+    // Extract claims from request extensions (set by auth middleware).
+    if let Some(claims) = req.extensions().get::<Claims>() {
+        state.user_store.revoke_token(&claims.jti);
+        tracing::info!(username = %claims.username, "User logged out");
+        let body = serde_json::json!({ "status": "logged out" });
+        (StatusCode::OK, Json(body)).into_response()
+    } else {
+        let body = serde_json::json!({ "error": "Not authenticated" });
+        (StatusCode::UNAUTHORIZED, Json(body)).into_response()
+    }
+}
+
+/// GET /api/v1/auth/me
+///
+/// Get the currently authenticated user's info.
+async fn get_current_user(
+    State(state): State<ApiState>,
+    req: axum::extract::Request,
+) -> impl IntoResponse {
+    if let Some(claims) = req.extensions().get::<Claims>() {
+        // Look up the full user from the store.
+        let user_id: uuid::Uuid = match claims.sub.parse() {
+            Ok(id) => id,
+            Err(_) => {
+                let body = serde_json::json!({ "error": "Invalid user ID in token" });
+                return (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response();
+            }
+        };
+
+        match state.user_store.get_user(user_id) {
+            Some(user) => {
+                let response = CurrentUserResponse {
+                    id: user.id.to_string(),
+                    username: user.username,
+                    enabled: user.enabled,
+                    created_at: user.created_at.to_rfc3339(),
+                };
+                (
+                    StatusCode::OK,
+                    Json(serde_json::to_value(response).unwrap()),
+                )
+                    .into_response()
+            }
+            None => {
+                let body = serde_json::json!({ "error": "User not found" });
+                (StatusCode::NOT_FOUND, Json(body)).into_response()
+            }
+        }
+    } else {
+        // No JWT claims — check if API-key auth is in use (no user identity).
+        let body = serde_json::json!({ "error": "Not authenticated with user credentials" });
+        (StatusCode::UNAUTHORIZED, Json(body)).into_response()
+    }
+}

--- a/crates/runifi-api/src/routes/mod.rs
+++ b/crates/runifi-api/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth_routes;
 pub mod bulletins;
 pub mod connections;
 pub mod events;
@@ -6,3 +7,5 @@ pub mod plugins;
 pub mod processors;
 pub mod services;
 pub mod system;
+pub mod user_groups;
+pub mod users;

--- a/crates/runifi-api/src/routes/user_groups.rs
+++ b/crates/runifi-api/src/routes/user_groups.rs
@@ -1,0 +1,245 @@
+//! User Group CRUD API routes.
+//!
+//! Endpoints:
+//!   - `GET    /api/v1/tenants/user-groups`       — list all groups
+//!   - `POST   /api/v1/tenants/user-groups`       — create a group
+//!   - `GET    /api/v1/tenants/user-groups/{id}`   — get a group by ID
+//!   - `PUT    /api/v1/tenants/user-groups/{id}`   — update a group
+//!   - `DELETE /api/v1/tenants/user-groups/{id}`   — delete a group
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router, middleware};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::rbac;
+use crate::state::ApiState;
+
+pub fn routes() -> Router<ApiState> {
+    Router::new()
+        .route(
+            "/api/v1/tenants/user-groups",
+            get(list_groups).post(create_group),
+        )
+        .route(
+            "/api/v1/tenants/user-groups/{id}",
+            get(get_group).put(update_group).delete(delete_group),
+        )
+        .layer(middleware::from_fn(rbac::require_manage_config))
+}
+
+/// Response for a user group.
+#[derive(Serialize)]
+struct UserGroupResponse {
+    id: String,
+    name: String,
+    members: Vec<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+impl UserGroupResponse {
+    fn from_model(group: &runifi_core::auth::models::UserGroup) -> Self {
+        Self {
+            id: group.id.to_string(),
+            name: group.name.clone(),
+            members: group.members.iter().map(|id| id.to_string()).collect(),
+            created_at: group.created_at.to_rfc3339(),
+            updated_at: group.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+/// Request body for creating a group.
+#[derive(Deserialize)]
+struct CreateGroupRequest {
+    name: String,
+    #[serde(default)]
+    members: Vec<String>,
+}
+
+/// Request body for updating a group.
+#[derive(Deserialize)]
+struct UpdateGroupRequest {
+    name: Option<String>,
+    members: Option<Vec<String>>,
+}
+
+/// GET /api/v1/tenants/user-groups
+async fn list_groups(State(state): State<ApiState>) -> impl IntoResponse {
+    let groups: Vec<UserGroupResponse> = state
+        .user_store
+        .list_groups()
+        .iter()
+        .map(UserGroupResponse::from_model)
+        .collect();
+
+    (StatusCode::OK, Json(serde_json::to_value(groups).unwrap())).into_response()
+}
+
+/// POST /api/v1/tenants/user-groups
+async fn create_group(
+    State(state): State<ApiState>,
+    Json(body): Json<CreateGroupRequest>,
+) -> impl IntoResponse {
+    if body.name.is_empty() {
+        let body = serde_json::json!({ "error": "Group name cannot be empty" });
+        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    }
+
+    let group = match state.user_store.create_group(body.name) {
+        Ok(group) => group,
+        Err(e) => {
+            let status = match &e {
+                runifi_core::auth::store::UserStoreError::DuplicateGroupName(_) => {
+                    StatusCode::CONFLICT
+                }
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let body = serde_json::json!({ "error": e.to_string() });
+            return (status, Json(body)).into_response();
+        }
+    };
+
+    // If members were provided, set them.
+    if !body.members.is_empty() {
+        let member_ids: Vec<Uuid> = match body
+            .members
+            .iter()
+            .map(|s| s.parse::<Uuid>())
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(ids) => ids,
+            Err(_) => {
+                let body = serde_json::json!({ "error": "Invalid member user ID" });
+                return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+            }
+        };
+
+        if let Err(e) = state
+            .user_store
+            .update_group(group.id, None, Some(member_ids))
+        {
+            let body = serde_json::json!({ "error": e.to_string() });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    }
+
+    // Fetch the final state.
+    let group = state.user_store.get_group(group.id).unwrap();
+    let response = UserGroupResponse::from_model(&group);
+    (
+        StatusCode::CREATED,
+        Json(serde_json::to_value(response).unwrap()),
+    )
+        .into_response()
+}
+
+/// GET /api/v1/tenants/user-groups/{id}
+async fn get_group(State(state): State<ApiState>, Path(id): Path<String>) -> impl IntoResponse {
+    let group_id: Uuid = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let body = serde_json::json!({ "error": "Invalid group ID" });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
+
+    match state.user_store.get_group(group_id) {
+        Some(group) => {
+            let response = UserGroupResponse::from_model(&group);
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(response).unwrap()),
+            )
+                .into_response()
+        }
+        None => {
+            let body = serde_json::json!({ "error": "Group not found" });
+            (StatusCode::NOT_FOUND, Json(body)).into_response()
+        }
+    }
+}
+
+/// PUT /api/v1/tenants/user-groups/{id}
+async fn update_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateGroupRequest>,
+) -> impl IntoResponse {
+    let group_id: Uuid = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let body = serde_json::json!({ "error": "Invalid group ID" });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
+
+    let member_ids = match body.members {
+        Some(ref members) => {
+            let ids: Result<Vec<Uuid>, _> = members.iter().map(|s| s.parse::<Uuid>()).collect();
+            match ids {
+                Ok(ids) => Some(ids),
+                Err(_) => {
+                    let body = serde_json::json!({ "error": "Invalid member user ID" });
+                    return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+                }
+            }
+        }
+        None => None,
+    };
+
+    match state
+        .user_store
+        .update_group(group_id, body.name, member_ids)
+    {
+        Ok(group) => {
+            let response = UserGroupResponse::from_model(&group);
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(response).unwrap()),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            let status = match &e {
+                runifi_core::auth::store::UserStoreError::GroupNotFound(_) => StatusCode::NOT_FOUND,
+                runifi_core::auth::store::UserStoreError::DuplicateGroupName(_) => {
+                    StatusCode::CONFLICT
+                }
+                runifi_core::auth::store::UserStoreError::UserNotFound(_) => {
+                    StatusCode::BAD_REQUEST
+                }
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let body = serde_json::json!({ "error": e.to_string() });
+            (status, Json(body)).into_response()
+        }
+    }
+}
+
+/// DELETE /api/v1/tenants/user-groups/{id}
+async fn delete_group(State(state): State<ApiState>, Path(id): Path<String>) -> impl IntoResponse {
+    let group_id: Uuid = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let body = serde_json::json!({ "error": "Invalid group ID" });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
+
+    match state.user_store.delete_group(group_id) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => {
+            let status = match &e {
+                runifi_core::auth::store::UserStoreError::GroupNotFound(_) => StatusCode::NOT_FOUND,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let body = serde_json::json!({ "error": e.to_string() });
+            (status, Json(body)).into_response()
+        }
+    }
+}

--- a/crates/runifi-api/src/routes/users.rs
+++ b/crates/runifi-api/src/routes/users.rs
@@ -1,0 +1,221 @@
+//! User CRUD API routes.
+//!
+//! Endpoints:
+//!   - `GET    /api/v1/tenants/users`       — list all users
+//!   - `POST   /api/v1/tenants/users`       — create a user
+//!   - `GET    /api/v1/tenants/users/{id}`   — get a user by ID
+//!   - `PUT    /api/v1/tenants/users/{id}`   — update a user
+//!   - `DELETE /api/v1/tenants/users/{id}`   — delete a user
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router, middleware};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::rbac;
+use crate::state::ApiState;
+
+pub fn routes() -> Router<ApiState> {
+    Router::new()
+        .route("/api/v1/tenants/users", get(list_users).post(create_user))
+        .route(
+            "/api/v1/tenants/users/{id}",
+            get(get_user).put(update_user).delete(delete_user),
+        )
+        .layer(middleware::from_fn(rbac::require_manage_config))
+}
+
+/// Response for a user (password hash is never included).
+#[derive(Serialize)]
+struct UserResponse {
+    id: String,
+    username: String,
+    enabled: bool,
+    created_at: String,
+    updated_at: String,
+}
+
+impl UserResponse {
+    fn from_model(user: &runifi_core::auth::models::User) -> Self {
+        Self {
+            id: user.id.to_string(),
+            username: user.username.clone(),
+            enabled: user.enabled,
+            created_at: user.created_at.to_rfc3339(),
+            updated_at: user.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+/// Request body for creating a user.
+#[derive(Deserialize)]
+struct CreateUserRequest {
+    username: String,
+    password: String,
+}
+
+/// Request body for updating a user.
+#[derive(Deserialize)]
+struct UpdateUserRequest {
+    username: Option<String>,
+    enabled: Option<bool>,
+    password: Option<String>,
+}
+
+/// GET /api/v1/tenants/users
+async fn list_users(State(state): State<ApiState>) -> impl IntoResponse {
+    let users: Vec<UserResponse> = state
+        .user_store
+        .list_users()
+        .iter()
+        .map(UserResponse::from_model)
+        .collect();
+
+    (StatusCode::OK, Json(serde_json::to_value(users).unwrap())).into_response()
+}
+
+/// POST /api/v1/tenants/users
+async fn create_user(
+    State(state): State<ApiState>,
+    Json(body): Json<CreateUserRequest>,
+) -> impl IntoResponse {
+    if body.username.is_empty() {
+        let body = serde_json::json!({ "error": "Username cannot be empty" });
+        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    }
+    if body.password.is_empty() {
+        let body = serde_json::json!({ "error": "Password cannot be empty" });
+        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    }
+
+    match state.user_store.create_user(body.username, &body.password) {
+        Ok(user) => {
+            let response = UserResponse::from_model(&user);
+            (
+                StatusCode::CREATED,
+                Json(serde_json::to_value(response).unwrap()),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            let status = match &e {
+                runifi_core::auth::store::UserStoreError::DuplicateUsername(_) => {
+                    StatusCode::CONFLICT
+                }
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let body = serde_json::json!({ "error": e.to_string() });
+            (status, Json(body)).into_response()
+        }
+    }
+}
+
+/// GET /api/v1/tenants/users/{id}
+async fn get_user(State(state): State<ApiState>, Path(id): Path<String>) -> impl IntoResponse {
+    let user_id: Uuid = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let body = serde_json::json!({ "error": "Invalid user ID" });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
+
+    match state.user_store.get_user(user_id) {
+        Some(user) => {
+            let response = UserResponse::from_model(&user);
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(response).unwrap()),
+            )
+                .into_response()
+        }
+        None => {
+            let body = serde_json::json!({ "error": "User not found" });
+            (StatusCode::NOT_FOUND, Json(body)).into_response()
+        }
+    }
+}
+
+/// PUT /api/v1/tenants/users/{id}
+async fn update_user(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateUserRequest>,
+) -> impl IntoResponse {
+    let user_id: Uuid = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let body = serde_json::json!({ "error": "Invalid user ID" });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
+
+    // Update basic fields.
+    match state
+        .user_store
+        .update_user(user_id, body.username, body.enabled)
+    {
+        Ok(_) => {}
+        Err(e) => {
+            let status = match &e {
+                runifi_core::auth::store::UserStoreError::UserNotFound(_) => StatusCode::NOT_FOUND,
+                runifi_core::auth::store::UserStoreError::DuplicateUsername(_) => {
+                    StatusCode::CONFLICT
+                }
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let body = serde_json::json!({ "error": e.to_string() });
+            return (status, Json(body)).into_response();
+        }
+    }
+
+    // Update password if provided.
+    if let Some(ref password) = body.password
+        && let Err(e) = state.user_store.change_password(user_id, password)
+    {
+        let body = serde_json::json!({ "error": e.to_string() });
+        return (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response();
+    }
+
+    // Return the updated user.
+    match state.user_store.get_user(user_id) {
+        Some(user) => {
+            let response = UserResponse::from_model(&user);
+            (
+                StatusCode::OK,
+                Json(serde_json::to_value(response).unwrap()),
+            )
+                .into_response()
+        }
+        None => {
+            let body = serde_json::json!({ "error": "User not found" });
+            (StatusCode::NOT_FOUND, Json(body)).into_response()
+        }
+    }
+}
+
+/// DELETE /api/v1/tenants/users/{id}
+async fn delete_user(State(state): State<ApiState>, Path(id): Path<String>) -> impl IntoResponse {
+    let user_id: Uuid = match id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            let body = serde_json::json!({ "error": "Invalid user ID" });
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
+
+    match state.user_store.delete_user(user_id) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => {
+            let status = match &e {
+                runifi_core::auth::store::UserStoreError::UserNotFound(_) => StatusCode::NOT_FOUND,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let body = serde_json::json!({ "error": e.to_string() });
+            (status, Json(body)).into_response()
+        }
+    }
+}

--- a/crates/runifi-api/src/state.rs
+++ b/crates/runifi-api/src/state.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
-use runifi_core::config::flow_config::SecurityConfig;
+use runifi_core::auth::jwt::JwtConfig;
+use runifi_core::auth::store::UserStore;
+use runifi_core::config::flow_config::{AuthConfig, SecurityConfig};
 use runifi_core::engine::handle::EngineHandle;
 use runifi_core::registry::plugin_registry::PluginRegistry;
 
@@ -20,6 +22,12 @@ pub struct ApiState {
     pub security: SecurityConfig,
     /// Plugin registry for creating service instances at runtime.
     pub plugin_registry: Option<Arc<PluginRegistry>>,
+    /// User store for identity management.
+    pub user_store: Arc<UserStore>,
+    /// JWT configuration for token generation/validation.
+    pub jwt_config: Option<Arc<JwtConfig>>,
+    /// Auth configuration.
+    pub auth_config: AuthConfig,
 }
 
 impl ApiState {
@@ -32,6 +40,9 @@ impl ApiState {
             detailed_errors: false,
             security: SecurityConfig::default(),
             plugin_registry: None,
+            user_store: Arc::new(UserStore::new()),
+            jwt_config: None,
+            auth_config: AuthConfig::default(),
         }
     }
 
@@ -49,12 +60,32 @@ impl ApiState {
             detailed_errors,
             security,
             plugin_registry: None,
+            user_store: Arc::new(UserStore::new()),
+            jwt_config: None,
+            auth_config: AuthConfig::default(),
         }
     }
 
     /// Set the plugin registry (called during API server setup).
     pub fn set_plugin_registry(&mut self, registry: Arc<PluginRegistry>) {
         self.plugin_registry = Some(registry);
+    }
+
+    /// Set the user store and JWT config for identity-based auth.
+    pub fn set_auth(
+        &mut self,
+        user_store: Arc<UserStore>,
+        jwt_config: JwtConfig,
+        auth_config: AuthConfig,
+    ) {
+        self.user_store = user_store;
+        self.jwt_config = Some(Arc::new(jwt_config));
+        self.auth_config = auth_config;
+    }
+
+    /// Returns `true` if JWT-based user auth is enabled.
+    pub fn user_auth_enabled(&self) -> bool {
+        self.auth_config.enabled && self.jwt_config.is_some()
     }
 
     /// Create a controller service instance by type name.

--- a/crates/runifi-core/Cargo.toml
+++ b/crates/runifi-core/Cargo.toml
@@ -30,6 +30,10 @@ zeroize = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
 subtle = { workspace = true }
+argon2 = { workspace = true }
+jsonwebtoken = { workspace = true }
+uuid = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/runifi-core/src/auth/jwt.rs
+++ b/crates/runifi-core/src/auth/jwt.rs
@@ -1,0 +1,124 @@
+//! JWT token generation and validation.
+
+use chrono::Utc;
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// JWT claims embedded in every access token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claims {
+    /// Subject — the user ID.
+    pub sub: String,
+    /// Username (convenience claim for display).
+    pub username: String,
+    /// Issued-at timestamp (seconds since epoch).
+    pub iat: i64,
+    /// Expiration timestamp (seconds since epoch).
+    pub exp: i64,
+    /// Unique token identifier (for revocation tracking).
+    pub jti: String,
+}
+
+/// Configuration for JWT token handling.
+#[derive(Debug, Clone)]
+pub struct JwtConfig {
+    /// HMAC-SHA256 secret key.
+    secret: Vec<u8>,
+    /// Token lifetime in seconds.
+    expiry_secs: i64,
+}
+
+impl JwtConfig {
+    /// Create a new JWT configuration.
+    pub fn new(secret: &str, expiry_secs: i64) -> Self {
+        Self {
+            secret: secret.as_bytes().to_vec(),
+            expiry_secs,
+        }
+    }
+
+    /// Generate a signed JWT for the given user.
+    pub fn generate_token(
+        &self,
+        user_id: Uuid,
+        username: &str,
+    ) -> Result<String, jsonwebtoken::errors::Error> {
+        let now = Utc::now().timestamp();
+        let claims = Claims {
+            sub: user_id.to_string(),
+            username: username.to_string(),
+            iat: now,
+            exp: now + self.expiry_secs,
+            jti: Uuid::now_v7().to_string(),
+        };
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(&self.secret),
+        )
+    }
+
+    /// Validate a JWT and return the claims if valid.
+    pub fn validate_token(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
+        let mut validation = Validation::default();
+        // No clock leeway — enforce strict expiration.
+        validation.leeway = 0;
+        let token_data =
+            decode::<Claims>(token, &DecodingKey::from_secret(&self.secret), &validation)?;
+        Ok(token_data.claims)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> JwtConfig {
+        JwtConfig::new("test-secret-key-at-least-32-chars-long!", 3600)
+    }
+
+    #[test]
+    fn generate_and_validate_token() {
+        let config = test_config();
+        let user_id = Uuid::now_v7();
+        let token = config.generate_token(user_id, "admin").unwrap();
+        let claims = config.validate_token(&token).unwrap();
+        assert_eq!(claims.sub, user_id.to_string());
+        assert_eq!(claims.username, "admin");
+    }
+
+    #[test]
+    fn expired_token_is_rejected() {
+        let config = JwtConfig::new("test-secret", -1); // Already expired
+        let user_id = Uuid::now_v7();
+        let token = config.generate_token(user_id, "admin").unwrap();
+        assert!(config.validate_token(&token).is_err());
+    }
+
+    #[test]
+    fn invalid_token_is_rejected() {
+        let config = test_config();
+        assert!(config.validate_token("not.a.valid.token").is_err());
+    }
+
+    #[test]
+    fn wrong_secret_rejects_token() {
+        let config1 = JwtConfig::new("secret-one", 3600);
+        let config2 = JwtConfig::new("secret-two", 3600);
+        let user_id = Uuid::now_v7();
+        let token = config1.generate_token(user_id, "admin").unwrap();
+        assert!(config2.validate_token(&token).is_err());
+    }
+
+    #[test]
+    fn each_token_has_unique_jti() {
+        let config = test_config();
+        let user_id = Uuid::now_v7();
+        let t1 = config.generate_token(user_id, "admin").unwrap();
+        let t2 = config.generate_token(user_id, "admin").unwrap();
+        let c1 = config.validate_token(&t1).unwrap();
+        let c2 = config.validate_token(&t2).unwrap();
+        assert_ne!(c1.jti, c2.jti);
+    }
+}

--- a/crates/runifi-core/src/auth/mod.rs
+++ b/crates/runifi-core/src/auth/mod.rs
@@ -1,0 +1,9 @@
+//! Core identity and local authentication.
+//!
+//! Provides user and group models, password hashing with Argon2, JWT session
+//! management, and an in-memory user/group store.
+
+pub mod jwt;
+pub mod models;
+pub mod password;
+pub mod store;

--- a/crates/runifi-core/src/auth/models.rs
+++ b/crates/runifi-core/src/auth/models.rs
@@ -1,0 +1,96 @@
+//! User and UserGroup domain models.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A local user identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    /// Unique user identifier.
+    pub id: Uuid,
+    /// Login username (unique, case-sensitive).
+    pub username: String,
+    /// Argon2 password hash (never serialized to API responses).
+    #[serde(skip_serializing)]
+    pub password_hash: String,
+    /// Whether the user account is enabled.
+    pub enabled: bool,
+    /// Timestamp when the user was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp of the last update.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl User {
+    /// Create a new user with a pre-hashed password.
+    pub fn new(username: String, password_hash: String) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::now_v7(),
+            username,
+            password_hash,
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+/// A group of users.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserGroup {
+    /// Unique group identifier.
+    pub id: Uuid,
+    /// Display name for the group.
+    pub name: String,
+    /// User IDs that belong to this group.
+    pub members: Vec<Uuid>,
+    /// Timestamp when the group was created.
+    pub created_at: DateTime<Utc>,
+    /// Timestamp of the last update.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl UserGroup {
+    /// Create a new empty group.
+    pub fn new(name: String) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::now_v7(),
+            name,
+            members: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_new_sets_defaults() {
+        let user = User::new("admin".to_string(), "hash".to_string());
+        assert_eq!(user.username, "admin");
+        assert_eq!(user.password_hash, "hash");
+        assert!(user.enabled);
+        assert!(user.created_at <= Utc::now());
+    }
+
+    #[test]
+    fn user_group_new_is_empty() {
+        let group = UserGroup::new("operators".to_string());
+        assert_eq!(group.name, "operators");
+        assert!(group.members.is_empty());
+    }
+
+    #[test]
+    fn user_serialization_skips_password() {
+        let user = User::new("alice".to_string(), "secret_hash".to_string());
+        let json = serde_json::to_string(&user).unwrap();
+        assert!(!json.contains("secret_hash"));
+        assert!(json.contains("alice"));
+    }
+}

--- a/crates/runifi-core/src/auth/password.rs
+++ b/crates/runifi-core/src/auth/password.rs
@@ -1,0 +1,67 @@
+//! Password hashing and verification using Argon2id.
+
+use argon2::Argon2;
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+
+/// Hash a plaintext password with Argon2id.
+///
+/// Returns the PHC-formatted hash string containing the algorithm parameters,
+/// salt, and hash — suitable for storage.
+pub fn hash_password(password: &str) -> Result<String, argon2::password_hash::Error> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2.hash_password(password.as_bytes(), &salt)?;
+    Ok(hash.to_string())
+}
+
+/// Verify a plaintext password against a stored Argon2 hash.
+///
+/// Returns `true` if the password matches, `false` otherwise.
+pub fn verify_password(password: &str, hash: &str) -> bool {
+    let Ok(parsed) = PasswordHash::new(hash) else {
+        return false;
+    };
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed)
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_and_verify_correct_password() {
+        let hash = hash_password("my-secure-password").unwrap();
+        assert!(verify_password("my-secure-password", &hash));
+    }
+
+    #[test]
+    fn verify_wrong_password_fails() {
+        let hash = hash_password("correct-password").unwrap();
+        assert!(!verify_password("wrong-password", &hash));
+    }
+
+    #[test]
+    fn verify_invalid_hash_fails() {
+        assert!(!verify_password("anything", "not-a-valid-hash"));
+    }
+
+    #[test]
+    fn hash_is_unique_per_call() {
+        let h1 = hash_password("same-password").unwrap();
+        let h2 = hash_password("same-password").unwrap();
+        // Different salts produce different hashes.
+        assert_ne!(h1, h2);
+        // But both verify correctly.
+        assert!(verify_password("same-password", &h1));
+        assert!(verify_password("same-password", &h2));
+    }
+
+    #[test]
+    fn hash_contains_argon2_marker() {
+        let hash = hash_password("test").unwrap();
+        assert!(hash.starts_with("$argon2"));
+    }
+}

--- a/crates/runifi-core/src/auth/store.rs
+++ b/crates/runifi-core/src/auth/store.rs
@@ -1,0 +1,438 @@
+//! In-memory user and group store.
+//!
+//! Provides thread-safe storage for users and groups. Uses `DashMap` for
+//! concurrent access without coarse-grained locking.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use uuid::Uuid;
+
+use super::models::{User, UserGroup};
+use super::password;
+
+/// Errors returned by the user store.
+#[derive(Debug, thiserror::Error)]
+pub enum UserStoreError {
+    #[error("User not found: {0}")]
+    UserNotFound(String),
+
+    #[error("Username already exists: {0}")]
+    DuplicateUsername(String),
+
+    #[error("Group not found: {0}")]
+    GroupNotFound(String),
+
+    #[error("Group name already exists: {0}")]
+    DuplicateGroupName(String),
+
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+
+    #[error("Password hashing failed: {0}")]
+    HashError(String),
+
+    #[error("Account disabled: {0}")]
+    AccountDisabled(String),
+}
+
+/// Thread-safe in-memory store for users and user groups.
+#[derive(Debug)]
+pub struct UserStore {
+    /// Users indexed by ID.
+    users: DashMap<Uuid, User>,
+    /// Username -> User ID index for fast lookup.
+    username_index: DashMap<String, Uuid>,
+    /// Groups indexed by ID.
+    groups: DashMap<Uuid, UserGroup>,
+    /// Group name -> Group ID index.
+    group_name_index: DashMap<String, Uuid>,
+    /// Revoked JWT token IDs (jti) — tokens that have been logged out.
+    revoked_tokens: DashMap<String, ()>,
+}
+
+impl UserStore {
+    /// Create a new empty user store.
+    pub fn new() -> Self {
+        Self {
+            users: DashMap::new(),
+            username_index: DashMap::new(),
+            groups: DashMap::new(),
+            group_name_index: DashMap::new(),
+            revoked_tokens: DashMap::new(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // User operations
+    // -----------------------------------------------------------------------
+
+    /// Create a new user with a plaintext password. Returns the created user.
+    pub fn create_user(
+        &self,
+        username: String,
+        plaintext_password: &str,
+    ) -> Result<User, UserStoreError> {
+        if self.username_index.contains_key(&username) {
+            return Err(UserStoreError::DuplicateUsername(username));
+        }
+
+        let hash = password::hash_password(plaintext_password)
+            .map_err(|e| UserStoreError::HashError(e.to_string()))?;
+
+        let user = User::new(username.clone(), hash);
+        let id = user.id;
+
+        self.username_index.insert(username, id);
+        self.users.insert(id, user.clone());
+
+        Ok(user)
+    }
+
+    /// Get a user by ID.
+    pub fn get_user(&self, id: Uuid) -> Option<User> {
+        self.users.get(&id).map(|r| r.value().clone())
+    }
+
+    /// Get a user by username.
+    pub fn get_user_by_username(&self, username: &str) -> Option<User> {
+        let id = self.username_index.get(username)?;
+        self.users.get(id.value()).map(|r| r.value().clone())
+    }
+
+    /// List all users.
+    pub fn list_users(&self) -> Vec<User> {
+        self.users.iter().map(|r| r.value().clone()).collect()
+    }
+
+    /// Update a user's properties (username, enabled).
+    /// Does NOT change password — use `change_password` for that.
+    pub fn update_user(
+        &self,
+        id: Uuid,
+        new_username: Option<String>,
+        enabled: Option<bool>,
+    ) -> Result<User, UserStoreError> {
+        let mut user = self
+            .users
+            .get_mut(&id)
+            .ok_or_else(|| UserStoreError::UserNotFound(id.to_string()))?;
+
+        if let Some(ref new_name) = new_username
+            && new_name != &user.username
+        {
+            // Check for duplicate.
+            if self.username_index.contains_key(new_name) {
+                return Err(UserStoreError::DuplicateUsername(new_name.clone()));
+            }
+            // Remove old index entry, add new one.
+            self.username_index.remove(&user.username);
+            self.username_index.insert(new_name.clone(), id);
+            user.username = new_name.clone();
+        }
+
+        if let Some(enabled) = enabled {
+            user.enabled = enabled;
+        }
+
+        user.updated_at = chrono::Utc::now();
+        Ok(user.clone())
+    }
+
+    /// Change a user's password.
+    pub fn change_password(
+        &self,
+        id: Uuid,
+        new_plaintext_password: &str,
+    ) -> Result<(), UserStoreError> {
+        let mut user = self
+            .users
+            .get_mut(&id)
+            .ok_or_else(|| UserStoreError::UserNotFound(id.to_string()))?;
+
+        let hash = password::hash_password(new_plaintext_password)
+            .map_err(|e| UserStoreError::HashError(e.to_string()))?;
+
+        user.password_hash = hash;
+        user.updated_at = chrono::Utc::now();
+        Ok(())
+    }
+
+    /// Delete a user by ID. Also removes user from any groups.
+    pub fn delete_user(&self, id: Uuid) -> Result<(), UserStoreError> {
+        let (_, user) = self
+            .users
+            .remove(&id)
+            .ok_or_else(|| UserStoreError::UserNotFound(id.to_string()))?;
+
+        self.username_index.remove(&user.username);
+
+        // Remove from all groups.
+        for mut group in self.groups.iter_mut() {
+            group.members.retain(|mid| *mid != id);
+        }
+
+        Ok(())
+    }
+
+    /// Authenticate a user with username and password.
+    /// Returns the user if credentials are valid.
+    pub fn authenticate(
+        &self,
+        username: &str,
+        plaintext_password: &str,
+    ) -> Result<User, UserStoreError> {
+        let user = self
+            .get_user_by_username(username)
+            .ok_or(UserStoreError::InvalidCredentials)?;
+
+        if !user.enabled {
+            return Err(UserStoreError::AccountDisabled(username.to_string()));
+        }
+
+        if !password::verify_password(plaintext_password, &user.password_hash) {
+            return Err(UserStoreError::InvalidCredentials);
+        }
+
+        Ok(user)
+    }
+
+    /// Return the total number of users.
+    pub fn user_count(&self) -> usize {
+        self.users.len()
+    }
+
+    // -----------------------------------------------------------------------
+    // Group operations
+    // -----------------------------------------------------------------------
+
+    /// Create a new user group.
+    pub fn create_group(&self, name: String) -> Result<UserGroup, UserStoreError> {
+        if self.group_name_index.contains_key(&name) {
+            return Err(UserStoreError::DuplicateGroupName(name));
+        }
+
+        let group = UserGroup::new(name.clone());
+        let id = group.id;
+        self.group_name_index.insert(name, id);
+        self.groups.insert(id, group.clone());
+        Ok(group)
+    }
+
+    /// Get a group by ID.
+    pub fn get_group(&self, id: Uuid) -> Option<UserGroup> {
+        self.groups.get(&id).map(|r| r.value().clone())
+    }
+
+    /// List all groups.
+    pub fn list_groups(&self) -> Vec<UserGroup> {
+        self.groups.iter().map(|r| r.value().clone()).collect()
+    }
+
+    /// Update a group's name and/or members.
+    pub fn update_group(
+        &self,
+        id: Uuid,
+        new_name: Option<String>,
+        members: Option<Vec<Uuid>>,
+    ) -> Result<UserGroup, UserStoreError> {
+        let mut group = self
+            .groups
+            .get_mut(&id)
+            .ok_or_else(|| UserStoreError::GroupNotFound(id.to_string()))?;
+
+        if let Some(ref name) = new_name
+            && name != &group.name
+        {
+            if self.group_name_index.contains_key(name) {
+                return Err(UserStoreError::DuplicateGroupName(name.clone()));
+            }
+            self.group_name_index.remove(&group.name);
+            self.group_name_index.insert(name.clone(), id);
+            group.name = name.clone();
+        }
+
+        if let Some(members) = members {
+            // Validate all member IDs exist.
+            for uid in &members {
+                if !self.users.contains_key(uid) {
+                    return Err(UserStoreError::UserNotFound(uid.to_string()));
+                }
+            }
+            group.members = members;
+        }
+
+        group.updated_at = chrono::Utc::now();
+        Ok(group.clone())
+    }
+
+    /// Delete a group by ID.
+    pub fn delete_group(&self, id: Uuid) -> Result<(), UserStoreError> {
+        let (_, group) = self
+            .groups
+            .remove(&id)
+            .ok_or_else(|| UserStoreError::GroupNotFound(id.to_string()))?;
+
+        self.group_name_index.remove(&group.name);
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Token revocation
+    // -----------------------------------------------------------------------
+
+    /// Revoke a JWT token by its JTI (used for logout).
+    pub fn revoke_token(&self, jti: &str) {
+        self.revoked_tokens.insert(jti.to_string(), ());
+    }
+
+    /// Check whether a token has been revoked.
+    pub fn is_token_revoked(&self, jti: &str) -> bool {
+        self.revoked_tokens.contains_key(jti)
+    }
+}
+
+impl Default for UserStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Create a shared `UserStore` wrapped in an `Arc`.
+pub fn new_shared_store() -> Arc<UserStore> {
+    Arc::new(UserStore::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_get_user() {
+        let store = UserStore::new();
+        let user = store.create_user("alice".to_string(), "pass123").unwrap();
+        assert_eq!(user.username, "alice");
+        assert!(user.enabled);
+
+        let fetched = store.get_user(user.id).unwrap();
+        assert_eq!(fetched.username, "alice");
+
+        let by_name = store.get_user_by_username("alice").unwrap();
+        assert_eq!(by_name.id, user.id);
+    }
+
+    #[test]
+    fn duplicate_username_rejected() {
+        let store = UserStore::new();
+        store.create_user("bob".to_string(), "pass").unwrap();
+        let result = store.create_user("bob".to_string(), "pass2");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn authenticate_valid_credentials() {
+        let store = UserStore::new();
+        store.create_user("admin".to_string(), "s3cret").unwrap();
+        let user = store.authenticate("admin", "s3cret").unwrap();
+        assert_eq!(user.username, "admin");
+    }
+
+    #[test]
+    fn authenticate_wrong_password() {
+        let store = UserStore::new();
+        store.create_user("admin".to_string(), "correct").unwrap();
+        assert!(store.authenticate("admin", "wrong").is_err());
+    }
+
+    #[test]
+    fn authenticate_disabled_user() {
+        let store = UserStore::new();
+        let user = store.create_user("disabled".to_string(), "pass").unwrap();
+        store.update_user(user.id, None, Some(false)).unwrap();
+        let result = store.authenticate("disabled", "pass");
+        assert!(matches!(result, Err(UserStoreError::AccountDisabled(_))));
+    }
+
+    #[test]
+    fn update_user_username() {
+        let store = UserStore::new();
+        let user = store.create_user("old".to_string(), "pass").unwrap();
+        store
+            .update_user(user.id, Some("new".to_string()), None)
+            .unwrap();
+        assert!(store.get_user_by_username("old").is_none());
+        assert!(store.get_user_by_username("new").is_some());
+    }
+
+    #[test]
+    fn delete_user_removes_from_groups() {
+        let store = UserStore::new();
+        let user = store.create_user("member".to_string(), "pass").unwrap();
+        let group = store.create_group("team".to_string()).unwrap();
+        store
+            .update_group(group.id, None, Some(vec![user.id]))
+            .unwrap();
+        assert_eq!(store.get_group(group.id).unwrap().members.len(), 1);
+
+        store.delete_user(user.id).unwrap();
+        assert_eq!(store.get_group(group.id).unwrap().members.len(), 0);
+    }
+
+    #[test]
+    fn create_and_list_groups() {
+        let store = UserStore::new();
+        store.create_group("admins".to_string()).unwrap();
+        store.create_group("operators".to_string()).unwrap();
+        assert_eq!(store.list_groups().len(), 2);
+    }
+
+    #[test]
+    fn duplicate_group_name_rejected() {
+        let store = UserStore::new();
+        store.create_group("team".to_string()).unwrap();
+        let result = store.create_group("team".to_string());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_group_members_validates_user_ids() {
+        let store = UserStore::new();
+        let group = store.create_group("team".to_string()).unwrap();
+        let fake_id = Uuid::now_v7();
+        let result = store.update_group(group.id, None, Some(vec![fake_id]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn delete_group() {
+        let store = UserStore::new();
+        let group = store.create_group("temp".to_string()).unwrap();
+        store.delete_group(group.id).unwrap();
+        assert!(store.get_group(group.id).is_none());
+    }
+
+    #[test]
+    fn token_revocation() {
+        let store = UserStore::new();
+        assert!(!store.is_token_revoked("token-123"));
+        store.revoke_token("token-123");
+        assert!(store.is_token_revoked("token-123"));
+    }
+
+    #[test]
+    fn change_password() {
+        let store = UserStore::new();
+        let user = store.create_user("user".to_string(), "old-pass").unwrap();
+        store.change_password(user.id, "new-pass").unwrap();
+        assert!(store.authenticate("user", "old-pass").is_err());
+        assert!(store.authenticate("user", "new-pass").is_ok());
+    }
+
+    #[test]
+    fn list_users() {
+        let store = UserStore::new();
+        store.create_user("a".to_string(), "p").unwrap();
+        store.create_user("b".to_string(), "p").unwrap();
+        assert_eq!(store.list_users().len(), 2);
+    }
+}

--- a/crates/runifi-core/src/config/flow_config.rs
+++ b/crates/runifi-core/src/config/flow_config.rs
@@ -14,6 +14,8 @@ pub struct FlowConfig {
     pub engine: EngineConfig,
     #[serde(default)]
     pub audit: AuditConfig,
+    #[serde(default)]
+    pub auth: AuthConfig,
 }
 
 /// Configuration for the web API server.
@@ -463,6 +465,76 @@ fn default_audit_enabled() -> bool {
 
 fn default_audit_log_to_tracing() -> bool {
     true
+}
+
+/// Configuration for user management and JWT authentication.
+///
+/// ```toml
+/// [auth]
+/// enabled = true
+/// single_user_mode = true
+/// jwt_secret = "${RUNIFI_JWT_SECRET}"
+/// jwt_expiry_secs = 3600
+/// default_admin_username = "admin"
+/// default_admin_password = "admin"
+/// ```
+#[derive(Debug, Deserialize, Clone)]
+pub struct AuthConfig {
+    /// Whether JWT-based user authentication is enabled.
+    /// When disabled, all requests bypass user auth (existing API key auth still applies).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Single-user mode: auto-create a default admin account on first boot
+    /// if no users exist. Intended for development and testing.
+    #[serde(default = "default_single_user_mode")]
+    pub single_user_mode: bool,
+    /// HMAC secret for signing JWT tokens. **Must** be set when auth is enabled.
+    /// Use env var substitution: `"${RUNIFI_JWT_SECRET}"`.
+    #[serde(default = "default_jwt_secret")]
+    pub jwt_secret: String,
+    /// JWT token lifetime in seconds. Default: 3600 (1 hour).
+    #[serde(default = "default_jwt_expiry")]
+    pub jwt_expiry_secs: i64,
+    /// Default admin username for single-user mode.
+    #[serde(default = "default_admin_username")]
+    pub default_admin_username: String,
+    /// Default admin password for single-user mode.
+    /// **Change this in production.**
+    #[serde(default = "default_admin_password")]
+    pub default_admin_password: String,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            single_user_mode: default_single_user_mode(),
+            jwt_secret: default_jwt_secret(),
+            jwt_expiry_secs: default_jwt_expiry(),
+            default_admin_username: default_admin_username(),
+            default_admin_password: default_admin_password(),
+        }
+    }
+}
+
+fn default_single_user_mode() -> bool {
+    true
+}
+
+fn default_jwt_secret() -> String {
+    "change-me-in-production".to_string()
+}
+
+fn default_jwt_expiry() -> i64 {
+    3600
+}
+
+fn default_admin_username() -> String {
+    "admin".to_string()
+}
+
+fn default_admin_password() -> String {
+    "admin".to_string()
 }
 
 #[cfg(test)]

--- a/crates/runifi-core/src/lib.rs
+++ b/crates/runifi-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod auth;
 pub mod config;
 pub mod connection;
 pub mod engine;

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -8,6 +8,8 @@ use tracing_subscriber::EnvFilter;
 use runifi_core::audit::{
     AuditLogger, CompositeAuditLogger, FileAuditLogger, NullAuditLogger, TracingAuditLogger,
 };
+use runifi_core::auth::jwt::JwtConfig;
+use runifi_core::auth::store::UserStore;
 use runifi_core::config::flow_config::FlowConfig;
 use runifi_core::config::permissions::check_config_permissions;
 use runifi_core::config::property_encryption::{
@@ -372,6 +374,50 @@ async fn main() -> Result<()> {
     }
     engine.set_plugin_types(plugin_types);
 
+    // Initialize user management if auth is enabled.
+    let user_store = Arc::new(UserStore::new());
+    let jwt_config = if config.auth.enabled {
+        if config.auth.jwt_secret == "change-me-in-production" {
+            tracing::warn!(
+                "Using default JWT secret. Set auth.jwt_secret or RUNIFI_JWT_SECRET for production."
+            );
+        }
+        let jwt = JwtConfig::new(&config.auth.jwt_secret, config.auth.jwt_expiry_secs);
+
+        // Single-user mode: bootstrap a default admin if no users exist.
+        if config.auth.single_user_mode && user_store.user_count() == 0 {
+            match user_store.create_user(
+                config.auth.default_admin_username.clone(),
+                &config.auth.default_admin_password,
+            ) {
+                Ok(user) => {
+                    tracing::info!(
+                        username = %user.username,
+                        "Single-user mode: default admin account created"
+                    );
+                    if config.auth.default_admin_password == "admin" {
+                        tracing::warn!(
+                            "Default admin password is 'admin'. Change it immediately in production."
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to create default admin user");
+                }
+            }
+        }
+
+        tracing::info!(
+            expiry_secs = config.auth.jwt_expiry_secs,
+            single_user_mode = config.auth.single_user_mode,
+            "JWT user authentication enabled"
+        );
+        Some(jwt)
+    } else {
+        tracing::info!("User authentication is disabled");
+        None
+    };
+
     // Start the API server if enabled.
     let api_handle = if config.api.enabled {
         let engine_handle = engine
@@ -381,12 +427,22 @@ async fn main() -> Result<()> {
 
         let api_config = config.api.clone();
         let api_registry = registry.clone();
+        let api_user_store = user_store.clone();
+        let api_jwt_config = jwt_config.clone();
+        let api_auth_config = config.auth.clone();
 
         Some(tokio::spawn(async move {
             if let Err(e) = runifi_api::start_api_server_with_registry(
                 engine_handle,
                 &api_config,
                 Some(api_registry),
+                if api_auth_config.enabled {
+                    Some(api_user_store)
+                } else {
+                    None
+                },
+                api_jwt_config,
+                Some(api_auth_config),
             )
             .await
             {


### PR DESCRIPTION
## Summary

Implements Phase 1 of user management: core identity system with local authentication.

### Changes
- **User and UserGroup models** with in-memory storage (DashMap-backed `UserStore`)
- **Argon2id password hashing** for secure credential storage
- **JWT-based session management** with configurable expiry and token revocation
- **Auth API endpoints**: `POST /api/v1/auth/login`, `POST /api/v1/auth/logout`, `GET /api/v1/auth/me`
- **User CRUD API**: `GET/POST/PUT/DELETE /api/v1/tenants/users`
- **UserGroup CRUD API**: `GET/POST/PUT/DELETE /api/v1/tenants/user-groups`
- **Auth middleware** extended to support JWT validation alongside existing API key auth
- **Single-user bootstrap mode**: auto-creates default admin on first boot (configurable)
- **`[auth]` config section** for JWT secret, expiry, single-user mode, and default admin credentials

### Architecture
- Auth models and store live in `runifi-core::auth` (reusable by other crates)
- JWT and password utilities are self-contained modules
- API routes follow existing patterns (axum Router + State extraction)
- Auth middleware supports both JWT and API key auth simultaneously
- User/group management requires `ManageConfig` (Admin) permission via RBAC

### Not in scope (follow-up PRs)
- Access policies and per-component permissions (Phase 2)
- Dashboard UI for user management (Phase 3)
- LDAP, OIDC, mTLS integration (Phase 4)

## Test Plan
- [x] Unit tests for Argon2 password hashing and verification (5 tests)
- [x] Unit tests for JWT token generation, validation, expiry, and uniqueness (5 tests)
- [x] Unit tests for UserStore CRUD operations (12 tests)
- [x] Unit tests for auth middleware exempt paths and bearer token extraction
- [x] All existing tests pass (387 total, 0 failures)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #183