### PR TITLE
feat: implement Funnel and Label canvas components (#177)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ComponentToolbar.tsx
@@ -117,10 +117,19 @@ function ComponentToolbarInner({ plugins, loading, onDragStart, onAddProcessor }
         e.preventDefault();
         return;
       }
+      // Funnel opens the same add-processor dialog filtered to Funnel type
+      if (componentType === 'funnel') {
+        const funnelPlugin = plugins.find((p) => p.type_name === 'Funnel');
+        if (funnelPlugin) {
+          onAddProcessor?.(funnelPlugin);
+        }
+        e.preventDefault();
+        return;
+      }
       e.dataTransfer.effectAllowed = 'copy';
       e.dataTransfer.setData('application/runifi-component', componentType);
     },
-    [],
+    [plugins, onAddProcessor],
   );
 
   return (
@@ -130,10 +139,27 @@ function ComponentToolbarInner({ plugins, loading, onDragStart, onAddProcessor }
           <button
             key={ct.id}
             className="toolbar-item"
-            draggable={ct.id !== 'processor'}
+            draggable={ct.id !== 'processor' && ct.id !== 'funnel'}
             onDragStart={(e) => handleToolbarDrag(e, ct.id)}
-            onClick={ct.id === 'processor' ? () => setShowAddDialog(!showAddDialog) : undefined}
-            title={ct.id === 'processor' ? 'Click to add a processor' : `Drag to add ${ct.label}`}
+            onClick={
+              ct.id === 'processor'
+                ? () => setShowAddDialog(!showAddDialog)
+                : ct.id === 'funnel'
+                  ? () => {
+                      const fp = plugins.find((p) => p.type_name === 'Funnel');
+                      if (fp) onAddProcessor?.(fp);
+                    }
+                  : undefined
+            }
+            title={
+              ct.id === 'processor'
+                ? 'Click to add a processor'
+                : ct.id === 'funnel'
+                  ? 'Click to add a funnel'
+                  : ct.id === 'label'
+                    ? 'Drag to add a label'
+                    : `Drag to add ${ct.label}`
+            }
             aria-label={ct.label}
           >
             <span className="toolbar-item-icon" aria-hidden="true">

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -23,6 +23,8 @@ import {
 } from '@xyflow/react';
 
 import { ProcessorNode } from './ProcessorNode';
+import { FunnelNode } from './FunnelNode';
+import { LabelNode } from './LabelNode';
 import { ConnectionEdge } from './ConnectionEdge';
 import { AddProcessorModal } from './AddProcessorModal';
 import { ConnectionModal } from './ConnectionModal';
@@ -34,14 +36,21 @@ import { ColorPickerDialog } from './ColorPickerDialog';
 import { computeLayout } from '../utils/layout';
 import { stateColor } from '../utils/format';
 import type { FlowResponse, SseMetricsEvent, PluginDescriptor } from '../types/api';
-import type { ProcessorNodeData, ConnectionEdgeData } from '../types/flow';
+import type { ProcessorNodeData, ConnectionEdgeData, LabelNodeData } from '../types/flow';
 import type { ToastKind } from '../hooks/useToast';
 
 // Concrete node and edge types
 type ProcNode = Node<ProcessorNodeData, 'processorNode'>;
+type FunnelFlowNode = Node<ProcessorNodeData, 'funnelNode'>;
+type LabelFlowNode = Node<LabelNodeData, 'labelNode'>;
+type AnyNode = ProcNode | FunnelFlowNode | LabelFlowNode;
 type ConnEdge = Edge<ConnectionEdgeData, 'connectionEdge'>;
 
-const nodeTypes = { processorNode: ProcessorNode } as const;
+const nodeTypes = {
+  processorNode: ProcessorNode,
+  funnelNode: FunnelNode,
+  labelNode: LabelNode,
+} as const;
 const edgeTypes = { connectionEdge: ConnectionEdge } as const;
 
 const POSITION_DEBOUNCE_MS = 800;
@@ -132,13 +141,14 @@ function buildEdges(
 }
 
 function pluginForNode(
-  nodes: ProcNode[],
+  nodes: AnyNode[],
   nodeId: string,
   plugins: PluginDescriptor[],
 ): PluginDescriptor | null {
   const node = nodes.find((n) => n.id === nodeId);
-  if (!node) return null;
-  return plugins.find((p) => p.type_name === node.data.typeName) ?? null;
+  if (!node || node.type === 'labelNode') return null;
+  const procData = node.data as ProcessorNodeData;
+  return plugins.find((p) => p.type_name === procData.typeName) ?? null;
 }
 
 function FlowCanvasInner({
@@ -162,17 +172,43 @@ function FlowCanvasInner({
   const initialNodes = useMemo(
     () => {
       const colors = savedColorsRef.current;
-      return computeLayout(topology.processors, topology.connections).map((n) => ({
-        ...n,
+      const procNodes: AnyNode[] = computeLayout(topology.processors, topology.connections).map((n) => {
+        // Use funnelNode type for Funnel processors
+        const isFunnel = n.data.typeName === 'Funnel';
+        return {
+          ...n,
+          type: isFunnel ? ('funnelNode' as const) : ('processorNode' as const),
+          data: {
+            ...n.data,
+            relationships: plugins.find((p) => p.type_name === n.data.typeName)?.relationships ?? [
+              'success',
+            ],
+            pending: false,
+            customColor: colors[n.id] ?? '',
+          },
+        };
+      });
+
+      // Add label nodes from topology
+      const labelNodes: AnyNode[] = (topology.labels ?? []).map((lbl): LabelFlowNode => ({
+        id: `label-${lbl.id}`,
+        type: 'labelNode' as const,
+        position: { x: lbl.x, y: lbl.y },
         data: {
-          ...n.data,
-          relationships: plugins.find((p) => p.type_name === n.data.typeName)?.relationships ?? [
-            'success',
-          ],
+          labelId: lbl.id,
+          text: lbl.text,
+          width: lbl.width,
+          height: lbl.height,
+          backgroundColor: lbl.background_color,
+          fontSize: lbl.font_size,
           pending: false,
-          customColor: colors[n.id] ?? '',
         },
+        draggable: true,
+        selectable: true,
+        connectable: false,
       }));
+
+      return [...procNodes, ...labelNodes];
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [topology],
@@ -183,7 +219,7 @@ function FlowCanvasInner({
     [topology],
   );
 
-  const [nodes, setNodes, onNodesChange] = useNodesState<ProcNode>(initialNodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState<AnyNode>(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState<ConnEdge>(initialEdges);
 
   const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
@@ -205,18 +241,41 @@ function FlowCanvasInner({
     topologyKey.current = topology.name;
     const colors = loadSavedColors();
     savedColorsRef.current = colors;
-    const newNodes = computeLayout(topology.processors, topology.connections).map((n) => ({
-      ...n,
+    const procNodes: AnyNode[] = computeLayout(topology.processors, topology.connections).map((n) => {
+      const isFunnel = n.data.typeName === 'Funnel';
+      return {
+        ...n,
+        type: isFunnel ? ('funnelNode' as const) : ('processorNode' as const),
+        data: {
+          ...n.data,
+          relationships: plugins.find((p) => p.type_name === n.data.typeName)?.relationships ?? [
+            'success',
+          ],
+          pending: false,
+          customColor: colors[n.id] ?? '',
+        },
+      };
+    });
+
+    const labelNodes: AnyNode[] = (topology.labels ?? []).map((lbl): LabelFlowNode => ({
+      id: `label-${lbl.id}`,
+      type: 'labelNode' as const,
+      position: { x: lbl.x, y: lbl.y },
       data: {
-        ...n.data,
-        relationships: plugins.find((p) => p.type_name === n.data.typeName)?.relationships ?? [
-          'success',
-        ],
+        labelId: lbl.id,
+        text: lbl.text,
+        width: lbl.width,
+        height: lbl.height,
+        backgroundColor: lbl.background_color,
+        fontSize: lbl.font_size,
         pending: false,
-        customColor: colors[n.id] ?? '',
       },
+      draggable: true,
+      selectable: true,
+      connectable: false,
     }));
-    setNodes(newNodes);
+
+    setNodes([...procNodes, ...labelNodes]);
     setEdges(buildEdges(topology, liveMetrics, handleQueueClick));
   }, [topology, liveMetrics, setNodes, setEdges, plugins, handleQueueClick]);
 
@@ -228,15 +287,19 @@ function FlowCanvasInner({
 
     setNodes((prev) =>
       prev.map((node) => {
+        // Skip label nodes — they have no processor metrics
+        if (node.type === 'labelNode') return node;
+
+        const procData = node.data as ProcessorNodeData;
         const proc = procMap.get(node.id);
         if (!proc) return node;
 
         const bulletin = bulletinMap.get(node.id) ?? null;
 
         if (
-          node.data.state === proc.state &&
-          node.data.metrics?.total_invocations === proc.metrics.total_invocations &&
-          node.data.bulletin === bulletin
+          procData.state === proc.state &&
+          procData.metrics?.total_invocations === proc.metrics.total_invocations &&
+          procData.bulletin === bulletin
         ) {
           return node;
         }
@@ -244,7 +307,7 @@ function FlowCanvasInner({
         return {
           ...node,
           data: {
-            ...node.data,
+            ...procData,
             state: proc.state,
             metrics: proc.metrics,
             bulletin,
@@ -298,11 +361,22 @@ function FlowCanvasInner({
 
     const timer = setTimeout(() => {
       positionTimers.current.delete(nodeId);
-      fetch(`/api/v1/processors/${encodeURIComponent(nodeId)}/position`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ x, y }),
-      }).catch(() => {});
+
+      // Labels use a different API endpoint
+      if (nodeId.startsWith('label-')) {
+        const labelId = nodeId.slice('label-'.length);
+        fetch(`/api/v1/process-groups/root/labels/${encodeURIComponent(labelId)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ x, y }),
+        }).catch(() => {});
+      } else {
+        fetch(`/api/v1/processors/${encodeURIComponent(nodeId)}/position`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ x, y }),
+        }).catch(() => {});
+      }
     }, POSITION_DEBOUNCE_MS);
 
     positionTimers.current.set(nodeId, timer);
@@ -344,6 +418,91 @@ function FlowCanvasInner({
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
+
+      // Handle component drops (funnel, label) from toolbar
+      const componentType = e.dataTransfer.getData('application/runifi-component');
+      if (componentType) {
+        const position = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+
+        if (componentType === 'funnel') {
+          // Create a funnel processor via the existing processor API
+          const funnelPlugin = plugins.find((p) => p.type_name === 'Funnel');
+          if (funnelPlugin) {
+            setPendingDrop({ plugin: funnelPlugin, position });
+          } else {
+            onToast('error', 'Funnel processor type not found in plugins registry.');
+          }
+          return;
+        }
+
+        if (componentType === 'label') {
+          // Create a label directly (no name dialog needed)
+          const newLabel: LabelFlowNode = {
+            id: `label-pending-${Date.now()}`,
+            type: 'labelNode' as const,
+            position,
+            data: {
+              labelId: '',
+              text: '',
+              width: 200,
+              height: 60,
+              backgroundColor: 'rgba(255, 255, 200, 0.12)',
+              fontSize: 14,
+              pending: true,
+            },
+            draggable: true,
+            selectable: true,
+            connectable: false,
+          };
+
+          setNodes((prev) => [...prev, newLabel]);
+
+          fetch('/api/v1/process-groups/root/labels', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              text: '',
+              x: position.x,
+              y: position.y,
+              width: 200,
+              height: 60,
+              background_color: 'rgba(255, 255, 200, 0.12)',
+              font_size: 14,
+            }),
+          })
+            .then((res) => {
+              if (!res.ok) throw new Error(`HTTP ${res.status}`);
+              return res.json() as Promise<{ id: string }>;
+            })
+            .then((created) => {
+              setNodes((prev) =>
+                prev.map((n) =>
+                  n.id === newLabel.id
+                    ? {
+                        ...n,
+                        id: `label-${created.id}`,
+                        data: {
+                          ...(n.data as LabelNodeData),
+                          labelId: created.id,
+                          pending: false,
+                        },
+                      }
+                    : n,
+                ),
+              );
+              onToast('success', 'Label added to canvas.');
+            })
+            .catch((err: unknown) => {
+              const msg = err instanceof Error ? err.message : String(err);
+              onToast('error', `Failed to create label: ${msg}`);
+            });
+          return;
+        }
+
+        return;
+      }
+
+      // Handle plugin drops (processors) from the add dialog
       const typeName = e.dataTransfer.getData('application/runifi-plugin');
       if (!typeName) return;
 
@@ -353,7 +512,7 @@ function FlowCanvasInner({
       const position = screenToFlowPosition({ x: e.clientX, y: e.clientY });
       setPendingDrop({ plugin, position });
     },
-    [plugins, screenToFlowPosition],
+    [plugins, screenToFlowPosition, setNodes, onToast],
   );
 
   const handleAddProcessor = useCallback(
@@ -362,9 +521,10 @@ function FlowCanvasInner({
       const { plugin, position } = pendingDrop;
       setPendingDrop(null);
 
-      const newNode: ProcNode = {
+      const isFunnel = plugin.type_name === 'Funnel';
+      const newNode: AnyNode = {
         id: name,
-        type: 'processorNode' as const,
+        type: isFunnel ? ('funnelNode' as const) : ('processorNode' as const),
         position,
         data: {
           label: name,
@@ -500,11 +660,20 @@ function FlowCanvasInner({
       if (kind === 'node') {
         const node = nodes.find((n) => n.id === id);
         if (!node) return;
+
+        // Label nodes use 'text' for display, processor nodes use 'label'
+        const displayLabel = node.type === 'labelNode'
+          ? ((node.data as LabelNodeData).text || 'Label')
+          : (node.data as ProcessorNodeData).label;
+        const nodeState = node.type === 'labelNode'
+          ? 'stopped'
+          : (node.data as ProcessorNodeData).state;
+
         setDeleteTarget({
           kind: 'node',
           id,
-          label: node.data.label,
-          nodeState: node.data.state,
+          label: displayLabel,
+          nodeState,
         });
       } else {
         const edge = edges.find((e) => e.id === id);
@@ -546,6 +715,23 @@ function FlowCanvasInner({
 
     if (deleteTarget.kind === 'node') {
       const { id, nodeState } = deleteTarget;
+
+      // Handle label deletion
+      if (id.startsWith('label-')) {
+        const labelId = id.slice('label-'.length);
+        setNodes((prev) => prev.filter((n) => n.id !== id));
+
+        fetch(`/api/v1/process-groups/root/labels/${encodeURIComponent(labelId)}`, { method: 'DELETE' })
+          .then((res) => {
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            onToast('success', 'Label deleted.');
+          })
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            onToast('error', `Failed to delete label: ${msg}.`);
+          });
+        return;
+      }
 
       if (nodeState === 'running') {
         onToast('error', `Cannot delete running processor "${id}". Stop it first.`);
@@ -694,16 +880,19 @@ function FlowCanvasInner({
     [nodes, edges, initiateDelete, handleDeleteSelected, handleSelectAll],
   );
 
-  const handleNodeContextMenu: NodeMouseHandler<ProcNode> = useCallback(
+  const handleNodeContextMenu: NodeMouseHandler<AnyNode> = useCallback(
     (event, node) => {
       event.preventDefault();
       const selectedIds = nodes.filter((n) => n.selected).map((n) => n.id);
+      const nodeState = node.type === 'labelNode'
+        ? 'stopped'
+        : (node.data as ProcessorNodeData).state;
       setContextMenu({
         x: event.clientX,
         y: event.clientY,
         nodeId: node.id,
         edgeId: null,
-        nodeState: node.data.state,
+        nodeState,
         selectedNodeIds: selectedIds.length > 1 ? selectedIds : undefined,
       });
     },
@@ -750,8 +939,9 @@ function FlowCanvasInner({
     const nodeId = contextMenu.nodeId;
     const node = nodes.find((n) => n.id === nodeId);
     setContextMenu(null);
-    if (node) {
-      setConfigTarget({ name: node.id, state: node.data.state });
+    if (node && node.type !== 'labelNode') {
+      const procData = node.data as ProcessorNodeData;
+      setConfigTarget({ name: node.id, state: procData.state });
     }
   }, [contextMenu, nodes]);
 
@@ -760,10 +950,11 @@ function FlowCanvasInner({
     const nodeId = contextMenu.nodeId;
     const node = nodes.find((n) => n.id === nodeId);
     setContextMenu(null);
-    if (node) {
+    if (node && node.type !== 'labelNode') {
+      const procData = node.data as ProcessorNodeData;
       setColorPickerTarget({
         nodeId: node.id,
-        currentColor: node.data.customColor ?? '',
+        currentColor: procData.customColor ?? '',
       });
     }
   }, [contextMenu, nodes]);
@@ -804,17 +995,24 @@ function FlowCanvasInner({
     [colorPickerTarget, setNodes],
   );
 
-  const handleNodeDoubleClick: NodeMouseHandler<ProcNode> = useCallback(
+  const handleNodeDoubleClick: NodeMouseHandler<AnyNode> = useCallback(
     (_event, node) => {
-      setConfigTarget({ name: node.id, state: node.data.state });
+      // Labels handle their own double-click (inline editing), skip config modal
+      if (node.type === 'labelNode') return;
+      const procData = node.data as ProcessorNodeData;
+      setConfigTarget({ name: node.id, state: procData.state });
     },
     [],
   );
 
-  const nodeColor = useCallback((node: ProcNode): string => {
-    if (node.data?.pending) return 'var(--warning)';
-    if (node.data?.customColor) return String(node.data.customColor);
-    return stateColor(node.data?.state ?? 'stopped');
+  const nodeColor = useCallback((node: AnyNode): string => {
+    if (node.type === 'labelNode') {
+      return (node.data as LabelNodeData).backgroundColor || 'rgba(255, 255, 200, 0.4)';
+    }
+    const procData = node.data as ProcessorNodeData;
+    if (procData.pending) return 'var(--warning)';
+    if (procData.customColor) return String(procData.customColor);
+    return stateColor(procData.state ?? 'stopped');
   }, []);
 
   const existingNames = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes]);
@@ -862,7 +1060,7 @@ function FlowCanvasInner({
           showInteractive={false}
           style={{ background: 'var(--surface)', border: '1px solid var(--border)' }}
         />
-        <MiniMap<ProcNode>
+        <MiniMap<AnyNode>
           nodeColor={nodeColor}
           maskColor="rgba(15,17,23,0.7)"
           style={{
@@ -902,16 +1100,18 @@ function FlowCanvasInner({
         <ConfirmDialog
           title={
             deleteTarget.kind === 'multi'
-              ? 'Delete Selected Processors'
+              ? 'Delete Selected Items'
               : deleteTarget.kind === 'node'
-                ? 'Delete Processor'
+                ? (deleteTarget.id.startsWith('label-') ? 'Delete Label' : 'Delete Processor')
                 : 'Delete Connection'
           }
           message={
             deleteTarget.kind === 'multi'
-              ? `Delete ${deleteTarget.nodeIds?.length ?? 0} selected processors? This will also remove all their connections.`
+              ? `Delete ${deleteTarget.nodeIds?.length ?? 0} selected items? This will also remove all their connections.`
               : deleteTarget.kind === 'node'
-                ? `Delete processor "${deleteTarget.label}"? This will also remove all its connections.`
+                ? (deleteTarget.id.startsWith('label-')
+                    ? `Delete label "${deleteTarget.label}"?`
+                    : `Delete processor "${deleteTarget.label}"? This will also remove all its connections.`)
                 : `Delete connection ${deleteTarget.label}?`
           }
           confirmLabel="Delete"
@@ -921,45 +1121,49 @@ function FlowCanvasInner({
         />
       )}
 
-      {contextMenu && (
-        <ContextMenu
-          menu={contextMenu}
-          onDelete={handleContextDelete}
-          onConfigure={contextMenu.nodeId ? handleContextConfigure : undefined}
-          onStart={
-            contextMenu.nodeId
-              ? () => controlProcessor(contextMenu.nodeId!, 'start')
-              : undefined
-          }
-          onStop={
-            contextMenu.nodeId
-              ? () => controlProcessor(contextMenu.nodeId!, 'stop')
-              : undefined
-          }
-          onPause={
-            contextMenu.nodeId
-              ? () => controlProcessor(contextMenu.nodeId!, 'pause')
-              : undefined
-          }
-          onResume={
-            contextMenu.nodeId
-              ? () => controlProcessor(contextMenu.nodeId!, 'resume')
-              : undefined
-          }
-          onResetCircuit={
-            contextMenu.nodeId
-              ? () => controlProcessor(contextMenu.nodeId!, 'reset-circuit')
-              : undefined
-          }
-          onChangeColor={contextMenu.nodeId ? handleContextChangeColor : undefined}
-          onViewQueue={contextMenu.edgeId ? handleContextViewQueue : undefined}
-          onSelectAll={contextMenu.isCanvas ? handleSelectAll : undefined}
-          onStartSelected={handleStartSelected}
-          onStopSelected={handleStopSelected}
-          onDeleteSelected={handleDeleteSelected}
-          onClose={() => setContextMenu(null)}
-        />
-      )}
+      {contextMenu && (() => {
+        const isLabelCtx = contextMenu.nodeId?.startsWith('label-');
+        const isProcessorCtx = contextMenu.nodeId && !isLabelCtx;
+        return (
+          <ContextMenu
+            menu={contextMenu}
+            onDelete={handleContextDelete}
+            onConfigure={isProcessorCtx ? handleContextConfigure : undefined}
+            onStart={
+              isProcessorCtx
+                ? () => controlProcessor(contextMenu.nodeId!, 'start')
+                : undefined
+            }
+            onStop={
+              isProcessorCtx
+                ? () => controlProcessor(contextMenu.nodeId!, 'stop')
+                : undefined
+            }
+            onPause={
+              isProcessorCtx
+                ? () => controlProcessor(contextMenu.nodeId!, 'pause')
+                : undefined
+            }
+            onResume={
+              isProcessorCtx
+                ? () => controlProcessor(contextMenu.nodeId!, 'resume')
+                : undefined
+            }
+            onResetCircuit={
+              isProcessorCtx
+                ? () => controlProcessor(contextMenu.nodeId!, 'reset-circuit')
+                : undefined
+            }
+            onChangeColor={isProcessorCtx ? handleContextChangeColor : undefined}
+            onViewQueue={contextMenu.edgeId ? handleContextViewQueue : undefined}
+            onSelectAll={contextMenu.isCanvas ? handleSelectAll : undefined}
+            onStartSelected={handleStartSelected}
+            onStopSelected={handleStopSelected}
+            onDeleteSelected={handleDeleteSelected}
+            onClose={() => setContextMenu(null)}
+          />
+        );
+      })()}
 
       {configTarget && (
         <ProcessorConfigModal

--- a/crates/runifi-api/dashboard-react/src/components/FunnelNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FunnelNode.tsx
@@ -1,0 +1,68 @@
+import { memo } from 'react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
+import type { ProcessorNodeData } from '../types/flow';
+
+/**
+ * FunnelNode renders a NiFi-style funnel on the canvas.
+ * Funnels are backed by a regular Funnel processor on the engine side,
+ * but rendered with a distinctive trapezoid/funnel shape instead of
+ * the standard processor box.
+ */
+export type FunnelNodeType = Node<ProcessorNodeData, 'funnelNode'>;
+
+function FunnelNodeInner({ data }: NodeProps<FunnelNodeType>) {
+  const { label, state, pending } = data;
+
+  const stateClass = pending ? 'pending' : state;
+
+  return (
+    <div
+      className={`funnel-node funnel-state-${stateClass}`}
+      role="article"
+      aria-label={`Funnel ${label}${pending ? ' (pending)' : ''}`}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        id="target"
+        className="funnel-handle-target"
+      />
+
+      {/* NiFi-style center connection handle */}
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="center-source"
+        className="center-connect-handle"
+      />
+
+      {/* Funnel SVG shape */}
+      <svg
+        className="funnel-shape"
+        viewBox="0 0 60 60"
+        width="60"
+        height="60"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5 10 L55 10 L40 50 L20 50 Z"
+          className="funnel-path"
+        />
+      </svg>
+
+      <span className="funnel-label" title={label}>{label}</span>
+
+      {/* Hidden per-relationship handle for edge anchoring */}
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="success"
+        className="edge-anchor-handle"
+        style={{ bottom: 0 }}
+      />
+    </div>
+  );
+}
+
+export const FunnelNode = memo(FunnelNodeInner);

--- a/crates/runifi-api/dashboard-react/src/components/LabelNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/LabelNode.tsx
@@ -1,0 +1,88 @@
+import { memo, useState, useCallback, useRef, useEffect } from 'react';
+import { type Node, type NodeProps } from '@xyflow/react';
+import type { LabelNodeData } from '../types/flow';
+
+export type LabelNodeType = Node<LabelNodeData, 'labelNode'>;
+
+function LabelNodeInner({ data }: NodeProps<LabelNodeType>) {
+  const { labelId, text, width, height, backgroundColor, fontSize, pending } = data;
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState(text);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, [editing]);
+
+  const handleDoubleClick = useCallback(() => {
+    setEditText(text);
+    setEditing(true);
+  }, [text]);
+
+  const handleSave = useCallback(() => {
+    setEditing(false);
+    const trimmed = editText.trim();
+    if (trimmed === text) return;
+
+    // Persist the text change to the backend
+    fetch(`/api/v1/process-groups/root/labels/${encodeURIComponent(labelId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: trimmed }),
+    }).catch(() => {});
+  }, [editText, text, labelId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setEditing(false);
+        setEditText(text);
+      }
+      // Shift+Enter for newlines, Enter alone to save
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSave();
+      }
+    },
+    [text, handleSave],
+  );
+
+  const bgColor = backgroundColor || 'rgba(255, 255, 200, 0.12)';
+  const fSize = fontSize || 14;
+
+  return (
+    <div
+      className={`label-node${pending ? ' label-node-pending' : ''}`}
+      style={{
+        width: `${width || 200}px`,
+        minHeight: `${height || 60}px`,
+        backgroundColor: bgColor,
+        fontSize: `${fSize}px`,
+      }}
+      onDoubleClick={handleDoubleClick}
+      role="article"
+      aria-label={`Label: ${text || 'empty'}${pending ? ' (pending)' : ''}`}
+    >
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          className="label-node-editor"
+          value={editText}
+          onChange={(e) => setEditText(e.target.value)}
+          onBlur={handleSave}
+          onKeyDown={handleKeyDown}
+          style={{ fontSize: `${fSize}px` }}
+        />
+      ) : (
+        <div className="label-node-text">
+          {text || 'Double-click to edit'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const LabelNode = memo(LabelNodeInner);

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -1820,6 +1820,149 @@ body {
   color: var(--text-dim);
 }
 
+/* ── Funnel node ────────────────────────────────────────────── */
+
+.funnel-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 80px;
+  cursor: default;
+  position: relative;
+}
+
+.funnel-shape {
+  flex-shrink: 0;
+}
+
+.funnel-path {
+  fill: var(--bg);
+  stroke: var(--border);
+  stroke-width: 2;
+  transition: stroke 0.2s, fill 0.2s;
+}
+
+.funnel-node:hover .funnel-path {
+  stroke: var(--accent);
+}
+
+.funnel-state-running .funnel-path {
+  stroke: var(--success);
+  fill: rgba(52, 211, 153, 0.06);
+}
+
+.funnel-state-stopped .funnel-path {
+  stroke: var(--text-dim);
+}
+
+.funnel-state-paused .funnel-path {
+  stroke: var(--warning);
+  fill: rgba(251, 191, 36, 0.06);
+}
+
+.funnel-state-pending .funnel-path {
+  stroke: var(--warning);
+  opacity: 0.7;
+}
+
+.funnel-state-circuit-open .funnel-path {
+  stroke: var(--danger);
+  fill: rgba(248, 113, 113, 0.08);
+}
+
+.funnel-label {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 80px;
+  text-align: center;
+}
+
+.funnel-handle-target {
+  top: 0 !important;
+}
+
+/* NiFi-style center connection handle for funnel nodes */
+.funnel-node .react-flow__handle.center-connect-handle {
+  width: 24px !important;
+  height: 24px !important;
+  bottom: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, 50%) !important;
+  background: transparent !important;
+  border: none !important;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10;
+  transition: opacity 0.15s;
+  border-radius: 50% !important;
+}
+
+.funnel-node:hover .react-flow__handle.center-connect-handle {
+  opacity: 1;
+  pointer-events: all;
+  background: rgba(79, 143, 247, 0.15) !important;
+  border: 2px solid var(--accent) !important;
+}
+
+.funnel-node:hover .react-flow__handle.center-connect-handle:hover {
+  background: rgba(79, 143, 247, 0.3) !important;
+  box-shadow: 0 0 8px rgba(79, 143, 247, 0.4);
+  cursor: crosshair;
+}
+
+/* ── Label node ─────────────────────────────────────────────── */
+
+.label-node {
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-family: var(--font);
+  cursor: default;
+  min-width: 100px;
+  min-height: 40px;
+  transition: border-color 0.2s;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.label-node:hover {
+  border-color: var(--accent);
+  border-style: solid;
+}
+
+.label-node-pending {
+  opacity: 0.7;
+}
+
+.label-node-text {
+  color: var(--text);
+  line-height: 1.4;
+  user-select: none;
+}
+
+.label-node-text:empty::before,
+.label-node-text:only-child:not(:empty)::before {
+  content: none;
+}
+
+.label-node-editor {
+  width: 100%;
+  height: 100%;
+  min-height: 40px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-family: var(--font);
+  line-height: 1.4;
+  resize: none;
+  outline: none;
+  padding: 0;
+}
+
 /* ── Responsive ─────────────────────────────────────────────── */
 
 @media (max-width: 768px) {

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -55,10 +55,22 @@ export interface FlowEdgeResponse {
   destination: string;
 }
 
+export interface FlowLabelResponse {
+  id: string;
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  background_color: string;
+  font_size: number;
+}
+
 export interface FlowResponse {
   name: string;
   processors: FlowNodeResponse[];
   connections: FlowEdgeResponse[];
+  labels?: FlowLabelResponse[];
 }
 
 export interface BulletinResponse {

--- a/crates/runifi-api/dashboard-react/src/types/flow.ts
+++ b/crates/runifi-api/dashboard-react/src/types/flow.ts
@@ -17,6 +17,16 @@ export interface ProcessorNodeData extends Record<string, unknown> {
   customColor: string;
 }
 
+export interface LabelNodeData extends Record<string, unknown> {
+  labelId: string;
+  text: string;
+  width: number;
+  height: number;
+  backgroundColor: string;
+  fontSize: number;
+  pending: boolean;
+}
+
 export interface ConnectionEdgeData extends Record<string, unknown> {
   relationship: string;
   queuedCount: number;

--- a/crates/runifi-api/dashboard-react/src/utils/layout.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/layout.ts
@@ -4,7 +4,7 @@ import type { Node } from '@xyflow/react';
 import type { FlowEdgeResponse, FlowNodeResponse } from '../types/api';
 import type { ProcessorNodeData } from '../types/flow';
 
-export type ProcNode = Node<ProcessorNodeData, 'processorNode'>;
+export type LayoutNode = Node<ProcessorNodeData>;
 
 const NODE_WIDTH = 220;
 const NODE_HEIGHT = 120;
@@ -15,14 +15,15 @@ const PADDING_Y = 60;
 
 /**
  * Compute layered positions for React Flow nodes using Kahn's topological
- * sort. Returns fully formed ProcNode objects ready for React Flow.
+ * sort. Returns fully formed node objects ready for React Flow.
+ * Funnel processors receive the 'funnelNode' type for distinct rendering.
  * The `relationships` and `pending` fields are set to defaults here and
  * overridden by the caller once the plugin list is available.
  */
 export function computeLayout(
   processors: FlowNodeResponse[],
   connections: FlowEdgeResponse[],
-): ProcNode[] {
+): LayoutNode[] {
   const names = processors.map((p) => p.name);
   const nameSet = new Set(names);
 
@@ -86,10 +87,10 @@ export function computeLayout(
     }
   }
 
-  // Build React Flow ProcNode objects
-  return processors.map((p): ProcNode => ({
+  // Build React Flow node objects — Funnel processors get a distinct type
+  return processors.map((p): LayoutNode => ({
     id: p.name,
-    type: 'processorNode' as const,
+    type: p.type_name === 'Funnel' ? 'funnelNode' : 'processorNode',
     position: positions.get(p.name) ?? { x: PADDING_X, y: PADDING_Y },
     data: {
       label: p.name,

--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -113,6 +113,21 @@ pub struct FlowResponse {
     pub name: String,
     pub processors: Vec<FlowNodeResponse>,
     pub connections: Vec<FlowEdgeResponse>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<FlowLabelResponse>,
+}
+
+/// A label in the flow topology response.
+#[derive(Serialize)]
+pub struct FlowLabelResponse {
+    pub id: String,
+    pub text: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub background_color: String,
+    pub font_size: f64,
 }
 
 #[derive(Serialize)]
@@ -442,4 +457,67 @@ pub struct CreateServiceRequest {
 #[derive(Deserialize)]
 pub struct UpdateServiceConfigRequest {
     pub properties: HashMap<String, String>,
+}
+
+// ── Label DTOs ────────────────────────────────────────────────────────
+
+/// Response for a canvas label.
+#[derive(Serialize)]
+pub struct LabelResponse {
+    pub id: String,
+    pub text: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub background_color: String,
+    pub font_size: f64,
+}
+
+/// Request body for `POST /api/v1/process-groups/root/labels`.
+#[derive(Deserialize)]
+pub struct CreateLabelRequest {
+    /// Label text content.
+    #[serde(default)]
+    pub text: String,
+    /// Canvas X position.
+    #[serde(default)]
+    pub x: f64,
+    /// Canvas Y position.
+    #[serde(default)]
+    pub y: f64,
+    /// Label width in pixels.
+    #[serde(default = "default_label_width")]
+    pub width: f64,
+    /// Label height in pixels.
+    #[serde(default = "default_label_height")]
+    pub height: f64,
+    /// Background colour (CSS hex string).
+    #[serde(default)]
+    pub background_color: String,
+    /// Font size in pixels.
+    #[serde(default = "default_font_size")]
+    pub font_size: f64,
+}
+
+fn default_label_width() -> f64 {
+    150.0
+}
+fn default_label_height() -> f64 {
+    40.0
+}
+fn default_font_size() -> f64 {
+    14.0
+}
+
+/// Request body for `PUT /api/v1/process-groups/root/labels/{id}`.
+#[derive(Deserialize)]
+pub struct UpdateLabelRequest {
+    pub text: Option<String>,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub background_color: Option<String>,
+    pub font_size: Option<f64>,
 }

--- a/crates/runifi-api/src/lib.rs
+++ b/crates/runifi-api/src/lib.rs
@@ -84,6 +84,7 @@ pub fn create_router_with_registry(
         .merge(routes::auth_routes::routes())
         .merge(routes::users::routes())
         .merge(routes::user_groups::routes())
+        .merge(routes::labels::routes())
         .merge(dashboard::routes())
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/crates/runifi-api/src/routes/flow.rs
+++ b/crates/runifi-api/src/routes/flow.rs
@@ -2,7 +2,9 @@ use axum::extract::State;
 use axum::routing::get;
 use axum::{Json, Router, middleware};
 
-use crate::dto::{FlowEdgeResponse, FlowNodeResponse, FlowResponse, PositionResponse};
+use crate::dto::{
+    FlowEdgeResponse, FlowLabelResponse, FlowNodeResponse, FlowResponse, PositionResponse,
+};
 use crate::rbac;
 use crate::state::ApiState;
 
@@ -40,9 +42,25 @@ async fn get_flow(State(state): State<ApiState>) -> Json<FlowResponse> {
         })
         .collect();
 
+    let labels: Vec<FlowLabelResponse> = handle
+        .list_labels()
+        .into_iter()
+        .map(|l| FlowLabelResponse {
+            id: l.id,
+            text: l.text,
+            x: l.x,
+            y: l.y,
+            width: l.width,
+            height: l.height,
+            background_color: l.background_color,
+            font_size: l.font_size,
+        })
+        .collect();
+
     Json(FlowResponse {
         name: handle.flow_name.clone(),
         processors,
         connections,
+        labels,
     })
 }

--- a/crates/runifi-api/src/routes/labels.rs
+++ b/crates/runifi-api/src/routes/labels.rs
@@ -1,0 +1,122 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{delete as delete_method, get, post, put};
+use axum::{Json, Router, middleware};
+
+use runifi_core::engine::handle::{LabelInfo, LabelUpdate, next_label_id};
+
+use crate::dto::{CreateLabelRequest, LabelResponse, UpdateLabelRequest};
+use crate::error::ApiError;
+use crate::rbac;
+use crate::state::ApiState;
+
+pub fn routes() -> Router<ApiState> {
+    // GET endpoints — ViewFlow (Viewer+)
+    let view_routes = Router::new()
+        .route("/api/v1/process-groups/root/labels", get(list_labels))
+        .route("/api/v1/process-groups/root/labels/{id}", get(get_label))
+        .layer(middleware::from_fn(rbac::require_view_flow));
+
+    // Mutation endpoints — ModifyFlow (Admin only)
+    let modify_routes = Router::new()
+        .route("/api/v1/process-groups/root/labels", post(create_label))
+        .route("/api/v1/process-groups/root/labels/{id}", put(update_label))
+        .route(
+            "/api/v1/process-groups/root/labels/{id}",
+            delete_method(delete_label),
+        )
+        .layer(middleware::from_fn(rbac::require_modify_flow));
+
+    view_routes.merge(modify_routes)
+}
+
+fn label_to_response(label: &LabelInfo) -> LabelResponse {
+    LabelResponse {
+        id: label.id.clone(),
+        text: label.text.clone(),
+        x: label.x,
+        y: label.y,
+        width: label.width,
+        height: label.height,
+        background_color: label.background_color.clone(),
+        font_size: label.font_size,
+    }
+}
+
+async fn list_labels(State(state): State<ApiState>) -> Json<Vec<LabelResponse>> {
+    let labels = state.handle.list_labels();
+    Json(labels.iter().map(label_to_response).collect())
+}
+
+async fn get_label(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<LabelResponse>, ApiError> {
+    let label = state
+        .handle
+        .get_label(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Label not found: {}", id)))?;
+
+    Ok(Json(label_to_response(&label)))
+}
+
+async fn create_label(
+    State(state): State<ApiState>,
+    Json(body): Json<CreateLabelRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let label = LabelInfo {
+        id: next_label_id(),
+        text: body.text,
+        x: body.x,
+        y: body.y,
+        width: body.width,
+        height: body.height,
+        background_color: body.background_color,
+        font_size: body.font_size,
+    };
+
+    let response = label_to_response(&label);
+
+    state.handle.add_label(label).map_err(ApiError::Conflict)?;
+
+    Ok((StatusCode::CREATED, Json(response)).into_response())
+}
+
+async fn update_label(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateLabelRequest>,
+) -> Result<Json<LabelResponse>, ApiError> {
+    let update = LabelUpdate {
+        text: body.text,
+        x: body.x,
+        y: body.y,
+        width: body.width,
+        height: body.height,
+        background_color: body.background_color,
+        font_size: body.font_size,
+    };
+
+    if !state.handle.update_label(&id, update) {
+        return Err(ApiError::BadRequest(format!("Label not found: {}", id)));
+    }
+
+    let label = state
+        .handle
+        .get_label(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Label not found: {}", id)))?;
+
+    Ok(Json(label_to_response(&label)))
+}
+
+async fn delete_label(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    if !state.handle.remove_label(&id) {
+        return Err(ApiError::BadRequest(format!("Label not found: {}", id)));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/runifi-api/src/routes/mod.rs
+++ b/crates/runifi-api/src/routes/mod.rs
@@ -3,6 +3,7 @@ pub mod bulletins;
 pub mod connections;
 pub mod events;
 pub mod flow;
+pub mod labels;
 pub mod plugins;
 pub mod processors;
 pub mod services;

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -408,6 +408,9 @@ impl FlowEngine {
         // Shared position store.
         let positions = Arc::new(DashMap::new());
 
+        // Shared label store.
+        let labels = Arc::new(RwLock::new(Vec::new()));
+
         // Build the EngineHandle.
         let engine_handle = EngineHandle {
             flow_name: self.flow_name.clone(),
@@ -420,6 +423,7 @@ impl FlowEngine {
             positions: positions.clone(),
             audit_logger: self.audit_logger.clone(),
             service_registry: self.service_registry.clone(),
+            labels: labels.clone(),
             mutation_tx,
             persistence: self.persistence.clone(),
         };
@@ -433,6 +437,7 @@ impl FlowEngine {
                 live_conns.clone(),
                 positions,
                 self.service_registry.clone(),
+                labels,
             );
             let persist_token = self.cancel_token.child_token();
             let persist_clone = persistence.clone();

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use dashmap::DashMap;
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use super::bulletin::BulletinBoard;
@@ -121,6 +123,53 @@ pub struct Position {
     pub y: f64,
 }
 
+/// A canvas label — text annotation with no data flow impact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabelInfo {
+    pub id: String,
+    pub text: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    /// CSS background colour (hex string, e.g. "#3b82f6").
+    #[serde(default)]
+    pub background_color: String,
+    /// Font size in pixels.
+    #[serde(default = "default_font_size")]
+    pub font_size: f64,
+}
+
+fn default_font_size() -> f64 {
+    14.0
+}
+
+/// Partial update for a canvas label. Only non-None fields are applied.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LabelUpdate {
+    pub text: Option<String>,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub background_color: Option<String>,
+    pub font_size: Option<f64>,
+}
+
+/// Auto-incrementing label ID generator.
+static LABEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Generate a unique label ID.
+pub fn next_label_id() -> String {
+    let id = LABEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("label-{}", id)
+}
+
+/// Reset the label ID counter to a specific value (used when restoring persisted state).
+pub fn reset_label_id_counter(next_id: u64) {
+    LABEL_ID_COUNTER.store(next_id, Ordering::Relaxed);
+}
+
 /// A Clone-able, Send+Sync handle for API queries and mutations against a running engine.
 ///
 /// Created by `FlowEngine::start()`. The processor and connection lists use
@@ -146,6 +195,8 @@ pub struct EngineHandle {
     pub audit_logger: Arc<dyn AuditLogger>,
     /// Controller service registry.
     pub service_registry: SharedServiceRegistry,
+    /// Canvas labels — text annotations, no data flow impact.
+    pub labels: Arc<RwLock<Vec<LabelInfo>>>,
     /// Sender half of the engine mutation command channel.
     pub(crate) mutation_tx: mpsc::Sender<MutationCommand>,
     /// Flow persistence layer (debounced background writer).
@@ -571,5 +622,75 @@ impl EngineHandle {
     /// Get info about a specific controller service.
     pub fn get_service_info(&self, name: &str) -> Option<ServiceInfo> {
         self.service_registry.read().get_service(name)
+    }
+
+    // ── Label management ────────────────────────────────────────────────
+
+    /// Add a canvas label. Returns an error if a label with the same ID exists.
+    pub fn add_label(&self, label: LabelInfo) -> Result<(), String> {
+        let mut labels = self.labels.write();
+        if labels.iter().any(|l| l.id == label.id) {
+            return Err(format!("Label already exists: {}", label.id));
+        }
+        labels.push(label);
+        drop(labels);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Update a canvas label. Applies all non-None fields. Returns false if not found.
+    pub fn update_label(&self, id: &str, update: LabelUpdate) -> bool {
+        let mut labels = self.labels.write();
+        if let Some(label) = labels.iter_mut().find(|l| l.id == id) {
+            if let Some(text) = update.text {
+                label.text = text;
+            }
+            if let Some(x) = update.x {
+                label.x = x;
+            }
+            if let Some(y) = update.y {
+                label.y = y;
+            }
+            if let Some(w) = update.width {
+                label.width = w;
+            }
+            if let Some(h) = update.height {
+                label.height = h;
+            }
+            if let Some(color) = update.background_color {
+                label.background_color = color;
+            }
+            if let Some(size) = update.font_size {
+                label.font_size = size;
+            }
+            drop(labels);
+            self.notify_persist();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove a canvas label by ID. Returns false if not found.
+    pub fn remove_label(&self, id: &str) -> bool {
+        let mut labels = self.labels.write();
+        let len_before = labels.len();
+        labels.retain(|l| l.id != id);
+        let removed = labels.len() < len_before;
+        drop(labels);
+        if removed {
+            self.notify_persist();
+        }
+        removed
+    }
+
+    /// Get a label by ID.
+    pub fn get_label(&self, id: &str) -> Option<LabelInfo> {
+        self.labels.read().iter().find(|l| l.id == id).cloned()
+    }
+
+    /// List all labels.
+    pub fn list_labels(&self) -> Vec<LabelInfo> {
+        self.labels.read().clone()
     }
 }

--- a/crates/runifi-core/src/engine/persistence.rs
+++ b/crates/runifi-core/src/engine/persistence.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
 
-use super::handle::{ConnectionInfo, Position, ProcessorInfo};
+use super::handle::{ConnectionInfo, LabelInfo, Position, ProcessorInfo};
 
 /// File names for persisted flow state.
 const FLOW_STATE_FILE: &str = "flow.json";
@@ -40,6 +40,8 @@ pub struct PersistedFlowState {
     pub positions: HashMap<String, PersistedPosition>,
     #[serde(default)]
     pub services: Vec<PersistedService>,
+    #[serde(default)]
+    pub labels: Vec<PersistedLabel>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,6 +91,34 @@ pub struct PersistedService {
     pub properties: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedLabel {
+    pub id: String,
+    pub text: String,
+    #[serde(default)]
+    pub x: f64,
+    #[serde(default)]
+    pub y: f64,
+    #[serde(default = "default_label_width")]
+    pub width: f64,
+    #[serde(default = "default_label_height")]
+    pub height: f64,
+    #[serde(default)]
+    pub background_color: String,
+    #[serde(default = "default_font_size")]
+    pub font_size: f64,
+}
+
+fn default_label_width() -> f64 {
+    150.0
+}
+fn default_label_height() -> f64 {
+    40.0
+}
+fn default_font_size() -> f64 {
+    14.0
+}
+
 // ── Snapshot source — breaks the Arc cycle ────────────────────────────────────
 
 /// The subset of engine state needed for persistence snapshotting.
@@ -102,6 +132,7 @@ pub(crate) struct SnapshotSource {
     pub connections: Arc<RwLock<Vec<ConnectionInfo>>>,
     pub positions: Arc<DashMap<String, Position>>,
     pub service_registry: crate::registry::service_registry::SharedServiceRegistry,
+    pub labels: Arc<RwLock<Vec<LabelInfo>>>,
 }
 
 // ── Snapshot from live engine state ───────────────────────────────────────────
@@ -162,6 +193,22 @@ impl PersistedFlowState {
             })
             .collect();
 
+        let labels: Vec<PersistedLabel> = source
+            .labels
+            .read()
+            .iter()
+            .map(|l| PersistedLabel {
+                id: l.id.clone(),
+                text: l.text.clone(),
+                x: l.x,
+                y: l.y,
+                width: l.width,
+                height: l.height,
+                background_color: l.background_color.clone(),
+                font_size: l.font_size,
+            })
+            .collect();
+
         Self {
             version: CURRENT_VERSION,
             flow_name: source.flow_name.clone(),
@@ -169,6 +216,7 @@ impl PersistedFlowState {
             connections,
             positions,
             services,
+            labels,
         }
     }
 }
@@ -320,6 +368,7 @@ impl FlowPersistence {
         connections: Arc<RwLock<Vec<ConnectionInfo>>>,
         positions: Arc<DashMap<String, Position>>,
         service_registry: crate::registry::service_registry::SharedServiceRegistry,
+        labels: Arc<RwLock<Vec<LabelInfo>>>,
     ) {
         *self.inner.source.write() = Some(SnapshotSource {
             flow_name,
@@ -327,6 +376,7 @@ impl FlowPersistence {
             connections,
             positions,
             service_registry,
+            labels,
         });
     }
 
@@ -423,6 +473,7 @@ mod tests {
             connections: vec![],
             positions: HashMap::new(),
             services: vec![],
+            labels: vec![],
         }
     }
 
@@ -468,6 +519,16 @@ mod tests {
                 name: "my-cache".to_string(),
                 type_name: "DistributedMapCacheServer".to_string(),
                 properties: HashMap::from([("Port".to_string(), "4557".to_string())]),
+            }],
+            labels: vec![PersistedLabel {
+                id: "label-1".to_string(),
+                text: "Test Label".to_string(),
+                x: 50.0,
+                y: 100.0,
+                width: 200.0,
+                height: 50.0,
+                background_color: "#3b82f6".to_string(),
+                font_size: 14.0,
             }],
         };
 
@@ -518,6 +579,7 @@ mod tests {
             connections: vec![],
             positions: HashMap::new(),
             services: vec![],
+            labels: vec![],
         };
         atomic_write(&conf_dir, &state2).unwrap();
 
@@ -616,6 +678,7 @@ mod tests {
             connections: vec![],
             positions: HashMap::new(),
             services: vec![],
+            labels: vec![],
         };
 
         atomic_write(&conf_dir, &state).unwrap();
@@ -656,12 +719,14 @@ mod tests {
         let connections = Arc::new(RwLock::new(Vec::new()));
         let positions = Arc::new(DashMap::new());
         let service_registry = crate::registry::service_registry::SharedServiceRegistry::new();
+        let labels = Arc::new(RwLock::new(Vec::new()));
         persistence.set_source(
             "debounce-test".to_string(),
             processors,
             connections,
             positions,
             service_registry,
+            labels,
         );
 
         let cancel = tokio_util::sync::CancellationToken::new();

--- a/crates/runifi-processors/src/funnel.rs
+++ b/crates/runifi-processors/src/funnel.rs
@@ -1,0 +1,192 @@
+use runifi_plugin_api::REL_SUCCESS;
+use runifi_plugin_api::context::ProcessContext;
+use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::property::PropertyDescriptor;
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::ProcessResult;
+use runifi_plugin_api::session::ProcessSession;
+
+/// A Funnel merges multiple incoming connections into a single output.
+///
+/// It acts as a pass-through: all FlowFiles received on any input connection
+/// are forwarded to the "success" relationship. Funnels have no configurable
+/// properties and are useful for combining flows from several sources before
+/// routing to a single destination.
+pub struct Funnel;
+
+impl Default for Funnel {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl Processor for Funnel {
+    fn on_trigger(
+        &mut self,
+        _context: &dyn ProcessContext,
+        session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        // Forward all available FlowFiles to success.
+        let batch = session.get_batch(256);
+        if batch.is_empty() {
+            // Nothing to do — yield back to scheduler.
+            return Ok(());
+        }
+
+        for flowfile in batch {
+            session.transfer(flowfile, &REL_SUCCESS);
+        }
+
+        session.commit();
+        Ok(())
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS]
+    }
+
+    fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
+        vec![]
+    }
+}
+
+inventory::submit! {
+    ProcessorDescriptor {
+        type_name: "Funnel",
+        description: "Merges multiple incoming connections into a single output",
+        factory: || Box::new(Funnel),
+        tags: &["Flow Control"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use runifi_plugin_api::property::PropertyValue;
+
+    struct TestContext;
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, _name: &str) -> PropertyValue {
+            PropertyValue::Unset
+        }
+        fn name(&self) -> &str {
+            "test-funnel"
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    struct CollectorSession {
+        pending: Vec<runifi_plugin_api::FlowFile>,
+        transferred: Vec<(runifi_plugin_api::FlowFile, &'static str)>,
+        committed: bool,
+    }
+
+    impl CollectorSession {
+        fn with_flowfiles(count: usize) -> Self {
+            let pending = (1..=count as u64)
+                .map(|id| runifi_plugin_api::FlowFile {
+                    id,
+                    attributes: Vec::new(),
+                    content_claim: None,
+                    size: 100,
+                    created_at_nanos: 0,
+                    lineage_start_id: id,
+                    penalized_until_nanos: 0,
+                })
+                .collect();
+            Self {
+                pending,
+                transferred: Vec::new(),
+                committed: false,
+            }
+        }
+    }
+
+    impl ProcessSession for CollectorSession {
+        fn get(&mut self) -> Option<runifi_plugin_api::FlowFile> {
+            self.pending.pop()
+        }
+        fn get_batch(&mut self, max: usize) -> Vec<runifi_plugin_api::FlowFile> {
+            let count = max.min(self.pending.len());
+            self.pending.drain(..count).collect()
+        }
+        fn read_content(&self, _ff: &runifi_plugin_api::FlowFile) -> ProcessResult<Bytes> {
+            Ok(Bytes::new())
+        }
+        fn write_content(
+            &mut self,
+            ff: runifi_plugin_api::FlowFile,
+            _data: Bytes,
+        ) -> ProcessResult<runifi_plugin_api::FlowFile> {
+            Ok(ff)
+        }
+        fn create(&mut self) -> runifi_plugin_api::FlowFile {
+            unimplemented!()
+        }
+        fn clone_flowfile(
+            &mut self,
+            _ff: &runifi_plugin_api::FlowFile,
+        ) -> runifi_plugin_api::FlowFile {
+            unimplemented!()
+        }
+        fn transfer(&mut self, ff: runifi_plugin_api::FlowFile, rel: &Relationship) {
+            self.transferred.push((ff, rel.name));
+        }
+        fn remove(&mut self, _ff: runifi_plugin_api::FlowFile) {}
+        fn penalize(&mut self, ff: runifi_plugin_api::FlowFile) -> runifi_plugin_api::FlowFile {
+            ff
+        }
+        fn commit(&mut self) {
+            self.committed = true;
+        }
+        fn rollback(&mut self) {}
+    }
+
+    #[test]
+    fn funnel_forwards_all_flowfiles() {
+        let mut funnel = Funnel;
+        let ctx = TestContext;
+        let mut session = CollectorSession::with_flowfiles(5);
+
+        funnel.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 5);
+        for (_, rel) in &session.transferred {
+            assert_eq!(*rel, "success");
+        }
+        assert!(session.committed);
+    }
+
+    #[test]
+    fn funnel_noop_on_empty_input() {
+        let mut funnel = Funnel;
+        let ctx = TestContext;
+        let mut session = CollectorSession::with_flowfiles(0);
+
+        funnel.on_trigger(&ctx, &mut session).unwrap();
+
+        assert!(session.transferred.is_empty());
+        assert!(!session.committed);
+    }
+
+    #[test]
+    fn funnel_has_no_properties() {
+        let funnel = Funnel;
+        assert!(funnel.property_descriptors().is_empty());
+    }
+
+    #[test]
+    fn funnel_has_success_relationship() {
+        let funnel = Funnel;
+        let rels = funnel.relationships();
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].name, "success");
+    }
+}

--- a/crates/runifi-processors/src/lib.rs
+++ b/crates/runifi-processors/src/lib.rs
@@ -26,4 +26,6 @@ pub mod validate_json;
 #[cfg(feature = "extraction")]
 pub mod extract_text;
 
+pub mod funnel;
+
 pub mod distributed_map_cache;

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -324,13 +324,40 @@ async fn main() -> Result<()> {
     engine.start().await.context("Failed to start engine")?;
     tracing::info!("Flow engine is running");
 
-    // Restore positions from persisted state. Uses restore_position() to
-    // avoid triggering an unnecessary persist of the state just loaded.
+    // Restore positions and labels from persisted state. Uses restore_position()
+    // to avoid triggering an unnecessary persist of the state just loaded.
     if let Some(ref state) = runtime_flow
         && let Some(handle) = engine.handle()
     {
         for (name, pos) in &state.positions {
             handle.restore_position(name, pos.x, pos.y);
+        }
+        // Restore labels directly into the shared labels vec (no persist trigger).
+        {
+            let mut labels = handle.labels.write();
+            let mut max_label_id: u64 = 0;
+            for pl in &state.labels {
+                // Extract numeric suffix from "label-N" for counter reset.
+                if let Some(suffix) = pl.id.strip_prefix("label-")
+                    && let Ok(n) = suffix.parse::<u64>()
+                {
+                    max_label_id = max_label_id.max(n);
+                }
+                labels.push(runifi_core::engine::handle::LabelInfo {
+                    id: pl.id.clone(),
+                    text: pl.text.clone(),
+                    x: pl.x,
+                    y: pl.y,
+                    width: pl.width,
+                    height: pl.height,
+                    background_color: pl.background_color.clone(),
+                    font_size: pl.font_size,
+                });
+            }
+            // Reset the label ID counter so new labels don't collide.
+            if max_label_id > 0 {
+                runifi_core::engine::handle::reset_label_id_counter(max_label_id + 1);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Implements Funnel and Label canvas components from issue #177 (scoped — Ports, Process Group, and Remote Process Group are excluded).

### Funnel
- **Engine**: Funnel processor (`crates/runifi-processors/src/funnel.rs`) — pass-through processor that forwards all incoming FlowFiles to `success` relationship via batch processing (256 at a time). Registered via `inventory::submit!` with type_name `Funnel` and tag `Flow Control`.
- **Dashboard**: `FunnelNode` React Flow component renders a NiFi-style trapezoid/funnel SVG shape with state-based coloring (running=green, stopped=gray, paused=yellow, circuit-open=red). Supports connection handles for wiring.
- **Toolbar**: Click or drag the Funnel toolbar button to create a Funnel processor (opens the standard name dialog).

### Label
- **Engine**: Label storage in `EngineHandle` with `LabelInfo` struct (id, text, position, dimensions, background color, font size). Full CRUD: `add_label`, `get_label`, `list_labels`, `update_label`, `remove_label`. Atomic label ID generation.
- **API**: Full CRUD REST endpoints at `/api/v1/process-groups/root/labels` with RBAC (ViewFlow for reads, ModifyFlow for mutations). Integrated into flow topology response (`GET /api/v1/flow` now includes labels).
- **Persistence**: Labels are included in `PersistedFlowState` snapshots and restored on server startup with full metadata.
- **Dashboard**: `LabelNode` React Flow component — editable text box with configurable background color and font size. Double-click to enter inline editing mode, Enter to save, Escape to cancel. Draggable with position persistence via the labels API.
- **Toolbar**: Drag the Label toolbar button onto the canvas to create a new label annotation.

### Canvas Integration
- `FlowCanvas` registers `funnelNode` and `labelNode` in the React Flow `nodeTypes` registry.
- Funnel processors are rendered as `funnelNode` type (distinguished by `typeName === 'Funnel'`).
- Labels are rendered as `labelNode` type with separate drag/drop handling (`application/runifi-component`).
- Context menu shows processor controls (start/stop/configure) only for processor/funnel nodes, not labels.
- Delete operations route to the correct backend API (processors vs. labels).
- MiniMap and node coloring support all three node types.

### Files Changed
- **New**: `crates/runifi-processors/src/funnel.rs`, `crates/runifi-api/src/routes/labels.rs`, `FunnelNode.tsx`, `LabelNode.tsx`
- **Modified**: Engine handle, persistence, flow engine, API DTOs, routes, server startup, FlowCanvas, ComponentToolbar, layout, types, CSS

Closes #177

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — all 321+ tests pass (including 4 funnel unit tests)
- [x] TypeScript compilation (`tsc --noEmit`) passes
- [x] Vite production build succeeds
- [x] Merge conflicts with dev resolved cleanly