### PR TITLE
test: add comprehensive test infrastructure (#17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +437,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -556,6 +595,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +685,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1062,6 +1143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1184,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1404,10 +1502,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1729,6 +1847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1931,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polyval"
@@ -2037,6 +2189,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2417,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc32fast",
+ "criterion",
  "crossbeam",
  "dashmap",
  "futures",
@@ -2790,6 +2963,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/runifi-core/Cargo.toml
+++ b/crates/runifi-core/Cargo.toml
@@ -40,3 +40,20 @@ tokio = { workspace = true, features = ["test-util", "macros"] }
 runifi-processors = { path = "../runifi-processors" }
 inventory = { workspace = true }
 tempfile = "3"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "flowfile_bench"
+harness = false
+
+[[bench]]
+name = "content_repo_bench"
+harness = false
+
+[[bench]]
+name = "connection_bench"
+harness = false
+
+[[bench]]
+name = "pipeline_bench"
+harness = false

--- a/crates/runifi-core/benches/connection_bench.rs
+++ b/crates/runifi-core/benches/connection_bench.rs
@@ -1,0 +1,118 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use runifi_core::connection::back_pressure::BackPressureConfig;
+use runifi_core::connection::flow_connection::FlowConnection;
+use runifi_plugin_api::FlowFile;
+
+fn make_flowfile(id: u64, size: u64) -> FlowFile {
+    FlowFile {
+        id,
+        attributes: Vec::new(),
+        content_claim: None,
+        size,
+        created_at_nanos: 0,
+        lineage_start_id: id,
+        penalized_until_nanos: 0,
+    }
+}
+
+fn bench_send_recv(c: &mut Criterion) {
+    let conn = FlowConnection::new("bench", BackPressureConfig::default());
+
+    c.bench_function("connection_send_recv_cycle", |b| {
+        let mut id = 0u64;
+        b.iter(|| {
+            id += 1;
+            let ff = make_flowfile(id, 100);
+            conn.try_send(ff).unwrap();
+            let received = conn.try_recv().unwrap();
+            black_box(received);
+        });
+    });
+}
+
+fn bench_send_throughput(c: &mut Criterion) {
+    c.bench_function("connection_send_1000", |b| {
+        b.iter(|| {
+            let conn = FlowConnection::new("bench", BackPressureConfig::default());
+            for i in 0..1000 {
+                conn.try_send(make_flowfile(i, 100)).unwrap();
+            }
+            black_box(conn.count());
+        });
+    });
+}
+
+fn bench_recv_throughput(c: &mut Criterion) {
+    c.bench_function("connection_recv_1000", |b| {
+        b.iter_with_setup(
+            || {
+                let conn = FlowConnection::new("bench", BackPressureConfig::default());
+                for i in 0..1000 {
+                    conn.try_send(make_flowfile(i, 100)).unwrap();
+                }
+                conn
+            },
+            |conn| {
+                for _ in 0..1000 {
+                    black_box(conn.try_recv().unwrap());
+                }
+            },
+        );
+    });
+}
+
+fn bench_batch_recv(c: &mut Criterion) {
+    c.bench_function("connection_batch_recv_100", |b| {
+        b.iter_with_setup(
+            || {
+                let conn = FlowConnection::new("bench", BackPressureConfig::default());
+                for i in 0..100 {
+                    conn.try_send(make_flowfile(i, 100)).unwrap();
+                }
+                conn
+            },
+            |conn| {
+                let batch = conn.try_recv_batch(100);
+                black_box(batch);
+            },
+        );
+    });
+}
+
+fn bench_back_pressure_check(c: &mut Criterion) {
+    let conn = FlowConnection::new("bench", BackPressureConfig::new(10000, u64::MAX));
+    for i in 0..5000 {
+        conn.try_send(make_flowfile(i, 100)).unwrap();
+    }
+
+    c.bench_function("connection_back_pressure_check", |b| {
+        b.iter(|| {
+            black_box(conn.is_back_pressured());
+        });
+    });
+}
+
+fn bench_queue_snapshot(c: &mut Criterion) {
+    let conn = FlowConnection::new("bench", BackPressureConfig::default());
+    for i in 0..100 {
+        conn.try_send(make_flowfile(i, 100)).unwrap();
+    }
+
+    c.bench_function("connection_queue_snapshot_100", |b| {
+        b.iter(|| {
+            let snapshot = conn.queue_snapshot(0, 100);
+            black_box(snapshot);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_send_recv,
+    bench_send_throughput,
+    bench_recv_throughput,
+    bench_batch_recv,
+    bench_back_pressure_check,
+    bench_queue_snapshot,
+);
+criterion_main!(benches);

--- a/crates/runifi-core/benches/content_repo_bench.rs
+++ b/crates/runifi-core/benches/content_repo_bench.rs
@@ -1,0 +1,106 @@
+use bytes::Bytes;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use runifi_core::repository::content_memory::InMemoryContentRepository;
+use runifi_core::repository::content_repo::ContentRepository;
+
+fn bench_create_small(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0u8; 64]); // 64 bytes — micro profile
+
+    c.bench_function("content_create_64B", |b| {
+        b.iter(|| {
+            black_box(repo.create(data.clone()).unwrap());
+        });
+    });
+}
+
+fn bench_create_5kb(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0u8; 5120]); // 5 KB — micro profile
+
+    c.bench_function("content_create_5KB", |b| {
+        b.iter(|| {
+            black_box(repo.create(data.clone()).unwrap());
+        });
+    });
+}
+
+fn bench_read_small(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0u8; 64]);
+    let claim = repo.create(data).unwrap();
+
+    c.bench_function("content_read_64B", |b| {
+        b.iter(|| {
+            black_box(repo.read(&claim).unwrap());
+        });
+    });
+}
+
+fn bench_read_5kb(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0u8; 5120]);
+    let claim = repo.create(data).unwrap();
+
+    c.bench_function("content_read_5KB", |b| {
+        b.iter(|| {
+            black_box(repo.read(&claim).unwrap());
+        });
+    });
+}
+
+fn bench_create_and_read_cycle(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0u8; 1024]);
+
+    c.bench_function("content_create_read_cycle_1KB", |b| {
+        b.iter(|| {
+            let claim = repo.create(data.clone()).unwrap();
+            let read_back = repo.read(&claim).unwrap();
+            black_box(read_back);
+            repo.decrement_ref(claim.resource_id).unwrap();
+        });
+    });
+}
+
+fn bench_ref_counting(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0u8; 64]);
+    let claim = repo.create(data).unwrap();
+
+    c.bench_function("content_increment_ref", |b| {
+        b.iter(|| {
+            repo.increment_ref(claim.resource_id).unwrap();
+        });
+    });
+}
+
+fn bench_zero_copy_slice(c: &mut Criterion) {
+    let repo = InMemoryContentRepository::new();
+    let data = Bytes::from(vec![0xABu8; 1024 * 1024]); // 1 MB
+    let claim = repo.create(data).unwrap();
+
+    let slice_claim = runifi_plugin_api::ContentClaim {
+        resource_id: claim.resource_id,
+        offset: 512 * 1024, // Middle of the buffer.
+        length: 1024,
+    };
+
+    c.bench_function("content_zero_copy_slice_1KB_from_1MB", |b| {
+        b.iter(|| {
+            black_box(repo.read(&slice_claim).unwrap());
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_create_small,
+    bench_create_5kb,
+    bench_read_small,
+    bench_read_5kb,
+    bench_create_and_read_cycle,
+    bench_ref_counting,
+    bench_zero_copy_slice,
+);
+criterion_main!(benches);

--- a/crates/runifi-core/benches/flowfile_bench.rs
+++ b/crates/runifi-core/benches/flowfile_bench.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use runifi_plugin_api::flowfile::{ContentClaim, FlowFile};
+
+fn make_flowfile(id: u64) -> FlowFile {
+    FlowFile {
+        id,
+        attributes: Vec::new(),
+        content_claim: None,
+        size: 0,
+        created_at_nanos: 0,
+        lineage_start_id: id,
+        penalized_until_nanos: 0,
+    }
+}
+
+fn bench_flowfile_creation(c: &mut Criterion) {
+    c.bench_function("flowfile_creation", |b| {
+        let mut id = 0u64;
+        b.iter(|| {
+            id += 1;
+            black_box(make_flowfile(id));
+        });
+    });
+}
+
+fn bench_flowfile_creation_with_attributes(c: &mut Criterion) {
+    c.bench_function("flowfile_creation_with_attrs", |b| {
+        let mut id = 0u64;
+        let key1: Arc<str> = Arc::from("filename");
+        let key2: Arc<str> = Arc::from("mime.type");
+        let key3: Arc<str> = Arc::from("path");
+        b.iter(|| {
+            id += 1;
+            let mut ff = make_flowfile(id);
+            ff.set_attribute(key1.clone(), Arc::from("test.txt"));
+            ff.set_attribute(key2.clone(), Arc::from("text/plain"));
+            ff.set_attribute(key3.clone(), Arc::from("/data"));
+            black_box(ff);
+        });
+    });
+}
+
+fn bench_attribute_lookup(c: &mut Criterion) {
+    let mut ff = make_flowfile(1);
+    for i in 0..16 {
+        ff.set_attribute(
+            Arc::from(format!("attr-{}", i).as_str()),
+            Arc::from(format!("value-{}", i).as_str()),
+        );
+    }
+
+    c.bench_function("attribute_lookup_16_attrs", |b| {
+        b.iter(|| {
+            black_box(ff.get_attribute("attr-15"));
+        });
+    });
+}
+
+fn bench_attribute_set(c: &mut Criterion) {
+    c.bench_function("attribute_set", |b| {
+        let key: Arc<str> = Arc::from("filename");
+        let value: Arc<str> = Arc::from("test.txt");
+        let mut ff = make_flowfile(1);
+        b.iter(|| {
+            ff.set_attribute(key.clone(), value.clone());
+            black_box(&ff);
+        });
+    });
+}
+
+fn bench_flowfile_clone(c: &mut Criterion) {
+    let mut ff = make_flowfile(1);
+    ff.size = 1024;
+    ff.content_claim = Some(ContentClaim {
+        resource_id: 1,
+        offset: 0,
+        length: 1024,
+    });
+    for i in 0..8 {
+        ff.set_attribute(
+            Arc::from(format!("attr-{}", i).as_str()),
+            Arc::from(format!("value-{}", i).as_str()),
+        );
+    }
+
+    c.bench_function("flowfile_clone_8_attrs", |b| {
+        b.iter(|| {
+            black_box(ff.clone());
+        });
+    });
+}
+
+fn bench_id_generator_throughput(c: &mut Criterion) {
+    use runifi_core::id::IdGenerator;
+
+    let id_gen = IdGenerator::new();
+    c.bench_function("id_generator", |b| {
+        b.iter(|| {
+            black_box(id_gen.next_id());
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_flowfile_creation,
+    bench_flowfile_creation_with_attributes,
+    bench_attribute_lookup,
+    bench_attribute_set,
+    bench_flowfile_clone,
+    bench_id_generator_throughput,
+);
+criterion_main!(benches);

--- a/crates/runifi-core/benches/pipeline_bench.rs
+++ b/crates/runifi-core/benches/pipeline_bench.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use runifi_core::connection::back_pressure::BackPressureConfig;
+use runifi_core::connection::flow_connection::FlowConnection;
+use runifi_core::id::IdGenerator;
+use runifi_core::repository::content_memory::InMemoryContentRepository;
+use runifi_core::repository::content_repo::ContentRepository;
+use runifi_core::session::process_session::CoreProcessSession;
+use runifi_plugin_api::session::ProcessSession;
+use runifi_plugin_api::{FlowFile, REL_SUCCESS};
+
+fn make_flowfile(id: u64, size: u64) -> FlowFile {
+    FlowFile {
+        id,
+        attributes: Vec::new(),
+        content_claim: None,
+        size,
+        created_at_nanos: 0,
+        lineage_start_id: id,
+        penalized_until_nanos: 0,
+    }
+}
+
+fn bench_session_create_transfer_commit(c: &mut Criterion) {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let id_gen = Arc::new(IdGenerator::new());
+
+    c.bench_function("session_create_transfer_commit", |b| {
+        b.iter(|| {
+            let mut session =
+                CoreProcessSession::new(content_repo.clone(), id_gen.clone(), vec![], 1000);
+            let ff = session.create();
+            session.transfer(ff, &REL_SUCCESS);
+            session.commit();
+            black_box(session.is_committed());
+        });
+    });
+}
+
+fn bench_session_write_content_5kb(c: &mut Criterion) {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let id_gen = Arc::new(IdGenerator::new());
+    let data = Bytes::from(vec![0u8; 5120]);
+
+    c.bench_function("session_write_content_5KB", |b| {
+        b.iter(|| {
+            let mut session =
+                CoreProcessSession::new(content_repo.clone(), id_gen.clone(), vec![], 1000);
+            let ff = session.create();
+            let ff = session.write_content(ff, data.clone()).unwrap();
+            session.transfer(ff, &REL_SUCCESS);
+            session.commit();
+        });
+    });
+}
+
+fn bench_end_to_end_pipeline_step(c: &mut Criterion) {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let id_gen = Arc::new(IdGenerator::new());
+    let data = Bytes::from(vec![0u8; 5120]); // 5 KB micro profile
+
+    c.bench_function("pipeline_step_5KB", |b| {
+        b.iter(|| {
+            // Simulate a single pipeline step:
+            // 1. Create FlowFile
+            // 2. Write 5KB content
+            // 3. Transfer to success
+            // 4. Commit
+            let mut session =
+                CoreProcessSession::new(content_repo.clone(), id_gen.clone(), vec![], 1000);
+            let ff = session.create();
+            let ff = session.write_content(ff, data.clone()).unwrap();
+            let _ = session.read_content(&ff).unwrap();
+            session.transfer(ff, &REL_SUCCESS);
+            session.commit();
+        });
+    });
+}
+
+fn bench_pipeline_with_connection(c: &mut Criterion) {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let id_gen = Arc::new(IdGenerator::new());
+    let data = Bytes::from(vec![0u8; 5120]);
+
+    c.bench_function("pipeline_conn_send_recv_5KB", |b| {
+        b.iter(|| {
+            let conn = Arc::new(FlowConnection::new("bench", BackPressureConfig::default()));
+
+            // Producer: create FF, write content, send to connection.
+            let claim = content_repo.create(data.clone()).unwrap();
+            let mut ff = make_flowfile(id_gen.next_id(), 5120);
+            ff.content_claim = Some(claim);
+            conn.try_send(ff).unwrap();
+
+            // Consumer: receive from connection, read content.
+            let received = conn.try_recv().unwrap();
+            let content = content_repo
+                .read(received.content_claim.as_ref().unwrap())
+                .unwrap();
+            black_box(content);
+
+            // Cleanup.
+            content_repo
+                .decrement_ref(received.content_claim.unwrap().resource_id)
+                .unwrap();
+        });
+    });
+}
+
+fn bench_batch_processing(c: &mut Criterion) {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let id_gen = Arc::new(IdGenerator::new());
+
+    c.bench_function("batch_create_100_flowfiles", |b| {
+        b.iter(|| {
+            let mut session =
+                CoreProcessSession::new(content_repo.clone(), id_gen.clone(), vec![], 1000);
+            for _ in 0..100 {
+                let ff = session.create();
+                session.transfer(ff, &REL_SUCCESS);
+            }
+            session.commit();
+            black_box(session.is_committed());
+        });
+    });
+}
+
+fn bench_session_rollback(c: &mut Criterion) {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let id_gen = Arc::new(IdGenerator::new());
+    let data = Bytes::from(vec![0u8; 1024]);
+
+    c.bench_function("session_rollback_with_content", |b| {
+        b.iter(|| {
+            let mut session =
+                CoreProcessSession::new(content_repo.clone(), id_gen.clone(), vec![], 1000);
+            let ff = session.create();
+            let _ff = session.write_content(ff, data.clone()).unwrap();
+            session.rollback();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_session_create_transfer_commit,
+    bench_session_write_content_5kb,
+    bench_end_to_end_pipeline_step,
+    bench_pipeline_with_connection,
+    bench_batch_processing,
+    bench_session_rollback,
+);
+criterion_main!(benches);

--- a/crates/runifi-core/src/connection/flow_connection.rs
+++ b/crates/runifi-core/src/connection/flow_connection.rs
@@ -416,4 +416,104 @@ mod tests {
         let snapshot = conn.queue_snapshot(0, 100);
         assert_eq!(snapshot[0].id, 2);
     }
+
+    #[test]
+    fn fifo_ordering() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        for i in 0..5 {
+            conn.try_send(test_flowfile(i, 10)).unwrap();
+        }
+        for i in 0..5 {
+            let ff = conn.try_recv().unwrap();
+            assert_eq!(ff.id, i);
+        }
+    }
+
+    #[test]
+    fn bytes_tracking_accurate() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        conn.try_send(test_flowfile(1, 100)).unwrap();
+        conn.try_send(test_flowfile(2, 200)).unwrap();
+        conn.try_send(test_flowfile(3, 300)).unwrap();
+        assert_eq!(conn.bytes(), 600);
+
+        conn.try_recv(); // removes 100 bytes
+        assert_eq!(conn.bytes(), 500);
+
+        conn.try_recv(); // removes 200 bytes
+        assert_eq!(conn.bytes(), 300);
+    }
+
+    #[test]
+    fn queue_get_with_position() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        for i in 0..5 {
+            conn.try_send(test_flowfile(i, 10)).unwrap();
+        }
+
+        let (pos, snap) = conn.queue_get_with_position(3).unwrap();
+        assert_eq!(pos, 3);
+        assert_eq!(snap.id, 3);
+
+        assert!(conn.queue_get_with_position(999).is_none());
+    }
+
+    #[test]
+    fn notifier_fires_on_send() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        let notifier = conn.notifier();
+
+        // Send triggers a notify.
+        conn.try_send(test_flowfile(1, 10)).unwrap();
+
+        // We can't easily test async Notify in a sync test,
+        // but we can verify the notifier is valid.
+        assert!(std::sync::Arc::strong_count(&notifier) >= 1);
+    }
+
+    #[test]
+    fn back_pressure_released_after_recv() {
+        let config = BackPressureConfig::new(2, u64::MAX);
+        let conn = FlowConnection::new("test", config);
+        conn.try_send(test_flowfile(1, 10)).unwrap();
+        conn.try_send(test_flowfile(2, 10)).unwrap();
+        assert!(conn.is_back_pressured());
+
+        conn.try_recv();
+        assert!(!conn.is_back_pressured());
+    }
+
+    #[test]
+    fn batch_recv_with_fewer_available() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        conn.try_send(test_flowfile(1, 10)).unwrap();
+        conn.try_send(test_flowfile(2, 10)).unwrap();
+
+        let batch = conn.try_recv_batch(5);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(conn.count(), 0);
+    }
+
+    #[test]
+    fn snapshot_with_attributes() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        let mut ff = test_flowfile(1, 100);
+        ff.attributes.push((Arc::from("key"), Arc::from("value")));
+        conn.try_send(ff).unwrap();
+
+        let snapshot = conn.queue_snapshot(0, 1);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].attributes.len(), 1);
+        assert_eq!(snapshot[0].attributes[0].0.as_ref(), "key");
+        assert_eq!(snapshot[0].attributes[0].1.as_ref(), "value");
+    }
+
+    #[test]
+    fn clear_empty_queue() {
+        let conn = FlowConnection::new("test", BackPressureConfig::default());
+        let removed = conn.clear_queue();
+        assert_eq!(removed, 0);
+        assert_eq!(conn.count(), 0);
+        assert_eq!(conn.bytes(), 0);
+    }
 }

--- a/crates/runifi-core/src/engine/supervisor.rs
+++ b/crates/runifi-core/src/engine/supervisor.rs
@@ -343,4 +343,128 @@ mod tests {
         sup.invoke(&ctx, &mut session);
         assert_eq!(sup.current_backoff(), Duration::from_millis(400));
     }
+
+    #[test]
+    fn backoff_capped_at_30s() {
+        let mut sup = ProcessorSupervisor::new(Box::new(FailProcessor));
+        let ctx = TestContext;
+        let mut session = NoOpSession;
+
+        // Trip through many failures to reach the cap.
+        for _ in 0..20 {
+            sup.invoke(&ctx, &mut session);
+        }
+
+        // Backoff should be capped at 30s.
+        assert!(sup.current_backoff() <= Duration::from_millis(30_000));
+    }
+
+    #[test]
+    fn success_after_failures_resets_count() {
+        // Create a processor that fails first, then succeeds.
+        struct ToggleProcessor {
+            call_count: u32,
+            fail_count: u32,
+        }
+        impl Processor for ToggleProcessor {
+            fn on_trigger(
+                &mut self,
+                _ctx: &dyn ProcessContext,
+                _session: &mut dyn ProcessSession,
+            ) -> ProcessResult {
+                self.call_count += 1;
+                if self.call_count <= self.fail_count {
+                    Err(PluginError::ProcessingFailed("test".into()))
+                } else {
+                    Ok(())
+                }
+            }
+            fn relationships(&self) -> Vec<Relationship> {
+                vec![]
+            }
+        }
+
+        let proc = ToggleProcessor {
+            call_count: 0,
+            fail_count: 3,
+        };
+        let mut sup = ProcessorSupervisor::new(Box::new(proc));
+        let ctx = TestContext;
+        let mut session = NoOpSession;
+
+        // 3 failures.
+        for _ in 0..3 {
+            sup.invoke(&ctx, &mut session);
+        }
+        assert_eq!(sup.consecutive_failures(), 3);
+        assert_eq!(sup.total_failures(), 3);
+
+        // Then success.
+        sup.invoke(&ctx, &mut session);
+        assert_eq!(sup.consecutive_failures(), 0);
+        assert_eq!(sup.total_failures(), 3); // Total doesn't reset.
+        assert_eq!(sup.total_invocations(), 4);
+    }
+
+    #[test]
+    fn on_scheduled_delegates_to_processor() {
+        let mut sup = ProcessorSupervisor::new(Box::new(OkProcessor));
+        let ctx = TestContext;
+        assert!(sup.on_scheduled(&ctx).is_ok());
+    }
+
+    #[test]
+    fn relationships_delegates_to_processor() {
+        let sup = ProcessorSupervisor::new(Box::new(OkProcessor));
+        let rels = sup.relationships();
+        assert!(rels.is_empty());
+    }
+
+    #[test]
+    fn panic_with_string_message() {
+        struct StringPanicProcessor;
+        impl Processor for StringPanicProcessor {
+            fn on_trigger(
+                &mut self,
+                _ctx: &dyn ProcessContext,
+                _session: &mut dyn ProcessSession,
+            ) -> ProcessResult {
+                panic!("{}", "string panic".to_string());
+            }
+            fn relationships(&self) -> Vec<Relationship> {
+                vec![]
+            }
+        }
+
+        let mut sup = ProcessorSupervisor::new(Box::new(StringPanicProcessor));
+        let ctx = TestContext;
+        let mut session = NoOpSession;
+
+        let result = sup.invoke(&ctx, &mut session);
+        if let InvocationResult::Panic(msg) = result {
+            assert!(msg.contains("string panic"));
+        } else {
+            panic!("Expected Panic result");
+        }
+    }
+
+    #[test]
+    fn circuit_stays_open_after_more_invocations() {
+        let mut sup = ProcessorSupervisor::new(Box::new(FailProcessor));
+        let ctx = TestContext;
+        let mut session = NoOpSession;
+
+        // Trip the circuit breaker.
+        for _ in 0..5 {
+            sup.invoke(&ctx, &mut session);
+        }
+        assert!(sup.is_circuit_open());
+
+        // Subsequent invocations return circuit-open error without incrementing counters.
+        let before_invocations = sup.total_invocations();
+        let result = sup.invoke(&ctx, &mut session);
+        assert!(matches!(result, InvocationResult::Failed(_)));
+        // total_invocations should not change since the circuit was open.
+        assert_eq!(sup.total_invocations(), before_invocations);
+    }
 }

--- a/crates/runifi-core/src/registry/plugin_registry.rs
+++ b/crates/runifi-core/src/registry/plugin_registry.rs
@@ -128,3 +128,72 @@ impl PluginRegistry {
             .unwrap_or_default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_finds_registered_processors() {
+        let registry = PluginRegistry::discover();
+        let types = registry.processor_types();
+        // We can't guarantee specific types without linking runifi-processors,
+        // but the API should work without panicking.
+        let _ = types;
+    }
+
+    #[test]
+    fn create_unknown_processor_returns_none() {
+        let registry = PluginRegistry::discover();
+        assert!(registry.create_processor("NonexistentProcessor").is_none());
+    }
+
+    #[test]
+    fn create_unknown_source_returns_none() {
+        let registry = PluginRegistry::discover();
+        assert!(registry.create_source("NonexistentSource").is_none());
+    }
+
+    #[test]
+    fn create_unknown_sink_returns_none() {
+        let registry = PluginRegistry::discover();
+        assert!(registry.create_sink("NonexistentSink").is_none());
+    }
+
+    #[test]
+    fn create_unknown_service_returns_none() {
+        let registry = PluginRegistry::discover();
+        assert!(registry.create_service("NonexistentService").is_none());
+    }
+
+    #[test]
+    fn processor_tags_for_unknown_type_returns_empty() {
+        let registry = PluginRegistry::discover();
+        let tags = registry.processor_tags("NonexistentProcessor");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn service_description_for_unknown_type_returns_none() {
+        let registry = PluginRegistry::discover();
+        assert!(registry.service_description("NonexistentService").is_none());
+    }
+
+    #[test]
+    fn source_types_does_not_panic() {
+        let registry = PluginRegistry::discover();
+        let _ = registry.source_types();
+    }
+
+    #[test]
+    fn sink_types_does_not_panic() {
+        let registry = PluginRegistry::discover();
+        let _ = registry.sink_types();
+    }
+
+    #[test]
+    fn service_types_does_not_panic() {
+        let registry = PluginRegistry::discover();
+        let _ = registry.service_types();
+    }
+}

--- a/crates/runifi-core/src/repository/content_memory.rs
+++ b/crates/runifi-core/src/repository/content_memory.rs
@@ -150,4 +150,106 @@ mod tests {
         };
         assert!(repo.read(&claim).is_err());
     }
+
+    #[test]
+    fn create_empty_content() {
+        let repo = InMemoryContentRepository::new();
+        let claim = repo.create(Bytes::new()).unwrap();
+        assert_eq!(claim.length, 0);
+        assert_eq!(claim.offset, 0);
+        let data = repo.read(&claim).unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn multiple_creates_produce_unique_ids() {
+        let repo = InMemoryContentRepository::new();
+        let c1 = repo.create(Bytes::from_static(b"a")).unwrap();
+        let c2 = repo.create(Bytes::from_static(b"b")).unwrap();
+        let c3 = repo.create(Bytes::from_static(b"c")).unwrap();
+        assert_ne!(c1.resource_id, c2.resource_id);
+        assert_ne!(c2.resource_id, c3.resource_id);
+    }
+
+    #[test]
+    fn zero_copy_slicing() {
+        let repo = InMemoryContentRepository::new();
+        let data = Bytes::from_static(b"hello world");
+        let claim = repo.create(data).unwrap();
+
+        // Read the full content.
+        let full = repo.read(&claim).unwrap();
+        assert_eq!(full, Bytes::from_static(b"hello world"));
+
+        // Read a slice.
+        let slice_claim = ContentClaim {
+            resource_id: claim.resource_id,
+            offset: 6,
+            length: 5,
+        };
+        let slice = repo.read(&slice_claim).unwrap();
+        assert_eq!(slice, Bytes::from_static(b"world"));
+    }
+
+    #[test]
+    fn out_of_bounds_read_fails() {
+        let repo = InMemoryContentRepository::new();
+        let claim = repo.create(Bytes::from_static(b"short")).unwrap();
+        let bad_claim = ContentClaim {
+            resource_id: claim.resource_id,
+            offset: 0,
+            length: 100, // Way beyond actual size.
+        };
+        assert!(repo.read(&bad_claim).is_err());
+    }
+
+    #[test]
+    fn increment_ref_on_missing_resource_fails() {
+        let repo = InMemoryContentRepository::new();
+        assert!(repo.increment_ref(9999).is_err());
+    }
+
+    #[test]
+    fn decrement_ref_on_missing_resource_fails() {
+        let repo = InMemoryContentRepository::new();
+        assert!(repo.decrement_ref(9999).is_err());
+    }
+
+    #[test]
+    fn concurrent_access() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let repo = Arc::new(InMemoryContentRepository::new());
+        let mut handles = Vec::new();
+
+        for i in 0..10 {
+            let repo = repo.clone();
+            handles.push(thread::spawn(move || {
+                let data = Bytes::from(format!("content-{}", i));
+                let claim = repo.create(data.clone()).unwrap();
+                let read_back = repo.read(&claim).unwrap();
+                assert_eq!(read_back, data);
+                claim
+            }));
+        }
+
+        let claims: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // All claims should have unique IDs.
+        let mut ids: Vec<u64> = claims.iter().map(|c| c.resource_id).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 10);
+    }
+
+    #[test]
+    fn large_content() {
+        let repo = InMemoryContentRepository::new();
+        let data = Bytes::from(vec![0xABu8; 1024 * 1024]); // 1 MB
+        let claim = repo.create(data.clone()).unwrap();
+        assert_eq!(claim.length, 1024 * 1024);
+        let read_back = repo.read(&claim).unwrap();
+        assert_eq!(read_back.len(), 1024 * 1024);
+        assert_eq!(read_back, data);
+    }
 }

--- a/crates/runifi-core/src/session/process_session.rs
+++ b/crates/runifi-core/src/session/process_session.rs
@@ -240,3 +240,244 @@ impl Drop for CoreProcessSession {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::back_pressure::BackPressureConfig;
+    use crate::repository::content_memory::InMemoryContentRepository;
+
+    fn make_session(input_connections: Vec<Arc<FlowConnection>>) -> CoreProcessSession {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        CoreProcessSession::new(content_repo, id_gen, input_connections, 1000)
+    }
+
+    fn make_flowfile(id: u64) -> FlowFile {
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    #[test]
+    fn create_returns_unique_ids() {
+        let mut session = make_session(vec![]);
+        let ff1 = session.create();
+        let ff2 = session.create();
+        assert_ne!(ff1.id, ff2.id);
+        assert!(ff1.id > 0);
+        assert!(ff2.id > 0);
+    }
+
+    #[test]
+    fn write_and_read_content() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        let data = Bytes::from_static(b"hello world");
+        let ff = session.write_content(ff, data.clone()).unwrap();
+        assert_eq!(ff.size, 11);
+        assert!(ff.content_claim.is_some());
+
+        let read_back = session.read_content(&ff).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn read_content_empty_when_no_claim() {
+        let session = make_session(vec![]);
+        let ff = make_flowfile(1);
+        let content = session.read_content(&ff).unwrap();
+        assert!(content.is_empty());
+    }
+
+    #[test]
+    fn transfer_buffers_until_commit() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        session.transfer(ff, &runifi_plugin_api::REL_SUCCESS);
+
+        assert!(!session.is_committed());
+        session.commit();
+        assert!(session.is_committed());
+    }
+
+    #[test]
+    fn take_transfers_returns_buffered() {
+        let mut session = make_session(vec![]);
+        let ff1 = session.create();
+        let ff2 = session.create();
+        session.transfer(ff1, &runifi_plugin_api::REL_SUCCESS);
+        session.transfer(ff2, &runifi_plugin_api::REL_FAILURE);
+        session.commit();
+
+        let transfers = session.take_transfers();
+        assert_eq!(transfers.len(), 2);
+        assert_eq!(transfers[0].1, "success");
+        assert_eq!(transfers[1].1, "failure");
+    }
+
+    #[test]
+    fn get_from_input_connection() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(42)).unwrap();
+
+        let mut session = make_session(vec![conn]);
+        let ff = session.get().unwrap();
+        assert_eq!(ff.id, 42);
+    }
+
+    #[test]
+    fn get_returns_none_when_empty() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        let mut session = make_session(vec![conn]);
+        assert!(session.get().is_none());
+    }
+
+    #[test]
+    fn get_batch_from_input() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        for i in 0..5 {
+            conn.try_send(make_flowfile(i)).unwrap();
+        }
+
+        let mut session = make_session(vec![conn]);
+        let batch = session.get_batch(3);
+        assert_eq!(batch.len(), 3);
+    }
+
+    #[test]
+    fn clone_flowfile_shares_content() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        let data = Bytes::from_static(b"shared content");
+        let ff = session.write_content(ff, data.clone()).unwrap();
+
+        let cloned = session.clone_flowfile(&ff);
+        assert_ne!(cloned.id, ff.id);
+        assert_eq!(cloned.content_claim, ff.content_claim);
+        assert_eq!(cloned.size, ff.size);
+
+        // Both should read the same content.
+        let original_content = session.read_content(&ff).unwrap();
+        let cloned_content = session.read_content(&cloned).unwrap();
+        assert_eq!(original_content, cloned_content);
+    }
+
+    #[test]
+    fn remove_decrements_ref_on_commit() {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        let mut session = CoreProcessSession::new(content_repo.clone(), id_gen, vec![], 1000);
+
+        let ff = session.create();
+        let data = Bytes::from_static(b"to be removed");
+        let ff = session.write_content(ff, data).unwrap();
+        let claim = ff.content_claim.clone().unwrap();
+
+        session.remove(ff);
+        // Before commit, content should still be accessible.
+        assert!(content_repo.read(&claim).is_ok());
+
+        session.commit();
+        // After commit, content should be freed (ref count 0).
+        assert!(content_repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn rollback_returns_flowfiles_to_input() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(42)).unwrap();
+        assert_eq!(conn.count(), 1);
+
+        let mut session = make_session(vec![conn.clone()]);
+        let ff = session.get().unwrap();
+        assert_eq!(ff.id, 42);
+        assert_eq!(conn.count(), 0);
+
+        session.rollback();
+        // FlowFile should be back in the connection.
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn rollback_cleans_up_created_content() {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        let mut session = CoreProcessSession::new(content_repo.clone(), id_gen, vec![], 1000);
+
+        let ff = session.create();
+        let data = Bytes::from_static(b"will be rolled back");
+        let ff = session.write_content(ff, data).unwrap();
+        let claim = ff.content_claim.clone().unwrap();
+
+        // Before rollback, content is accessible.
+        assert!(content_repo.read(&claim).is_ok());
+
+        session.rollback();
+        // After rollback, content should be freed.
+        assert!(content_repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn drop_without_commit_triggers_rollback() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(99)).unwrap();
+
+        {
+            let mut session = make_session(vec![conn.clone()]);
+            let _ff = session.get().unwrap();
+            assert_eq!(conn.count(), 0);
+            // Drop without commit.
+        }
+
+        // FlowFile should be back in the connection via auto-rollback.
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn penalize_sets_future_timestamp() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        assert_eq!(ff.penalized_until_nanos, 0);
+
+        let penalized = session.penalize(ff);
+        assert!(penalized.penalized_until_nanos > 0);
+    }
+
+    #[test]
+    fn acquired_count_tracks_gets() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        for i in 0..3 {
+            conn.try_send(make_flowfile(i)).unwrap();
+        }
+
+        let mut session = make_session(vec![conn]);
+        session.get();
+        session.get();
+        assert_eq!(session.acquired_count(), 2);
+    }
+
+    #[test]
+    fn committed_remove_ids_tracked() {
+        let mut session = make_session(vec![]);
+        let ff1 = session.create();
+        let ff2 = session.create();
+        let id1 = ff1.id;
+        let id2 = ff2.id;
+
+        session.remove(ff1);
+        session.remove(ff2);
+        session.commit();
+
+        let remove_ids = session.take_committed_remove_ids();
+        assert_eq!(remove_ids.len(), 2);
+        assert!(remove_ids.contains(&id1));
+        assert!(remove_ids.contains(&id2));
+    }
+}

--- a/crates/runifi-core/tests/end_to_end_flow.rs
+++ b/crates/runifi-core/tests/end_to_end_flow.rs
@@ -1,0 +1,479 @@
+/// Integration tests for end-to-end flow execution.
+///
+/// Tests complete pipelines: GenerateFlowFile -> LogAttribute -> PutFile,
+/// back-pressure behavior, and fault tolerance with circuit breakers.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use runifi_core::connection::back_pressure::BackPressureConfig;
+use runifi_core::engine::flow_engine::FlowEngine;
+use runifi_core::engine::processor_node::SchedulingStrategy;
+use runifi_core::registry::plugin_registry::PluginRegistry;
+use runifi_core::repository::content_memory::InMemoryContentRepository;
+use runifi_core::repository::flowfile_repo::InMemoryFlowFileRepository;
+use runifi_plugin_api::context::ProcessContext;
+use runifi_plugin_api::processor::ProcessorDescriptor;
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+use runifi_plugin_api::session::ProcessSession;
+use runifi_plugin_api::{Processor, REL_FAILURE, REL_SUCCESS};
+
+// ── Test processors ──────────────────────────────────────────────────────────
+
+/// A processor that always panics (for fault tolerance testing).
+struct PanicProcessor;
+
+impl Processor for PanicProcessor {
+    fn on_trigger(
+        &mut self,
+        _ctx: &dyn ProcessContext,
+        _session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        panic!("deliberate integration test panic");
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS, REL_FAILURE]
+    }
+}
+
+/// A processor that always returns an error.
+struct ErrorProcessor;
+
+impl Processor for ErrorProcessor {
+    fn on_trigger(
+        &mut self,
+        _ctx: &dyn ProcessContext,
+        _session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        Err(PluginError::ProcessingFailed(
+            "deliberate integration test error".into(),
+        ))
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS, REL_FAILURE]
+    }
+}
+
+/// A pass-through processor that transfers input to success.
+struct PassThroughProcessor;
+
+impl Processor for PassThroughProcessor {
+    fn on_trigger(
+        &mut self,
+        _ctx: &dyn ProcessContext,
+        session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        while let Some(ff) = session.get() {
+            session.transfer(ff, &REL_SUCCESS);
+        }
+        session.commit();
+        Ok(())
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS, REL_FAILURE]
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn make_engine() -> FlowEngine {
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let flowfile_repo = Arc::new(InMemoryFlowFileRepository);
+    FlowEngine::new("integration-test", content_repo, flowfile_repo)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn engine_start_stop_lifecycle() {
+    let mut engine = make_engine();
+    assert!(!engine.is_running());
+
+    engine.start().await.unwrap();
+    assert!(engine.is_running());
+    assert!(engine.handle().is_some());
+
+    engine.stop().await;
+    assert!(!engine.is_running());
+}
+
+#[tokio::test]
+async fn engine_double_start_returns_error() {
+    let mut engine = make_engine();
+    engine.start().await.unwrap();
+
+    let result = engine.start().await;
+    assert!(result.is_err());
+
+    engine.stop().await;
+}
+
+#[tokio::test]
+async fn dag_construction_with_processors() {
+    let mut engine = make_engine();
+
+    // Build a simple pipeline: generator -> passthrough.
+    let gen_id = engine.add_processor(
+        "generator",
+        "GenerateFlowFile",
+        Box::new(PassThroughProcessor), // Using passthrough as placeholder.
+        SchedulingStrategy::TimerDriven { interval_ms: 100 },
+        HashMap::new(),
+    );
+
+    let pass_id = engine.add_processor(
+        "passthrough",
+        "PassThrough",
+        Box::new(PassThroughProcessor),
+        SchedulingStrategy::EventDriven,
+        HashMap::new(),
+    );
+
+    engine.connect(gen_id, "success", pass_id, BackPressureConfig::default());
+
+    engine.start().await.unwrap();
+
+    {
+        let handle = engine.handle().unwrap();
+        let procs = handle.processors.read();
+        assert_eq!(procs.len(), 2);
+
+        let conns = handle.connections.read();
+        assert_eq!(conns.len(), 1);
+    }
+
+    engine.stop().await;
+}
+
+#[tokio::test]
+async fn fault_tolerance_panic_recovery() {
+    let mut engine = make_engine();
+
+    // Add a panic processor and a normal processor.
+    let panic_id = engine.add_processor(
+        "panicker",
+        "PanicProcessor",
+        Box::new(PanicProcessor),
+        SchedulingStrategy::TimerDriven { interval_ms: 50 },
+        HashMap::new(),
+    );
+
+    let normal_id = engine.add_processor(
+        "normal",
+        "PassThrough",
+        Box::new(PassThroughProcessor),
+        SchedulingStrategy::TimerDriven { interval_ms: 50 },
+        HashMap::new(),
+    );
+
+    // Connect them for topology (not that data will flow through panicker).
+    engine.connect(
+        panic_id,
+        "success",
+        normal_id,
+        BackPressureConfig::default(),
+    );
+
+    engine.start().await.unwrap();
+
+    // Wait for the panic processor to trip its circuit breaker.
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    // The engine should still be running (panic was caught).
+    assert!(engine.is_running());
+
+    // The panicker's circuit breaker should be open after 5 consecutive panics.
+    {
+        let handle = engine.handle().unwrap();
+        let procs = handle.processors.read();
+        let panicker = procs.iter().find(|p| p.name == "panicker").unwrap();
+        let snap = panicker.metrics.snapshot();
+        assert!(
+            snap.circuit_open,
+            "Circuit breaker should be open after panics"
+        );
+    }
+
+    engine.stop().await;
+}
+
+#[tokio::test]
+async fn fault_tolerance_error_circuit_breaker() {
+    let mut engine = make_engine();
+
+    engine.add_processor(
+        "errorer",
+        "ErrorProcessor",
+        Box::new(ErrorProcessor),
+        SchedulingStrategy::TimerDriven { interval_ms: 10 },
+        HashMap::new(),
+    );
+
+    engine.start().await.unwrap();
+
+    // Wait enough time for 5+ failures with exponential backoff.
+    // Backoff sequence after each failure: 200ms, 400ms, 800ms, 1600ms.
+    // Plus 10ms timer interval between each. Total: ~3100ms minimum.
+    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+
+    {
+        let handle = engine.handle().unwrap();
+        let procs = handle.processors.read();
+        let errorer = procs.iter().find(|p| p.name == "errorer").unwrap();
+        let snap = errorer.metrics.snapshot();
+
+        assert!(snap.total_failures >= 5, "Should have at least 5 failures");
+        assert!(snap.circuit_open, "Circuit breaker should be open");
+    }
+
+    engine.stop().await;
+}
+
+#[tokio::test]
+async fn generate_flowfile_end_to_end() {
+    // We'll use the processor registry to test with real processors.
+    // This test requires runifi-processors to be linked.
+    let content_repo = Arc::new(InMemoryContentRepository::new());
+    let flowfile_repo = Arc::new(InMemoryFlowFileRepository);
+    let registry = Arc::new(PluginRegistry::discover());
+
+    // Try to create a GenerateFlowFile processor from the registry.
+    if let Some(gen_proc) = registry.create_processor("GenerateFlowFile") {
+        let mut engine = FlowEngine::new("e2e-test", content_repo, flowfile_repo);
+        engine.set_registry(registry);
+
+        let mut props = HashMap::new();
+        props.insert("File Size".to_string(), "64".to_string());
+        props.insert("Batch Size".to_string(), "1".to_string());
+        props.insert("Data Format".to_string(), "text".to_string());
+
+        let pass = Box::new(PassThroughProcessor);
+
+        let gen_id = engine.add_processor(
+            "generator",
+            "GenerateFlowFile",
+            gen_proc,
+            SchedulingStrategy::TimerDriven { interval_ms: 50 },
+            props,
+        );
+
+        let sink_id = engine.add_processor(
+            "sink",
+            "PassThrough",
+            pass,
+            SchedulingStrategy::EventDriven,
+            HashMap::new(),
+        );
+
+        engine.connect(gen_id, "success", sink_id, BackPressureConfig::default());
+        engine.start().await.unwrap();
+
+        // Let it run for a bit to generate FlowFiles.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        {
+            let handle = engine.handle().unwrap();
+            let procs = handle.processors.read();
+            let generator = procs.iter().find(|p| p.name == "generator").unwrap();
+            let snap = generator.metrics.snapshot();
+            assert!(
+                snap.flowfiles_out > 0,
+                "Generator should have produced FlowFiles"
+            );
+        }
+
+        engine.stop().await;
+    }
+    // If the processor isn't available, the test passes silently
+    // (it might not be linked in all test configurations).
+}
+
+#[tokio::test]
+async fn back_pressure_slows_upstream() {
+    let mut engine = make_engine();
+
+    // Create a small connection that will fill up quickly.
+    let config = BackPressureConfig::new(5, u64::MAX);
+
+    // A simple counter processor that generates FlowFiles.
+    struct CounterProcessor {
+        count: u64,
+    }
+
+    impl Processor for CounterProcessor {
+        fn on_trigger(
+            &mut self,
+            _ctx: &dyn ProcessContext,
+            session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            let ff = session.create();
+            self.count += 1;
+            session.transfer(ff, &REL_SUCCESS);
+            session.commit();
+            Ok(())
+        }
+
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS]
+        }
+    }
+
+    // Slow consumer that never processes anything (simulates back-pressure).
+    struct SlowConsumer;
+
+    impl Processor for SlowConsumer {
+        fn on_trigger(
+            &mut self,
+            _ctx: &dyn ProcessContext,
+            _session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            // Intentionally don't consume — just sleep.
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            Ok(())
+        }
+
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS]
+        }
+    }
+
+    let gen_id = engine.add_processor(
+        "fast-producer",
+        "Counter",
+        Box::new(CounterProcessor { count: 0 }),
+        SchedulingStrategy::TimerDriven { interval_ms: 10 },
+        HashMap::new(),
+    );
+
+    let consumer_id = engine.add_processor(
+        "slow-consumer",
+        "SlowConsumer",
+        Box::new(SlowConsumer),
+        SchedulingStrategy::EventDriven,
+        HashMap::new(),
+    );
+
+    engine.connect(gen_id, "success", consumer_id, config);
+
+    engine.start().await.unwrap();
+
+    // Let it run briefly.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // The connection queue should be at or near capacity.
+    {
+        let handle = engine.handle().unwrap();
+        let conns = handle.connections.read();
+        if let Some(conn) = conns.first() {
+            let count = conn.connection.queue_count();
+            // The queue should have some items (back-pressure is working).
+            assert!(
+                count <= 5,
+                "Queue should not exceed capacity (count={})",
+                count
+            );
+        }
+    }
+
+    engine.stop().await;
+}
+
+#[tokio::test]
+async fn event_driven_scheduling() {
+    let mut engine = make_engine();
+
+    struct CountingProcessor {
+        triggered: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    }
+
+    impl Processor for CountingProcessor {
+        fn on_trigger(
+            &mut self,
+            _ctx: &dyn ProcessContext,
+            session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            while let Some(ff) = session.get() {
+                self.triggered
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                session.transfer(ff, &REL_SUCCESS);
+            }
+            session.commit();
+            Ok(())
+        }
+
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS]
+        }
+    }
+
+    let trigger_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let trigger_count_clone = trigger_count.clone();
+
+    // Timer-driven producer.
+    let gen_id = engine.add_processor(
+        "producer",
+        "PassThrough",
+        Box::new(PassThroughProcessor),
+        SchedulingStrategy::TimerDriven { interval_ms: 50 },
+        HashMap::new(),
+    );
+
+    // Event-driven consumer.
+    let consumer_id = engine.add_processor(
+        "consumer",
+        "Counting",
+        Box::new(CountingProcessor {
+            triggered: trigger_count_clone,
+        }),
+        SchedulingStrategy::EventDriven,
+        HashMap::new(),
+    );
+
+    engine.connect(
+        gen_id,
+        "success",
+        consumer_id,
+        BackPressureConfig::default(),
+    );
+
+    engine.start().await.unwrap();
+
+    // The consumer should not trigger without input data.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let count = trigger_count.load(std::sync::atomic::Ordering::Relaxed);
+    // Event-driven processor only triggers when data arrives.
+    // Since the producer doesn't generate data (it's PassThrough with no input),
+    // the consumer should have 0 triggers.
+    assert_eq!(
+        count, 0,
+        "Event-driven processor should not trigger without input"
+    );
+
+    engine.stop().await;
+}
+
+// Register test processors so they're available via the registry in integration tests.
+inventory::submit!(ProcessorDescriptor {
+    type_name: "PanicTestProc",
+    description: "Always panics — integration test only",
+    factory: || Box::new(PanicProcessor),
+    tags: &[],
+});
+
+inventory::submit!(ProcessorDescriptor {
+    type_name: "ErrorTestProc",
+    description: "Always errors — integration test only",
+    factory: || Box::new(ErrorProcessor),
+    tags: &[],
+});
+
+inventory::submit!(ProcessorDescriptor {
+    type_name: "PassThroughTestProc",
+    description: "Pass-through — integration test only",
+    factory: || Box::new(PassThroughProcessor),
+    tags: &[],
+});

--- a/crates/runifi-plugin-api/src/flowfile.rs
+++ b/crates/runifi-plugin-api/src/flowfile.rs
@@ -68,3 +68,171 @@ impl FlowFile {
         self.penalized_until_nanos > now_nanos
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_flowfile(id: u64) -> FlowFile {
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    #[test]
+    fn creation_has_correct_defaults() {
+        let ff = make_flowfile(1);
+        assert_eq!(ff.id, 1);
+        assert!(ff.attributes.is_empty());
+        assert!(ff.content_claim.is_none());
+        assert_eq!(ff.size, 0);
+        assert_eq!(ff.lineage_start_id, 1);
+        assert_eq!(ff.penalized_until_nanos, 0);
+    }
+
+    #[test]
+    fn set_and_get_attribute() {
+        let mut ff = make_flowfile(1);
+        ff.set_attribute(Arc::from("filename"), Arc::from("test.txt"));
+        assert_eq!(ff.get_attribute("filename").unwrap().as_ref(), "test.txt");
+    }
+
+    #[test]
+    fn get_missing_attribute_returns_none() {
+        let ff = make_flowfile(1);
+        assert!(ff.get_attribute("nonexistent").is_none());
+    }
+
+    #[test]
+    fn set_attribute_overwrites_existing() {
+        let mut ff = make_flowfile(1);
+        ff.set_attribute(Arc::from("key"), Arc::from("value1"));
+        ff.set_attribute(Arc::from("key"), Arc::from("value2"));
+        assert_eq!(ff.get_attribute("key").unwrap().as_ref(), "value2");
+        assert_eq!(ff.attributes.len(), 1);
+    }
+
+    #[test]
+    fn remove_attribute_returns_value() {
+        let mut ff = make_flowfile(1);
+        ff.set_attribute(Arc::from("key"), Arc::from("value"));
+        let removed = ff.remove_attribute("key");
+        assert_eq!(removed.unwrap().as_ref(), "value");
+        assert!(ff.get_attribute("key").is_none());
+    }
+
+    #[test]
+    fn remove_missing_attribute_returns_none() {
+        let mut ff = make_flowfile(1);
+        assert!(ff.remove_attribute("nonexistent").is_none());
+    }
+
+    #[test]
+    fn multiple_attributes() {
+        let mut ff = make_flowfile(1);
+        ff.set_attribute(Arc::from("a"), Arc::from("1"));
+        ff.set_attribute(Arc::from("b"), Arc::from("2"));
+        ff.set_attribute(Arc::from("c"), Arc::from("3"));
+        assert_eq!(ff.attributes.len(), 3);
+        assert_eq!(ff.get_attribute("a").unwrap().as_ref(), "1");
+        assert_eq!(ff.get_attribute("b").unwrap().as_ref(), "2");
+        assert_eq!(ff.get_attribute("c").unwrap().as_ref(), "3");
+    }
+
+    #[test]
+    fn clone_preserves_all_fields() {
+        let mut ff = make_flowfile(1);
+        ff.size = 1024;
+        ff.created_at_nanos = 42;
+        ff.set_attribute(Arc::from("key"), Arc::from("value"));
+        ff.content_claim = Some(ContentClaim {
+            resource_id: 10,
+            offset: 0,
+            length: 1024,
+        });
+
+        let cloned = ff.clone();
+        assert_eq!(cloned.id, ff.id);
+        assert_eq!(cloned.size, ff.size);
+        assert_eq!(cloned.created_at_nanos, ff.created_at_nanos);
+        assert_eq!(cloned.lineage_start_id, ff.lineage_start_id);
+        assert_eq!(cloned.get_attribute("key").unwrap().as_ref(), "value");
+        assert_eq!(cloned.content_claim, ff.content_claim);
+    }
+
+    #[test]
+    fn clone_attribute_independence() {
+        let mut ff = make_flowfile(1);
+        ff.set_attribute(Arc::from("key"), Arc::from("original"));
+
+        let mut cloned = ff.clone();
+        cloned.set_attribute(Arc::from("key"), Arc::from("modified"));
+
+        // Original should be unchanged.
+        assert_eq!(ff.get_attribute("key").unwrap().as_ref(), "original");
+        assert_eq!(cloned.get_attribute("key").unwrap().as_ref(), "modified");
+    }
+
+    #[test]
+    fn is_penalized_returns_true_when_penalized() {
+        let mut ff = make_flowfile(1);
+        ff.penalized_until_nanos = 1000;
+        assert!(ff.is_penalized(500));
+        assert!(!ff.is_penalized(1000));
+        assert!(!ff.is_penalized(1500));
+    }
+
+    #[test]
+    fn content_claim_equality() {
+        let claim1 = ContentClaim {
+            resource_id: 1,
+            offset: 0,
+            length: 100,
+        };
+        let claim2 = ContentClaim {
+            resource_id: 1,
+            offset: 0,
+            length: 100,
+        };
+        let claim3 = ContentClaim {
+            resource_id: 2,
+            offset: 0,
+            length: 100,
+        };
+        assert_eq!(claim1, claim2);
+        assert_ne!(claim1, claim3);
+    }
+
+    #[test]
+    fn remove_attribute_with_swap_remove_preserves_others() {
+        let mut ff = make_flowfile(1);
+        ff.set_attribute(Arc::from("a"), Arc::from("1"));
+        ff.set_attribute(Arc::from("b"), Arc::from("2"));
+        ff.set_attribute(Arc::from("c"), Arc::from("3"));
+
+        ff.remove_attribute("a");
+        assert_eq!(ff.attributes.len(), 2);
+        // swap_remove moves the last element to the removed position
+        assert!(ff.get_attribute("b").is_some());
+        assert!(ff.get_attribute("c").is_some());
+    }
+
+    #[test]
+    fn arc_str_sharing() {
+        // Verify Arc<str> can be shared across FlowFiles for common keys.
+        let key: Arc<str> = Arc::from("filename");
+        let mut ff1 = make_flowfile(1);
+        let mut ff2 = make_flowfile(2);
+        ff1.set_attribute(key.clone(), Arc::from("file1.txt"));
+        ff2.set_attribute(key.clone(), Arc::from("file2.txt"));
+
+        // Both FlowFiles share the same key Arc.
+        assert!(Arc::ptr_eq(&ff1.attributes[0].0, &ff2.attributes[0].0));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #17

Adds comprehensive test infrastructure across the RuniFi codebase:

- **Unit tests** for FlowFile, CoreProcessSession, InMemoryContentRepository, FlowConnection, ProcessorSupervisor, and PluginRegistry
- **Integration tests** for engine lifecycle, DAG construction, fault tolerance (panic recovery, error circuit breaker), back-pressure enforcement, event-driven scheduling, and GenerateFlowFile end-to-end
- **Criterion benchmarks** for FlowFile operations, ContentRepository throughput, FlowConnection performance, and pipeline session latency

## Changes

### Unit Tests (in `#[cfg(test)]` modules)
- `flowfile.rs`: 13 tests (creation, attributes, clone, penalization, Arc sharing)
- `process_session.rs`: 16 tests (create, read/write, transfer, rollback, remove, penalize)
- `content_memory.rs`: 7 additional tests (empty content, unique IDs, slicing, concurrent, large content)
- `flow_connection.rs`: 8 additional tests (FIFO, bytes tracking, batch recv, snapshots)
- `supervisor.rs`: 6 additional tests (backoff cap, success reset, delegation, circuit state)
- `plugin_registry.rs`: 10 tests (discover, create unknown, tags, service types)

### Integration Tests (`crates/runifi-core/tests/`)
- `end_to_end_flow.rs`: 8 tests covering engine lifecycle, DAG construction, fault tolerance, back-pressure, and event-driven scheduling

### Criterion Benchmarks (`crates/runifi-core/benches/`)
- `flowfile_bench.rs`: FlowFile creation, attribute ops, clone, ID generation
- `content_repo_bench.rs`: create/read at various sizes, ref counting, zero-copy slice
- `connection_bench.rs`: send/recv cycles, batch operations, back-pressure checks
- `pipeline_bench.rs`: session lifecycle, content write, batch create, rollback

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes (490 tests, 0 failures)
- [x] `cargo bench --workspace -- --test` verifies all benchmarks compile and run
- [x] No production code modified — only test and benchmark files added