### PR TITLE
feat: implement record-oriented processing framework (#33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2581,7 @@ name = "runifi-processors"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "csv",
  "inventory",
  "jsonpath-rust",
  "jsonpath_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { version = "0.7", features = ["codec", "io"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+csv = "1"                     # CSV reader/writer for record processing
 
 # Error handling
 thiserror = "2"

--- a/crates/runifi-plugin-api/src/lib.rs
+++ b/crates/runifi-plugin-api/src/lib.rs
@@ -2,6 +2,7 @@ pub mod context;
 pub mod flowfile;
 pub mod processor;
 pub mod property;
+pub mod record;
 pub mod relationship;
 pub mod result;
 pub mod service;
@@ -14,6 +15,9 @@ pub use context::ProcessContext;
 pub use flowfile::{ContentClaim, FlowFile};
 pub use processor::{Processor, ProcessorDescriptor};
 pub use property::{PropertyDescriptor, PropertyValue};
+pub use record::{
+    Record, RecordFieldType, RecordReader, RecordSchema, RecordValue, RecordWriter, SchemaField,
+};
 pub use relationship::{REL_FAILURE, REL_ORIGINAL, REL_SUCCESS, Relationship};
 pub use result::{PluginError, ProcessResult};
 pub use service::{ControllerService, ControllerServiceDescriptor, ServiceLookup};

--- a/crates/runifi-plugin-api/src/record.rs
+++ b/crates/runifi-plugin-api/src/record.rs
@@ -1,0 +1,584 @@
+//! Record-oriented processing types.
+//!
+//! Provides [`Record`], [`RecordSchema`], [`RecordReader`], and [`RecordWriter`]
+//! for structured data processing. Instead of splitting a 1M-line CSV into 1M
+//! FlowFiles, a record-aware processor parses FlowFile content into records,
+//! transforms/routes at the record level, and writes results back.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use crate::result::ProcessResult;
+
+// ---------------------------------------------------------------------------
+// RecordValue — the value type for record fields
+// ---------------------------------------------------------------------------
+
+/// A dynamically-typed value within a [`Record`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecordValue {
+    /// A string value.
+    String(String),
+    /// An integer value (i64 covers most use cases without precision loss).
+    Int(i64),
+    /// A floating-point value.
+    Float(f64),
+    /// A boolean value.
+    Boolean(bool),
+    /// A nested array of values.
+    Array(Vec<RecordValue>),
+    /// A nested record (sub-object).
+    Record(Record),
+    /// An explicit null/missing value.
+    Null,
+}
+
+impl fmt::Display for RecordValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordValue::String(s) => write!(f, "{s}"),
+            RecordValue::Int(n) => write!(f, "{n}"),
+            RecordValue::Float(n) => write!(f, "{n}"),
+            RecordValue::Boolean(b) => write!(f, "{b}"),
+            RecordValue::Null => write!(f, "null"),
+            RecordValue::Array(arr) => {
+                write!(f, "[")?;
+                for (i, v) in arr.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{v}")?;
+                }
+                write!(f, "]")
+            }
+            RecordValue::Record(rec) => write!(f, "{rec:?}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Record — ordered map of field names to values
+// ---------------------------------------------------------------------------
+
+/// An ordered map of field names to [`RecordValue`]s.
+///
+/// Uses `BTreeMap` for deterministic field ordering which is important
+/// for CSV output and schema consistency.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Record {
+    fields: BTreeMap<String, RecordValue>,
+}
+
+impl Record {
+    /// Create a new empty record.
+    pub fn new() -> Self {
+        Self {
+            fields: BTreeMap::new(),
+        }
+    }
+
+    /// Create a record from a list of (name, value) pairs.
+    pub fn from_fields(fields: Vec<(String, RecordValue)>) -> Self {
+        Self {
+            fields: fields.into_iter().collect(),
+        }
+    }
+
+    /// Get a field value by name.
+    pub fn get(&self, name: &str) -> Option<&RecordValue> {
+        self.fields.get(name)
+    }
+
+    /// Set a field value.
+    pub fn set(&mut self, name: String, value: RecordValue) {
+        self.fields.insert(name, value);
+    }
+
+    /// Remove a field, returning the value if it existed.
+    pub fn remove(&mut self, name: &str) -> Option<RecordValue> {
+        self.fields.remove(name)
+    }
+
+    /// Return field names in order.
+    pub fn field_names(&self) -> Vec<&str> {
+        self.fields.keys().map(|k| k.as_str()).collect()
+    }
+
+    /// Return the number of fields.
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Check if the record has no fields.
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Iterate over (name, value) pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &RecordValue)> {
+        self.fields.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Consume the record and return the inner field map.
+    pub fn into_fields(self) -> BTreeMap<String, RecordValue> {
+        self.fields
+    }
+}
+
+impl Default for Record {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RecordFieldType — the type descriptor for schema fields
+// ---------------------------------------------------------------------------
+
+/// The data type of a schema field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordFieldType {
+    String,
+    Int,
+    Float,
+    Boolean,
+    Array(Box<RecordFieldType>),
+    Record(Arc<RecordSchema>),
+    Null,
+    /// A union/choice type — the value can be any of these types.
+    Choice(Vec<RecordFieldType>),
+}
+
+// ---------------------------------------------------------------------------
+// RecordSchema — defines the structure of records
+// ---------------------------------------------------------------------------
+
+/// A named field in a [`RecordSchema`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaField {
+    pub name: String,
+    pub field_type: RecordFieldType,
+    pub nullable: bool,
+}
+
+/// Describes the expected structure of records.
+///
+/// Schemas can be named for registry lookup and support nested schemas
+/// via [`RecordFieldType::Record`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordSchema {
+    /// Optional schema name (for registry lookup).
+    pub name: Option<String>,
+    /// Ordered list of fields.
+    pub fields: Vec<SchemaField>,
+}
+
+impl RecordSchema {
+    /// Create a new schema with a name and fields.
+    pub fn new(name: Option<String>, fields: Vec<SchemaField>) -> Self {
+        Self { name, fields }
+    }
+
+    /// Look up a field by name.
+    pub fn field(&self, name: &str) -> Option<&SchemaField> {
+        self.fields.iter().find(|f| f.name == name)
+    }
+
+    /// Return all field names in order.
+    pub fn field_names(&self) -> Vec<&str> {
+        self.fields.iter().map(|f| f.name.as_str()).collect()
+    }
+
+    /// Infer a schema from a single record.
+    pub fn infer_from_record(record: &Record) -> Self {
+        let fields = record
+            .iter()
+            .map(|(name, value)| SchemaField {
+                name: name.to_string(),
+                field_type: Self::infer_type(value),
+                nullable: matches!(value, RecordValue::Null),
+            })
+            .collect();
+        Self { name: None, fields }
+    }
+
+    /// Merge two schemas, unifying field types with Choice where they differ.
+    pub fn merge(&self, other: &RecordSchema) -> RecordSchema {
+        let mut merged_fields: Vec<SchemaField> = self.fields.clone();
+
+        for other_field in &other.fields {
+            if let Some(existing) = merged_fields
+                .iter_mut()
+                .find(|f| f.name == other_field.name)
+            {
+                // If types differ, create a Choice type.
+                if existing.field_type != other_field.field_type {
+                    let types = match &existing.field_type {
+                        RecordFieldType::Choice(types) => {
+                            let mut types = types.clone();
+                            if !types.contains(&other_field.field_type) {
+                                types.push(other_field.field_type.clone());
+                            }
+                            types
+                        }
+                        _ => {
+                            if existing.field_type == other_field.field_type {
+                                vec![existing.field_type.clone()]
+                            } else {
+                                vec![existing.field_type.clone(), other_field.field_type.clone()]
+                            }
+                        }
+                    };
+                    existing.field_type = RecordFieldType::Choice(types);
+                }
+                existing.nullable = existing.nullable || other_field.nullable;
+            } else {
+                // Field only exists in `other` — mark as nullable.
+                let mut field = other_field.clone();
+                field.nullable = true;
+                merged_fields.push(field);
+            }
+        }
+
+        // Fields that only exist in `self` but not in `other` become nullable.
+        for field in &mut merged_fields {
+            if !other.fields.iter().any(|f| f.name == field.name) {
+                field.nullable = true;
+            }
+        }
+
+        RecordSchema {
+            name: None,
+            fields: merged_fields,
+        }
+    }
+
+    fn infer_type(value: &RecordValue) -> RecordFieldType {
+        match value {
+            RecordValue::String(_) => RecordFieldType::String,
+            RecordValue::Int(_) => RecordFieldType::Int,
+            RecordValue::Float(_) => RecordFieldType::Float,
+            RecordValue::Boolean(_) => RecordFieldType::Boolean,
+            RecordValue::Null => RecordFieldType::Null,
+            RecordValue::Array(items) => {
+                if let Some(first) = items.first() {
+                    RecordFieldType::Array(Box::new(Self::infer_type(first)))
+                } else {
+                    RecordFieldType::Array(Box::new(RecordFieldType::Null))
+                }
+            }
+            RecordValue::Record(rec) => {
+                RecordFieldType::Record(Arc::new(RecordSchema::infer_from_record(rec)))
+            }
+        }
+    }
+
+    /// Validate a record against this schema.
+    /// Returns `Ok(())` if the record conforms, or an error message.
+    pub fn validate(&self, record: &Record) -> Result<(), String> {
+        for field in &self.fields {
+            match record.get(&field.name) {
+                None | Some(RecordValue::Null) => {
+                    if !field.nullable {
+                        return Err(format!(
+                            "required field '{}' is missing or null",
+                            field.name
+                        ));
+                    }
+                }
+                Some(value) => {
+                    if !Self::value_matches_type(value, &field.field_type) {
+                        return Err(format!(
+                            "field '{}' has type {:?}, expected {:?}",
+                            field.name,
+                            Self::infer_type(value),
+                            field.field_type
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn value_matches_type(value: &RecordValue, expected: &RecordFieldType) -> bool {
+        match (value, expected) {
+            (RecordValue::Null, _) => true, // null is always valid (checked separately via nullable)
+            (RecordValue::String(_), RecordFieldType::String) => true,
+            (RecordValue::Int(_), RecordFieldType::Int) => true,
+            (RecordValue::Float(_), RecordFieldType::Float) => true,
+            // Accept Int where Float is expected (implicit widening).
+            (RecordValue::Int(_), RecordFieldType::Float) => true,
+            (RecordValue::Boolean(_), RecordFieldType::Boolean) => true,
+            (RecordValue::Array(_), RecordFieldType::Array(_)) => true,
+            (RecordValue::Record(_), RecordFieldType::Record(_)) => true,
+            (_, RecordFieldType::Choice(types)) => {
+                types.iter().any(|t| Self::value_matches_type(value, t))
+            }
+            _ => false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RecordReader / RecordWriter traits
+// ---------------------------------------------------------------------------
+
+/// Parses raw bytes into an iterator of [`Record`]s.
+///
+/// Implementations are typically registered as controller services and
+/// shared across processors.
+pub trait RecordReader: Send + Sync {
+    /// Parse the given bytes into a vector of records.
+    ///
+    /// An optional schema can be provided for validation. If `None`,
+    /// the reader should infer the schema from the data.
+    fn read_records(
+        &self,
+        data: &[u8],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<Record>>;
+
+    /// Return the schema of the data, if it can be determined without
+    /// reading all records. Returns `None` if schema inference requires
+    /// reading data.
+    fn schema_from_header(&self, _data: &[u8]) -> Option<RecordSchema> {
+        None
+    }
+}
+
+/// Serializes records into raw bytes.
+pub trait RecordWriter: Send + Sync {
+    /// Write the given records into bytes.
+    ///
+    /// An optional schema can be provided to control field ordering and
+    /// formatting. If `None`, the writer should use the records' own
+    /// field ordering.
+    fn write_records(
+        &self,
+        records: &[Record],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<u8>>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_basic_operations() {
+        let mut rec = Record::new();
+        assert!(rec.is_empty());
+
+        rec.set("name".to_string(), RecordValue::String("Alice".to_string()));
+        rec.set("age".to_string(), RecordValue::Int(30));
+        rec.set("active".to_string(), RecordValue::Boolean(true));
+
+        assert_eq!(rec.len(), 3);
+        assert!(!rec.is_empty());
+        assert_eq!(
+            rec.get("name"),
+            Some(&RecordValue::String("Alice".to_string()))
+        );
+        assert_eq!(rec.get("age"), Some(&RecordValue::Int(30)));
+        assert_eq!(rec.get("missing"), None);
+
+        let removed = rec.remove("age");
+        assert_eq!(removed, Some(RecordValue::Int(30)));
+        assert_eq!(rec.len(), 2);
+    }
+
+    #[test]
+    fn record_from_fields() {
+        let rec = Record::from_fields(vec![
+            ("a".to_string(), RecordValue::Int(1)),
+            ("b".to_string(), RecordValue::Int(2)),
+        ]);
+        assert_eq!(rec.len(), 2);
+        assert_eq!(rec.get("a"), Some(&RecordValue::Int(1)));
+    }
+
+    #[test]
+    fn record_nested() {
+        let inner = Record::from_fields(vec![(
+            "zip".to_string(),
+            RecordValue::String("90210".to_string()),
+        )]);
+        let outer = Record::from_fields(vec![(
+            "address".to_string(),
+            RecordValue::Record(inner.clone()),
+        )]);
+        assert_eq!(outer.get("address"), Some(&RecordValue::Record(inner)));
+    }
+
+    #[test]
+    fn schema_infer_from_record() {
+        let rec = Record::from_fields(vec![
+            ("name".to_string(), RecordValue::String("Bob".to_string())),
+            ("age".to_string(), RecordValue::Int(25)),
+            ("score".to_string(), RecordValue::Float(98.5)),
+        ]);
+        let schema = RecordSchema::infer_from_record(&rec);
+
+        assert_eq!(schema.fields.len(), 3);
+        assert_eq!(
+            schema.field("name").unwrap().field_type,
+            RecordFieldType::String
+        );
+        assert_eq!(
+            schema.field("age").unwrap().field_type,
+            RecordFieldType::Int
+        );
+        assert_eq!(
+            schema.field("score").unwrap().field_type,
+            RecordFieldType::Float
+        );
+    }
+
+    #[test]
+    fn schema_validate_pass() {
+        let schema = RecordSchema::new(
+            None,
+            vec![
+                SchemaField {
+                    name: "name".to_string(),
+                    field_type: RecordFieldType::String,
+                    nullable: false,
+                },
+                SchemaField {
+                    name: "age".to_string(),
+                    field_type: RecordFieldType::Int,
+                    nullable: true,
+                },
+            ],
+        );
+
+        let rec = Record::from_fields(vec![
+            ("name".to_string(), RecordValue::String("Alice".to_string())),
+            ("age".to_string(), RecordValue::Int(30)),
+        ]);
+        assert!(schema.validate(&rec).is_ok());
+
+        // Null value for nullable field is ok.
+        let rec2 = Record::from_fields(vec![
+            ("name".to_string(), RecordValue::String("Bob".to_string())),
+            ("age".to_string(), RecordValue::Null),
+        ]);
+        assert!(schema.validate(&rec2).is_ok());
+    }
+
+    #[test]
+    fn schema_validate_missing_required() {
+        let schema = RecordSchema::new(
+            None,
+            vec![SchemaField {
+                name: "name".to_string(),
+                field_type: RecordFieldType::String,
+                nullable: false,
+            }],
+        );
+
+        let rec = Record::new();
+        let result = schema.validate(&rec);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing or null"));
+    }
+
+    #[test]
+    fn schema_validate_wrong_type() {
+        let schema = RecordSchema::new(
+            None,
+            vec![SchemaField {
+                name: "age".to_string(),
+                field_type: RecordFieldType::Int,
+                nullable: false,
+            }],
+        );
+
+        let rec = Record::from_fields(vec![(
+            "age".to_string(),
+            RecordValue::String("thirty".to_string()),
+        )]);
+        assert!(schema.validate(&rec).is_err());
+    }
+
+    #[test]
+    fn schema_validate_int_as_float() {
+        let schema = RecordSchema::new(
+            None,
+            vec![SchemaField {
+                name: "value".to_string(),
+                field_type: RecordFieldType::Float,
+                nullable: false,
+            }],
+        );
+
+        // Int should be accepted where Float is expected.
+        let rec = Record::from_fields(vec![("value".to_string(), RecordValue::Int(42))]);
+        assert!(schema.validate(&rec).is_ok());
+    }
+
+    #[test]
+    fn schema_merge() {
+        let s1 = RecordSchema::new(
+            None,
+            vec![
+                SchemaField {
+                    name: "a".to_string(),
+                    field_type: RecordFieldType::String,
+                    nullable: false,
+                },
+                SchemaField {
+                    name: "b".to_string(),
+                    field_type: RecordFieldType::Int,
+                    nullable: false,
+                },
+            ],
+        );
+        let s2 = RecordSchema::new(
+            None,
+            vec![
+                SchemaField {
+                    name: "a".to_string(),
+                    field_type: RecordFieldType::String,
+                    nullable: false,
+                },
+                SchemaField {
+                    name: "c".to_string(),
+                    field_type: RecordFieldType::Float,
+                    nullable: false,
+                },
+            ],
+        );
+
+        let merged = s1.merge(&s2);
+        assert_eq!(merged.fields.len(), 3);
+        // "b" only in s1 -> nullable.
+        assert!(merged.field("b").unwrap().nullable);
+        // "c" only in s2 -> nullable.
+        assert!(merged.field("c").unwrap().nullable);
+        // "a" in both -> not nullable.
+        assert!(!merged.field("a").unwrap().nullable);
+    }
+
+    #[test]
+    fn record_value_display() {
+        assert_eq!(format!("{}", RecordValue::String("hi".to_string())), "hi");
+        assert_eq!(format!("{}", RecordValue::Int(42)), "42");
+        assert_eq!(format!("{}", RecordValue::Float(3.14)), "3.14");
+        assert_eq!(format!("{}", RecordValue::Boolean(true)), "true");
+        assert_eq!(format!("{}", RecordValue::Null), "null");
+        assert_eq!(
+            format!(
+                "{}",
+                RecordValue::Array(vec![RecordValue::Int(1), RecordValue::Int(2)])
+            ),
+            "[1, 2]"
+        );
+    }
+}

--- a/crates/runifi-processors/Cargo.toml
+++ b/crates/runifi-processors/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [features]
 default = ["all"]
-all = ["filesystem", "routing", "debug", "transformation", "json", "extraction", "transport"]
+all = ["filesystem", "routing", "debug", "transformation", "json", "extraction", "transport", "record"]
 filesystem = []
 routing = []
 debug = []
@@ -15,6 +15,7 @@ transformation = ["serde_json", "jsonpath_lib"]
 json = ["serde_json", "dep:jsonschema"]
 extraction = ["dep:jsonpath-rust", "serde_json"]
 transport = ["dep:runifi-transport", "dep:tokio"]
+record = ["serde_json", "dep:csv"]
 
 [dependencies]
 runifi-plugin-api = { workspace = true }
@@ -30,3 +31,4 @@ jsonschema = { workspace = true, optional = true }
 jsonpath-rust = { workspace = true, optional = true }
 runifi-transport = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
+csv = { workspace = true, optional = true }

--- a/crates/runifi-processors/src/lib.rs
+++ b/crates/runifi-processors/src/lib.rs
@@ -35,6 +35,9 @@ pub mod pull_flowfile;
 #[cfg(feature = "transport")]
 pub mod push_flowfile;
 
+#[cfg(feature = "record")]
+pub mod record;
+
 pub mod funnel;
 
 pub mod distributed_map_cache;

--- a/crates/runifi-processors/src/record/convert_record.rs
+++ b/crates/runifi-processors/src/record/convert_record.rs
@@ -1,0 +1,399 @@
+//! ConvertRecord processor — reads FlowFile content with one format and writes
+//! with another (e.g., CSV -> JSON, JSON -> CSV).
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use runifi_plugin_api::context::ProcessContext;
+use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::property::PropertyDescriptor;
+use runifi_plugin_api::record::{RecordReader, RecordWriter};
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::ProcessResult;
+use runifi_plugin_api::session::ProcessSession;
+use runifi_plugin_api::{REL_FAILURE, REL_SUCCESS};
+
+use super::csv_reader::CsvRecordReader;
+use super::csv_writer::CsvRecordWriter;
+use super::json_reader::JsonRecordReader;
+use super::json_writer::{JsonOutputFormat, JsonRecordWriter};
+
+const PROP_READER_FORMAT: PropertyDescriptor = PropertyDescriptor::new(
+    "Record Reader",
+    "Input format: 'json', 'json-lines', 'csv', 'tsv'",
+)
+.required()
+.default_value("json")
+.allowed_values(&["json", "json-lines", "csv", "tsv"]);
+
+const PROP_WRITER_FORMAT: PropertyDescriptor = PropertyDescriptor::new(
+    "Record Writer",
+    "Output format: 'json', 'json-lines', 'csv', 'tsv'",
+)
+.required()
+.default_value("json")
+.allowed_values(&["json", "json-lines", "csv", "tsv"]);
+
+const PROP_CSV_HEADER: PropertyDescriptor = PropertyDescriptor::new(
+    "Include Header",
+    "Whether CSV/TSV output includes a header row",
+)
+.default_value("true")
+.allowed_values(&["true", "false"]);
+
+/// Converts FlowFile content between record formats.
+///
+/// Reads the incoming FlowFile using the configured reader format, then
+/// writes the records using the configured writer format. This enables
+/// format conversion (e.g., CSV to JSON) without per-record FlowFile overhead.
+pub struct ConvertRecord;
+
+impl ConvertRecord {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ConvertRecord {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Processor for ConvertRecord {
+    fn on_trigger(
+        &mut self,
+        context: &dyn ProcessContext,
+        session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        let reader_format = context
+            .get_property("Record Reader")
+            .unwrap_or("json")
+            .to_string();
+        let writer_format = context
+            .get_property("Record Writer")
+            .unwrap_or("json")
+            .to_string();
+        let include_header = context.get_property("Include Header").unwrap_or("true") == "true";
+
+        let reader = build_reader(&reader_format);
+        let writer = build_writer(&writer_format, include_header);
+
+        while let Some(flowfile) = session.get() {
+            let content = session.read_content(&flowfile)?;
+
+            match reader.read_records(&content, None) {
+                Ok(records) => {
+                    let record_count = records.len();
+                    match writer.write_records(&records, None) {
+                        Ok(output) => {
+                            let mut ff = session.write_content(flowfile, Bytes::from(output))?;
+                            ff.set_attribute(
+                                Arc::from("record.count"),
+                                Arc::from(record_count.to_string().as_str()),
+                            );
+                            ff.set_attribute(
+                                Arc::from("mime.type"),
+                                Arc::from(mime_type_for_format(&writer_format)),
+                            );
+                            session.transfer(ff, &REL_SUCCESS);
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                error = %e,
+                                format = writer_format,
+                                "Failed to write records"
+                            );
+                            session.transfer(flowfile, &REL_FAILURE);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        format = reader_format,
+                        "Failed to read records"
+                    );
+                    session.transfer(flowfile, &REL_FAILURE);
+                }
+            }
+        }
+
+        session.commit();
+        Ok(())
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS, REL_FAILURE]
+    }
+
+    fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
+        vec![PROP_READER_FORMAT, PROP_WRITER_FORMAT, PROP_CSV_HEADER]
+    }
+}
+
+fn build_reader(format: &str) -> Box<dyn RecordReader> {
+    match format {
+        "csv" => Box::new(CsvRecordReader::new()),
+        "tsv" => Box::new(CsvRecordReader::new().delimiter(b'\t')),
+        "json-lines" => Box::new(JsonRecordReader::new()),
+        _ => Box::new(JsonRecordReader::new()), // "json" and default
+    }
+}
+
+fn build_writer(format: &str, include_header: bool) -> Box<dyn RecordWriter> {
+    match format {
+        "csv" => Box::new(CsvRecordWriter::new().write_header(include_header)),
+        "tsv" => Box::new(
+            CsvRecordWriter::new()
+                .delimiter(b'\t')
+                .write_header(include_header),
+        ),
+        "json-lines" => Box::new(JsonRecordWriter::new(JsonOutputFormat::LineDelimited)),
+        _ => Box::new(JsonRecordWriter::new(JsonOutputFormat::Array)), // "json" and default
+    }
+}
+
+fn mime_type_for_format(format: &str) -> &'static str {
+    match format {
+        "json" | "json-lines" => "application/json",
+        "csv" => "text/csv",
+        "tsv" => "text/tab-separated-values",
+        _ => "application/octet-stream",
+    }
+}
+
+inventory::submit! {
+    ProcessorDescriptor {
+        type_name: "ConvertRecord",
+        description: "Converts FlowFile content between record formats (CSV, JSON, TSV)",
+        factory: || Box::new(ConvertRecord::new()),
+        tags: &["Record", "Transformation", "Convert"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runifi_plugin_api::FlowFile;
+    use runifi_plugin_api::property::PropertyValue;
+    use runifi_plugin_api::result::PluginError;
+
+    struct TestContext {
+        reader_format: String,
+        writer_format: String,
+        include_header: String,
+    }
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, name: &str) -> PropertyValue {
+            match name {
+                "Record Reader" => PropertyValue::String(self.reader_format.clone()),
+                "Record Writer" => PropertyValue::String(self.writer_format.clone()),
+                "Include Header" => PropertyValue::String(self.include_header.clone()),
+                _ => PropertyValue::Unset,
+            }
+        }
+        fn name(&self) -> &str {
+            "test-convert"
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    struct ConvertSession {
+        inputs: Vec<FlowFile>,
+        content: std::collections::HashMap<u64, Bytes>,
+        transferred: Vec<(FlowFile, &'static str)>,
+        next_id: u64,
+    }
+
+    impl ConvertSession {
+        fn new() -> Self {
+            Self {
+                inputs: Vec::new(),
+                content: std::collections::HashMap::new(),
+                transferred: Vec::new(),
+                next_id: 100,
+            }
+        }
+
+        fn add_flowfile_with_content(&mut self, data: &[u8]) {
+            let id = self.next_id;
+            self.next_id += 1;
+            let ff = FlowFile {
+                id,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: data.len() as u64,
+                created_at_nanos: 0,
+                lineage_start_id: id,
+                penalized_until_nanos: 0,
+            };
+            self.content.insert(id, Bytes::from(data.to_vec()));
+            self.inputs.push(ff);
+        }
+    }
+
+    impl ProcessSession for ConvertSession {
+        fn get(&mut self) -> Option<FlowFile> {
+            if self.inputs.is_empty() {
+                None
+            } else {
+                Some(self.inputs.remove(0))
+            }
+        }
+        fn get_batch(&mut self, _max: usize) -> Vec<FlowFile> {
+            std::mem::take(&mut self.inputs)
+        }
+        fn read_content(&self, ff: &FlowFile) -> ProcessResult<Bytes> {
+            self.content
+                .get(&ff.id)
+                .cloned()
+                .ok_or(PluginError::ContentNotFound(ff.id))
+        }
+        fn write_content(&mut self, mut ff: FlowFile, data: Bytes) -> ProcessResult<FlowFile> {
+            ff.size = data.len() as u64;
+            self.content.insert(ff.id, data);
+            Ok(ff)
+        }
+        fn create(&mut self) -> FlowFile {
+            let id = self.next_id;
+            self.next_id += 1;
+            FlowFile {
+                id,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: 0,
+                created_at_nanos: 0,
+                lineage_start_id: id,
+                penalized_until_nanos: 0,
+            }
+        }
+        fn clone_flowfile(&mut self, ff: &FlowFile) -> FlowFile {
+            let id = self.next_id;
+            self.next_id += 1;
+            let mut cloned = ff.clone();
+            cloned.id = id;
+            if let Some(content) = self.content.get(&ff.id) {
+                self.content.insert(id, content.clone());
+            }
+            cloned
+        }
+        fn transfer(&mut self, ff: FlowFile, rel: &Relationship) {
+            self.transferred.push((ff, rel.name));
+        }
+        fn remove(&mut self, _ff: FlowFile) {}
+        fn penalize(&mut self, ff: FlowFile) -> FlowFile {
+            ff
+        }
+        fn commit(&mut self) {}
+        fn rollback(&mut self) {}
+    }
+
+    #[test]
+    fn converts_csv_to_json() {
+        let mut proc = ConvertRecord::new();
+        let ctx = TestContext {
+            reader_format: "csv".to_string(),
+            writer_format: "json".to_string(),
+            include_header: "true".to_string(),
+        };
+
+        let mut session = ConvertSession::new();
+        session.add_flowfile_with_content(b"name,age\nAlice,30\nBob,25\n");
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "success");
+
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(output).unwrap();
+
+        assert!(parsed.is_array());
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        // Check record count attribute.
+        assert_eq!(
+            ff.get_attribute("record.count").map(|v| v.as_ref()),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn converts_json_to_csv() {
+        let mut proc = ConvertRecord::new();
+        let ctx = TestContext {
+            reader_format: "json".to_string(),
+            writer_format: "csv".to_string(),
+            include_header: "true".to_string(),
+        };
+
+        let mut session = ConvertSession::new();
+        session
+            .add_flowfile_with_content(br#"[{"name":"Alice","age":30},{"name":"Bob","age":25}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "success");
+
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let text = std::str::from_utf8(output).unwrap();
+
+        // Should have header + 2 rows.
+        let lines: Vec<&str> = text.trim().lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            ff.get_attribute("mime.type").map(|v| v.as_ref()),
+            Some("text/csv")
+        );
+    }
+
+    #[test]
+    fn converts_json_to_ndjson() {
+        let mut proc = ConvertRecord::new();
+        let ctx = TestContext {
+            reader_format: "json".to_string(),
+            writer_format: "json-lines".to_string(),
+            include_header: "true".to_string(),
+        };
+
+        let mut session = ConvertSession::new();
+        session.add_flowfile_with_content(br#"[{"x":1},{"x":2}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred[0].1, "success");
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let text = std::str::from_utf8(output).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+        assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn invalid_input_goes_to_failure() {
+        let mut proc = ConvertRecord::new();
+        let ctx = TestContext {
+            reader_format: "json".to_string(),
+            writer_format: "csv".to_string(),
+            include_header: "true".to_string(),
+        };
+
+        let mut session = ConvertSession::new();
+        session.add_flowfile_with_content(b"this is not json");
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+    }
+}

--- a/crates/runifi-processors/src/record/csv_reader.rs
+++ b/crates/runifi-processors/src/record/csv_reader.rs
@@ -1,0 +1,303 @@
+//! CSV RecordReader — parses CSV data into Records.
+
+use runifi_plugin_api::record::{
+    Record, RecordFieldType, RecordReader, RecordSchema, RecordValue, SchemaField,
+};
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+
+/// A [`RecordReader`] that parses CSV data.
+///
+/// Supports configurable delimiter and header handling. When headers are present,
+/// they become field names. Without headers, fields are named `column_0`, `column_1`, etc.
+pub struct CsvRecordReader {
+    delimiter: u8,
+    has_header: bool,
+}
+
+impl CsvRecordReader {
+    pub fn new() -> Self {
+        Self {
+            delimiter: b',',
+            has_header: true,
+        }
+    }
+
+    /// Set the field delimiter (default: `,`).
+    pub fn delimiter(mut self, delim: u8) -> Self {
+        self.delimiter = delim;
+        self
+    }
+
+    /// Set whether the CSV has a header row (default: `true`).
+    pub fn has_header(mut self, has: bool) -> Self {
+        self.has_header = has;
+        self
+    }
+}
+
+impl Default for CsvRecordReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RecordReader for CsvRecordReader {
+    fn read_records(
+        &self,
+        data: &[u8],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<Record>> {
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(self.delimiter)
+            .has_headers(self.has_header)
+            .from_reader(data);
+
+        // Determine field names: from headers, schema, or generated.
+        let headers: Vec<String> = if self.has_header {
+            let hdrs = rdr
+                .headers()
+                .map_err(|e| PluginError::ProcessingFailed(format!("CSV header error: {e}")))?;
+            hdrs.iter().map(|h| h.to_string()).collect()
+        } else if let Some(s) = schema {
+            s.field_names().iter().map(|n| n.to_string()).collect()
+        } else {
+            Vec::new() // Will generate column_N names on first record.
+        };
+
+        let mut records = Vec::new();
+
+        for (row_idx, result) in rdr.records().enumerate() {
+            let csv_record = result.map_err(|e| {
+                PluginError::ProcessingFailed(format!("CSV parse error at row {row_idx}: {e}"))
+            })?;
+
+            let field_names: Vec<String> = if headers.is_empty() {
+                // Generate column names based on the number of fields.
+                (0..csv_record.len())
+                    .map(|i| format!("column_{i}"))
+                    .collect()
+            } else {
+                headers.clone()
+            };
+
+            let fields: Vec<(String, RecordValue)> = field_names
+                .into_iter()
+                .zip(csv_record.iter())
+                .map(|(name, value)| {
+                    let record_value = if let Some(s) = schema {
+                        parse_typed_value(value, s.field(&name))
+                    } else {
+                        infer_value(value)
+                    };
+                    (name, record_value)
+                })
+                .collect();
+
+            let record = Record::from_fields(fields);
+
+            // Validate against schema if provided.
+            if let Some(s) = schema {
+                s.validate(&record).map_err(|e| {
+                    PluginError::ProcessingFailed(format!("row {row_idx} schema validation: {e}"))
+                })?;
+            }
+
+            records.push(record);
+        }
+
+        Ok(records)
+    }
+
+    fn schema_from_header(&self, data: &[u8]) -> Option<RecordSchema> {
+        if !self.has_header {
+            return None;
+        }
+
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(self.delimiter)
+            .has_headers(true)
+            .from_reader(data);
+
+        let headers = rdr.headers().ok()?;
+        let fields = headers
+            .iter()
+            .map(|h| SchemaField {
+                name: h.to_string(),
+                field_type: RecordFieldType::String, // CSV fields are strings by default.
+                nullable: true,
+            })
+            .collect();
+
+        Some(RecordSchema::new(None, fields))
+    }
+}
+
+/// Parse a CSV field value using the schema field type for guidance.
+fn parse_typed_value(raw: &str, field: Option<&SchemaField>) -> RecordValue {
+    let Some(field) = field else {
+        return infer_value(raw);
+    };
+
+    if raw.is_empty() && field.nullable {
+        return RecordValue::Null;
+    }
+
+    match &field.field_type {
+        RecordFieldType::Int => raw
+            .parse::<i64>()
+            .map(RecordValue::Int)
+            .unwrap_or_else(|_| RecordValue::String(raw.to_string())),
+        RecordFieldType::Float => raw
+            .parse::<f64>()
+            .map(RecordValue::Float)
+            .unwrap_or_else(|_| RecordValue::String(raw.to_string())),
+        RecordFieldType::Boolean => match raw.to_lowercase().as_str() {
+            "true" | "1" | "yes" => RecordValue::Boolean(true),
+            "false" | "0" | "no" => RecordValue::Boolean(false),
+            _ => RecordValue::String(raw.to_string()),
+        },
+        _ => RecordValue::String(raw.to_string()),
+    }
+}
+
+/// Attempt to infer the type of a CSV field value.
+fn infer_value(raw: &str) -> RecordValue {
+    if raw.is_empty() {
+        return RecordValue::Null;
+    }
+    // Try integer.
+    if let Ok(i) = raw.parse::<i64>() {
+        return RecordValue::Int(i);
+    }
+    // Try float.
+    if let Ok(f) = raw.parse::<f64>() {
+        return RecordValue::Float(f);
+    }
+    // Try boolean.
+    match raw.to_lowercase().as_str() {
+        "true" => return RecordValue::Boolean(true),
+        "false" => return RecordValue::Boolean(false),
+        _ => {}
+    }
+    RecordValue::String(raw.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_csv_with_header() {
+        let reader = CsvRecordReader::new();
+        let data = b"name,age,score\nAlice,30,95.5\nBob,25,88.0\n";
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[0].get("name"),
+            Some(&RecordValue::String("Alice".to_string()))
+        );
+        assert_eq!(records[0].get("age"), Some(&RecordValue::Int(30)));
+        assert_eq!(records[0].get("score"), Some(&RecordValue::Float(95.5)));
+    }
+
+    #[test]
+    fn reads_csv_without_header() {
+        let reader = CsvRecordReader::new().has_header(false);
+        let data = b"Alice,30\nBob,25\n";
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[0].get("column_0"),
+            Some(&RecordValue::String("Alice".to_string()))
+        );
+        assert_eq!(records[0].get("column_1"), Some(&RecordValue::Int(30)));
+    }
+
+    #[test]
+    fn reads_tsv() {
+        let reader = CsvRecordReader::new().delimiter(b'\t');
+        let data = b"name\tage\nAlice\t30\n";
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].get("name"),
+            Some(&RecordValue::String("Alice".to_string()))
+        );
+    }
+
+    #[test]
+    fn infers_types() {
+        let reader = CsvRecordReader::new();
+        let data = b"int,float,bool,str\n42,3.14,true,hello\n";
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records[0].get("int"), Some(&RecordValue::Int(42)));
+        assert_eq!(records[0].get("float"), Some(&RecordValue::Float(3.14)));
+        assert_eq!(records[0].get("bool"), Some(&RecordValue::Boolean(true)));
+        assert_eq!(
+            records[0].get("str"),
+            Some(&RecordValue::String("hello".to_string()))
+        );
+    }
+
+    #[test]
+    fn empty_field_is_null() {
+        let reader = CsvRecordReader::new();
+        let data = b"a,b\n1,\n";
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records[0].get("b"), Some(&RecordValue::Null));
+    }
+
+    #[test]
+    fn schema_typed_parsing() {
+        let schema = RecordSchema::new(
+            None,
+            vec![
+                SchemaField {
+                    name: "count".to_string(),
+                    field_type: RecordFieldType::Int,
+                    nullable: false,
+                },
+                SchemaField {
+                    name: "ratio".to_string(),
+                    field_type: RecordFieldType::Float,
+                    nullable: false,
+                },
+                SchemaField {
+                    name: "active".to_string(),
+                    field_type: RecordFieldType::Boolean,
+                    nullable: false,
+                },
+            ],
+        );
+
+        let reader = CsvRecordReader::new();
+        let data = b"count,ratio,active\n10,0.5,yes\n";
+        let records = reader.read_records(data, Some(&schema)).unwrap();
+
+        assert_eq!(records[0].get("count"), Some(&RecordValue::Int(10)));
+        assert_eq!(records[0].get("ratio"), Some(&RecordValue::Float(0.5)));
+        assert_eq!(records[0].get("active"), Some(&RecordValue::Boolean(true)));
+    }
+
+    #[test]
+    fn schema_from_header_works() {
+        let reader = CsvRecordReader::new();
+        let data = b"name,age,score\n";
+        let schema = reader.schema_from_header(data).unwrap();
+
+        assert_eq!(schema.field_names(), vec!["name", "age", "score"]);
+    }
+
+    #[test]
+    fn reads_empty_csv() {
+        let reader = CsvRecordReader::new();
+        let data = b"name,age\n";
+        let records = reader.read_records(data, None).unwrap();
+        assert!(records.is_empty());
+    }
+}

--- a/crates/runifi-processors/src/record/csv_writer.rs
+++ b/crates/runifi-processors/src/record/csv_writer.rs
@@ -1,0 +1,293 @@
+//! CSV RecordWriter — serializes Records into CSV format.
+
+use runifi_plugin_api::record::{Record, RecordSchema, RecordValue, RecordWriter};
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+
+/// A [`RecordWriter`] that serializes records to CSV.
+///
+/// Supports configurable delimiter and header output. Field order is determined
+/// by the schema (if provided) or by the first record's field ordering.
+pub struct CsvRecordWriter {
+    delimiter: u8,
+    write_header: bool,
+}
+
+impl CsvRecordWriter {
+    pub fn new() -> Self {
+        Self {
+            delimiter: b',',
+            write_header: true,
+        }
+    }
+
+    /// Set the field delimiter (default: `,`).
+    pub fn delimiter(mut self, delim: u8) -> Self {
+        self.delimiter = delim;
+        self
+    }
+
+    /// Set whether to write a header row (default: `true`).
+    pub fn write_header(mut self, write: bool) -> Self {
+        self.write_header = write;
+        self
+    }
+}
+
+impl Default for CsvRecordWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RecordWriter for CsvRecordWriter {
+    fn write_records(
+        &self,
+        records: &[Record],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<u8>> {
+        if records.is_empty() {
+            // Write just headers if schema is provided and header writing is enabled.
+            if self.write_header
+                && let Some(s) = schema
+            {
+                let mut wtr = csv::WriterBuilder::new()
+                    .delimiter(self.delimiter)
+                    .has_headers(false) // We write headers manually.
+                    .from_writer(Vec::new());
+                let headers: Vec<&str> = s.field_names();
+                wtr.write_record(&headers).map_err(|e| {
+                    PluginError::ProcessingFailed(format!("CSV header write error: {e}"))
+                })?;
+                return wtr
+                    .into_inner()
+                    .map_err(|e| PluginError::ProcessingFailed(format!("CSV flush error: {e}")));
+            }
+            return Ok(Vec::new());
+        }
+
+        // Determine field order: from schema or from first record.
+        let field_order: Vec<String> = if let Some(s) = schema {
+            s.field_names().iter().map(|n| n.to_string()).collect()
+        } else {
+            records[0]
+                .field_names()
+                .iter()
+                .map(|n| n.to_string())
+                .collect()
+        };
+
+        let mut wtr = csv::WriterBuilder::new()
+            .delimiter(self.delimiter)
+            .has_headers(false) // We manage headers ourselves for ordering.
+            .from_writer(Vec::new());
+
+        // Write header row.
+        if self.write_header {
+            let headers: Vec<&str> = field_order.iter().map(|s| s.as_str()).collect();
+            wtr.write_record(&headers).map_err(|e| {
+                PluginError::ProcessingFailed(format!("CSV header write error: {e}"))
+            })?;
+        }
+
+        // Write data rows.
+        for record in records {
+            let row: Vec<String> = field_order
+                .iter()
+                .map(|field_name| {
+                    record
+                        .get(field_name)
+                        .map(record_value_to_csv_string)
+                        .unwrap_or_default()
+                })
+                .collect();
+            wtr.write_record(&row)
+                .map_err(|e| PluginError::ProcessingFailed(format!("CSV write error: {e}")))?;
+        }
+
+        wtr.into_inner()
+            .map_err(|e| PluginError::ProcessingFailed(format!("CSV flush error: {e}")))
+    }
+}
+
+/// Convert a [`RecordValue`] to its CSV string representation.
+fn record_value_to_csv_string(value: &RecordValue) -> String {
+    match value {
+        RecordValue::Null => String::new(),
+        RecordValue::String(s) => s.clone(),
+        RecordValue::Int(n) => n.to_string(),
+        RecordValue::Float(f) => f.to_string(),
+        RecordValue::Boolean(b) => b.to_string(),
+        RecordValue::Array(arr) => {
+            // Serialize arrays as JSON-like representation within CSV.
+            let items: Vec<String> = arr.iter().map(record_value_to_csv_string).collect();
+            format!("[{}]", items.join(","))
+        }
+        RecordValue::Record(_) => {
+            // Nested records are not well-represented in CSV; use a marker.
+            "{...}".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runifi_plugin_api::RecordReader;
+
+    fn make_record(fields: Vec<(&str, RecordValue)>) -> Record {
+        Record::from_fields(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn writes_csv_with_header() {
+        let writer = CsvRecordWriter::new();
+        let records = vec![
+            make_record(vec![
+                ("age", RecordValue::Int(30)),
+                ("name", RecordValue::String("Alice".to_string())),
+            ]),
+            make_record(vec![
+                ("age", RecordValue::Int(25)),
+                ("name", RecordValue::String("Bob".to_string())),
+            ]),
+        ];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+
+        assert_eq!(lines.len(), 3); // header + 2 rows
+        assert_eq!(lines[0], "age,name");
+        assert_eq!(lines[1], "30,Alice");
+        assert_eq!(lines[2], "25,Bob");
+    }
+
+    #[test]
+    fn writes_csv_without_header() {
+        let writer = CsvRecordWriter::new().write_header(false);
+        let records = vec![make_record(vec![
+            ("a", RecordValue::Int(1)),
+            ("b", RecordValue::Int(2)),
+        ])];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "1,2");
+    }
+
+    #[test]
+    fn writes_tsv() {
+        let writer = CsvRecordWriter::new().delimiter(b'\t');
+        let records = vec![make_record(vec![
+            ("a", RecordValue::String("x".to_string())),
+            ("b", RecordValue::String("y".to_string())),
+        ])];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("a\tb"));
+        assert!(text.contains("x\ty"));
+    }
+
+    #[test]
+    fn writes_empty_records() {
+        let writer = CsvRecordWriter::new();
+        let output = writer.write_records(&[], None).unwrap();
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn null_becomes_empty() {
+        let writer = CsvRecordWriter::new();
+        let records = vec![make_record(vec![
+            ("a", RecordValue::Int(1)),
+            ("b", RecordValue::Null),
+        ])];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+        assert_eq!(lines[1], "1,");
+    }
+
+    #[test]
+    fn boolean_values() {
+        let writer = CsvRecordWriter::new();
+        let records = vec![make_record(vec![("flag", RecordValue::Boolean(true))])];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("true"));
+    }
+
+    #[test]
+    fn schema_controls_field_order() {
+        use runifi_plugin_api::record::{RecordFieldType, SchemaField};
+
+        let schema = RecordSchema::new(
+            None,
+            vec![
+                SchemaField {
+                    name: "z".to_string(),
+                    field_type: RecordFieldType::String,
+                    nullable: false,
+                },
+                SchemaField {
+                    name: "a".to_string(),
+                    field_type: RecordFieldType::String,
+                    nullable: false,
+                },
+            ],
+        );
+
+        let writer = CsvRecordWriter::new();
+        let records = vec![make_record(vec![
+            ("a", RecordValue::String("first".to_string())),
+            ("z", RecordValue::String("last".to_string())),
+        ])];
+
+        let output = writer.write_records(&records, Some(&schema)).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+
+        // Schema specifies z before a.
+        assert_eq!(lines[0], "z,a");
+        assert_eq!(lines[1], "last,first");
+    }
+
+    #[test]
+    fn roundtrip_csv() {
+        use crate::record::csv_reader::CsvRecordReader;
+
+        let original = vec![
+            make_record(vec![
+                ("name", RecordValue::String("Alice".to_string())),
+                ("score", RecordValue::String("95.5".to_string())),
+            ]),
+            make_record(vec![
+                ("name", RecordValue::String("Bob".to_string())),
+                ("score", RecordValue::String("88".to_string())),
+            ]),
+        ];
+
+        let writer = CsvRecordWriter::new();
+        let bytes = writer.write_records(&original, None).unwrap();
+
+        let reader = CsvRecordReader::new();
+        let parsed = reader.read_records(&bytes, None).unwrap();
+
+        // CSV round-trip may infer different types (strings -> ints/floats).
+        // Check field names and count.
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed[0].get("name").is_some());
+        assert!(parsed[0].get("score").is_some());
+    }
+}

--- a/crates/runifi-processors/src/record/json_reader.rs
+++ b/crates/runifi-processors/src/record/json_reader.rs
@@ -1,0 +1,244 @@
+//! JSON RecordReader — parses JSON arrays and line-delimited JSON into Records.
+
+use runifi_plugin_api::record::{Record, RecordReader, RecordSchema, RecordValue};
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+use serde_json::Value;
+
+/// A [`RecordReader`] that parses JSON data.
+///
+/// Supports two formats:
+/// - **Array format**: `[{"a":1}, {"a":2}]` — a JSON array of objects.
+/// - **Line-delimited (NDJSON)**: One JSON object per line, separated by newlines.
+///
+/// The reader auto-detects the format: if the trimmed input starts with `[`,
+/// it is treated as an array; otherwise as line-delimited.
+pub struct JsonRecordReader;
+
+impl JsonRecordReader {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for JsonRecordReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RecordReader for JsonRecordReader {
+    fn read_records(
+        &self,
+        data: &[u8],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<Record>> {
+        let text = std::str::from_utf8(data).map_err(|e| {
+            PluginError::ProcessingFailed(format!("invalid UTF-8 in JSON input: {e}"))
+        })?;
+
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let records = if trimmed.starts_with('[') {
+            // Array format.
+            let arr: Vec<Value> = serde_json::from_str(trimmed).map_err(|e| {
+                PluginError::ProcessingFailed(format!("failed to parse JSON array: {e}"))
+            })?;
+            arr.into_iter()
+                .map(json_value_to_record)
+                .collect::<ProcessResult<Vec<_>>>()?
+        } else {
+            // Line-delimited (NDJSON) format.
+            let mut records = Vec::new();
+            for (line_num, line) in trimmed.lines().enumerate() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let value: Value = serde_json::from_str(line).map_err(|e| {
+                    PluginError::ProcessingFailed(format!(
+                        "failed to parse JSON on line {}: {e}",
+                        line_num + 1
+                    ))
+                })?;
+                records.push(json_value_to_record(value)?);
+            }
+            records
+        };
+
+        // Validate against schema if provided.
+        if let Some(schema) = schema {
+            for (i, record) in records.iter().enumerate() {
+                schema.validate(record).map_err(|e| {
+                    PluginError::ProcessingFailed(format!("record {i} schema validation: {e}"))
+                })?;
+            }
+        }
+
+        Ok(records)
+    }
+}
+
+/// Convert a `serde_json::Value` into a [`Record`].
+///
+/// Only JSON objects become records. Other values produce an error.
+fn json_value_to_record(value: Value) -> ProcessResult<Record> {
+    match value {
+        Value::Object(map) => {
+            let fields: Vec<(String, RecordValue)> = map
+                .into_iter()
+                .map(|(k, v)| (k, json_value_to_record_value(v)))
+                .collect();
+            Ok(Record::from_fields(fields))
+        }
+        other => Err(PluginError::ProcessingFailed(format!(
+            "expected JSON object, got {other}"
+        ))),
+    }
+}
+
+/// Convert a `serde_json::Value` into a [`RecordValue`].
+fn json_value_to_record_value(value: Value) -> RecordValue {
+    match value {
+        Value::Null => RecordValue::Null,
+        Value::Bool(b) => RecordValue::Boolean(b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                RecordValue::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                RecordValue::Float(f)
+            } else {
+                RecordValue::String(n.to_string())
+            }
+        }
+        Value::String(s) => RecordValue::String(s),
+        Value::Array(arr) => {
+            RecordValue::Array(arr.into_iter().map(json_value_to_record_value).collect())
+        }
+        Value::Object(map) => {
+            let fields: Vec<(String, RecordValue)> = map
+                .into_iter()
+                .map(|(k, v)| (k, json_value_to_record_value(v)))
+                .collect();
+            RecordValue::Record(Record::from_fields(fields))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_json_array() {
+        let reader = JsonRecordReader::new();
+        let data = br#"[{"name":"Alice","age":30},{"name":"Bob","age":25}]"#;
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[0].get("name"),
+            Some(&RecordValue::String("Alice".to_string()))
+        );
+        assert_eq!(records[0].get("age"), Some(&RecordValue::Int(30)));
+        assert_eq!(
+            records[1].get("name"),
+            Some(&RecordValue::String("Bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn reads_ndjson() {
+        let reader = JsonRecordReader::new();
+        let data = b"{\"x\":1}\n{\"x\":2}\n{\"x\":3}\n";
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].get("x"), Some(&RecordValue::Int(1)));
+        assert_eq!(records[2].get("x"), Some(&RecordValue::Int(3)));
+    }
+
+    #[test]
+    fn reads_empty_input() {
+        let reader = JsonRecordReader::new();
+        let records = reader.read_records(b"", None).unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn reads_nested_objects() {
+        let reader = JsonRecordReader::new();
+        let data = br#"[{"user":{"name":"Alice"},"tags":["a","b"]}]"#;
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records.len(), 1);
+        let user = records[0].get("user").unwrap();
+        match user {
+            RecordValue::Record(inner) => {
+                assert_eq!(
+                    inner.get("name"),
+                    Some(&RecordValue::String("Alice".to_string()))
+                );
+            }
+            other => panic!("expected Record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reads_null_and_bool() {
+        let reader = JsonRecordReader::new();
+        let data = br#"[{"flag":true,"empty":null}]"#;
+        let records = reader.read_records(data, None).unwrap();
+
+        assert_eq!(records[0].get("flag"), Some(&RecordValue::Boolean(true)));
+        assert_eq!(records[0].get("empty"), Some(&RecordValue::Null));
+    }
+
+    #[test]
+    fn reads_floats() {
+        let reader = JsonRecordReader::new();
+        let data = br#"[{"pi":3.14}]"#;
+        let records = reader.read_records(data, None).unwrap();
+        assert_eq!(records[0].get("pi"), Some(&RecordValue::Float(3.14)));
+    }
+
+    #[test]
+    fn rejects_non_object() {
+        let reader = JsonRecordReader::new();
+        let data = br#"[1, 2, 3]"#;
+        assert!(reader.read_records(data, None).is_err());
+    }
+
+    #[test]
+    fn validates_against_schema() {
+        use runifi_plugin_api::record::{RecordFieldType, SchemaField};
+
+        let schema = RecordSchema::new(
+            None,
+            vec![SchemaField {
+                name: "name".to_string(),
+                field_type: RecordFieldType::String,
+                nullable: false,
+            }],
+        );
+
+        let reader = JsonRecordReader::new();
+        // Valid.
+        let data = br#"[{"name":"Alice"}]"#;
+        assert!(reader.read_records(data, Some(&schema)).is_ok());
+
+        // Missing required field.
+        let data2 = br#"[{"age":30}]"#;
+        assert!(reader.read_records(data2, Some(&schema)).is_err());
+    }
+
+    #[test]
+    fn ndjson_skips_blank_lines() {
+        let reader = JsonRecordReader::new();
+        let data = b"{\"a\":1}\n\n{\"a\":2}\n\n";
+        let records = reader.read_records(data, None).unwrap();
+        assert_eq!(records.len(), 2);
+    }
+}

--- a/crates/runifi-processors/src/record/json_writer.rs
+++ b/crates/runifi-processors/src/record/json_writer.rs
@@ -1,0 +1,269 @@
+//! JSON RecordWriter — serializes Records into JSON arrays or NDJSON.
+
+use runifi_plugin_api::record::{Record, RecordSchema, RecordValue, RecordWriter};
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+use serde_json::{Map, Value};
+
+/// Output format for JSON writing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonOutputFormat {
+    /// A JSON array of objects: `[{...}, {...}]`
+    Array,
+    /// Newline-delimited JSON (NDJSON): one object per line.
+    LineDelimited,
+}
+
+/// A [`RecordWriter`] that serializes records to JSON.
+pub struct JsonRecordWriter {
+    format: JsonOutputFormat,
+    pretty: bool,
+}
+
+impl JsonRecordWriter {
+    pub fn new(format: JsonOutputFormat) -> Self {
+        Self {
+            format,
+            pretty: false,
+        }
+    }
+
+    /// Enable pretty-printing (indented JSON).
+    pub fn pretty(mut self) -> Self {
+        self.pretty = true;
+        self
+    }
+}
+
+impl Default for JsonRecordWriter {
+    fn default() -> Self {
+        Self::new(JsonOutputFormat::Array)
+    }
+}
+
+impl RecordWriter for JsonRecordWriter {
+    fn write_records(
+        &self,
+        records: &[Record],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<u8>> {
+        match self.format {
+            JsonOutputFormat::Array => self.write_array(records, schema),
+            JsonOutputFormat::LineDelimited => self.write_ndjson(records, schema),
+        }
+    }
+}
+
+impl JsonRecordWriter {
+    fn write_array(
+        &self,
+        records: &[Record],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<u8>> {
+        let values: Vec<Value> = records
+            .iter()
+            .map(|r| record_to_json_value(r, schema))
+            .collect();
+        let arr = Value::Array(values);
+
+        let bytes = if self.pretty {
+            serde_json::to_vec_pretty(&arr)
+        } else {
+            serde_json::to_vec(&arr)
+        }
+        .map_err(|e| PluginError::ProcessingFailed(format!("JSON serialization error: {e}")))?;
+
+        Ok(bytes)
+    }
+
+    fn write_ndjson(
+        &self,
+        records: &[Record],
+        schema: Option<&RecordSchema>,
+    ) -> ProcessResult<Vec<u8>> {
+        let mut output = Vec::new();
+        for record in records {
+            let value = record_to_json_value(record, schema);
+            let line = serde_json::to_vec(&value).map_err(|e| {
+                PluginError::ProcessingFailed(format!("JSON serialization error: {e}"))
+            })?;
+            output.extend_from_slice(&line);
+            output.push(b'\n');
+        }
+        Ok(output)
+    }
+}
+
+/// Convert a [`Record`] into a `serde_json::Value`.
+///
+/// If a schema is provided, fields are written in schema order. Extra fields
+/// in the record that are not in the schema are appended at the end.
+fn record_to_json_value(record: &Record, schema: Option<&RecordSchema>) -> Value {
+    let mut map = Map::new();
+
+    if let Some(schema) = schema {
+        // Write fields in schema order first.
+        for field_def in &schema.fields {
+            let value = record
+                .get(&field_def.name)
+                .map(record_value_to_json)
+                .unwrap_or(Value::Null);
+            map.insert(field_def.name.clone(), value);
+        }
+        // Append any extra fields not in the schema.
+        for (name, value) in record.iter() {
+            if !map.contains_key(name) {
+                map.insert(name.to_string(), record_value_to_json(value));
+            }
+        }
+    } else {
+        for (name, value) in record.iter() {
+            map.insert(name.to_string(), record_value_to_json(value));
+        }
+    }
+
+    Value::Object(map)
+}
+
+/// Convert a [`RecordValue`] into a `serde_json::Value`.
+fn record_value_to_json(value: &RecordValue) -> Value {
+    match value {
+        RecordValue::Null => Value::Null,
+        RecordValue::Boolean(b) => Value::Bool(*b),
+        RecordValue::Int(n) => Value::Number((*n).into()),
+        RecordValue::Float(f) => {
+            serde_json::Number::from_f64(*f).map_or(Value::Null, Value::Number)
+        }
+        RecordValue::String(s) => Value::String(s.clone()),
+        RecordValue::Array(arr) => Value::Array(arr.iter().map(record_value_to_json).collect()),
+        RecordValue::Record(rec) => record_to_json_value(rec, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runifi_plugin_api::RecordReader;
+
+    fn make_record(fields: Vec<(&str, RecordValue)>) -> Record {
+        Record::from_fields(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn writes_json_array() {
+        let writer = JsonRecordWriter::new(JsonOutputFormat::Array);
+        let records = vec![
+            make_record(vec![
+                ("name", RecordValue::String("Alice".to_string())),
+                ("age", RecordValue::Int(30)),
+            ]),
+            make_record(vec![
+                ("name", RecordValue::String("Bob".to_string())),
+                ("age", RecordValue::Int(25)),
+            ]),
+        ];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let parsed: Vec<Value> = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["name"], "Alice");
+        assert_eq!(parsed[0]["age"], 30);
+        assert_eq!(parsed[1]["name"], "Bob");
+    }
+
+    #[test]
+    fn writes_ndjson() {
+        let writer = JsonRecordWriter::new(JsonOutputFormat::LineDelimited);
+        let records = vec![
+            make_record(vec![("x", RecordValue::Int(1))]),
+            make_record(vec![("x", RecordValue::Int(2))]),
+        ];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+
+        assert_eq!(lines.len(), 2);
+        let v0: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(v0["x"], 1);
+    }
+
+    #[test]
+    fn writes_empty_records() {
+        let writer = JsonRecordWriter::new(JsonOutputFormat::Array);
+        let output = writer.write_records(&[], None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert_eq!(text, "[]");
+    }
+
+    #[test]
+    fn writes_nested_values() {
+        let writer = JsonRecordWriter::new(JsonOutputFormat::Array);
+        let inner = make_record(vec![("zip", RecordValue::String("90210".to_string()))]);
+        let records = vec![make_record(vec![
+            ("address", RecordValue::Record(inner)),
+            (
+                "tags",
+                RecordValue::Array(vec![
+                    RecordValue::String("a".to_string()),
+                    RecordValue::String("b".to_string()),
+                ]),
+            ),
+        ])];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let parsed: Vec<Value> = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(parsed[0]["address"]["zip"], "90210");
+        assert_eq!(parsed[0]["tags"][0], "a");
+    }
+
+    #[test]
+    fn writes_null_and_bool() {
+        let writer = JsonRecordWriter::new(JsonOutputFormat::Array);
+        let records = vec![make_record(vec![
+            ("flag", RecordValue::Boolean(true)),
+            ("empty", RecordValue::Null),
+        ])];
+
+        let output = writer.write_records(&records, None).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        let parsed: Vec<Value> = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(parsed[0]["flag"], true);
+        assert!(parsed[0]["empty"].is_null());
+    }
+
+    #[test]
+    fn roundtrip_json() {
+        use crate::record::json_reader::JsonRecordReader;
+
+        let original = vec![
+            make_record(vec![
+                ("name", RecordValue::String("Alice".to_string())),
+                ("age", RecordValue::Int(30)),
+                ("active", RecordValue::Boolean(true)),
+            ]),
+            make_record(vec![
+                ("name", RecordValue::String("Bob".to_string())),
+                ("age", RecordValue::Int(25)),
+                ("active", RecordValue::Boolean(false)),
+            ]),
+        ];
+
+        let writer = JsonRecordWriter::new(JsonOutputFormat::Array);
+        let bytes = writer.write_records(&original, None).unwrap();
+
+        let reader = JsonRecordReader::new();
+        let parsed = reader.read_records(&bytes, None).unwrap();
+
+        assert_eq!(original, parsed);
+    }
+}

--- a/crates/runifi-processors/src/record/mod.rs
+++ b/crates/runifi-processors/src/record/mod.rs
@@ -1,0 +1,13 @@
+//! Record-oriented processing: readers, writers, schema registry, and processors.
+//!
+//! This module implements the record processing framework for RuniFi, enabling
+//! structured data transformation without creating individual FlowFiles per record.
+
+pub mod convert_record;
+pub mod csv_reader;
+pub mod csv_writer;
+pub mod json_reader;
+pub mod json_writer;
+pub mod partition_record;
+pub mod schema_registry;
+pub mod update_record;

--- a/crates/runifi-processors/src/record/partition_record.rs
+++ b/crates/runifi-processors/src/record/partition_record.rs
@@ -1,0 +1,482 @@
+//! PartitionRecord processor — splits records into groups by field value.
+//!
+//! Reads records from a FlowFile, groups them by the value of a specified field,
+//! and creates one output FlowFile per group. Each output FlowFile's content
+//! contains only the records belonging to that group.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use runifi_plugin_api::context::ProcessContext;
+use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::property::PropertyDescriptor;
+use runifi_plugin_api::record::{Record, RecordReader, RecordValue, RecordWriter};
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+use runifi_plugin_api::session::ProcessSession;
+use runifi_plugin_api::{REL_FAILURE, REL_SUCCESS};
+
+use super::csv_reader::CsvRecordReader;
+use super::csv_writer::CsvRecordWriter;
+use super::json_reader::JsonRecordReader;
+use super::json_writer::{JsonOutputFormat, JsonRecordWriter};
+
+const PROP_FORMAT: PropertyDescriptor = PropertyDescriptor::new(
+    "Record Format",
+    "Data format: 'json', 'json-lines', 'csv', 'tsv'",
+)
+.required()
+.default_value("json")
+.allowed_values(&["json", "json-lines", "csv", "tsv"]);
+
+const PROP_PARTITION_FIELD: PropertyDescriptor = PropertyDescriptor::new(
+    "Partition Field",
+    "The record field to partition by. Records with the same value in this field are grouped together.",
+)
+.required();
+
+/// Partitions records by a field value, creating one FlowFile per group.
+///
+/// For example, if the partition field is "department", a FlowFile containing:
+/// ```json
+/// [{"name":"Alice","department":"eng"},{"name":"Bob","department":"sales"},{"name":"Carol","department":"eng"}]
+/// ```
+/// produces two FlowFiles:
+/// - One with `[{"name":"Alice","department":"eng"},{"name":"Carol","department":"eng"}]`
+///   and attribute `partition.value=eng`
+/// - One with `[{"name":"Bob","department":"sales"}]`
+///   and attribute `partition.value=sales`
+pub struct PartitionRecord;
+
+impl PartitionRecord {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for PartitionRecord {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Processor for PartitionRecord {
+    fn on_trigger(
+        &mut self,
+        context: &dyn ProcessContext,
+        session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        let format = context
+            .get_property("Record Format")
+            .unwrap_or("json")
+            .to_string();
+        let partition_field = context
+            .get_property("Partition Field")
+            .as_str()
+            .ok_or(PluginError::PropertyRequired("Partition Field"))?
+            .to_string();
+
+        let reader = build_reader(&format);
+        let writer = build_writer(&format);
+
+        while let Some(flowfile) = session.get() {
+            let content = session.read_content(&flowfile)?;
+
+            match reader.read_records(&content, None) {
+                Ok(records) => {
+                    // Group records by partition field value.
+                    let mut groups: BTreeMap<String, Vec<Record>> = BTreeMap::new();
+
+                    for record in records {
+                        let key = record
+                            .get(&partition_field)
+                            .map(record_value_to_partition_key)
+                            .unwrap_or_else(|| "__null__".to_string());
+                        groups.entry(key).or_default().push(record);
+                    }
+
+                    // Create one FlowFile per group.
+                    for (partition_value, group_records) in &groups {
+                        let record_count = group_records.len();
+                        match writer.write_records(group_records, None) {
+                            Ok(output) => {
+                                let mut new_ff = session.create();
+                                // Copy attributes from the original FlowFile.
+                                for (key, value) in &flowfile.attributes {
+                                    new_ff.set_attribute(key.clone(), value.clone());
+                                }
+                                new_ff = session.write_content(new_ff, Bytes::from(output))?;
+                                new_ff.set_attribute(
+                                    Arc::from("partition.field"),
+                                    Arc::from(partition_field.as_str()),
+                                );
+                                new_ff.set_attribute(
+                                    Arc::from("partition.value"),
+                                    Arc::from(partition_value.as_str()),
+                                );
+                                new_ff.set_attribute(
+                                    Arc::from("record.count"),
+                                    Arc::from(record_count.to_string().as_str()),
+                                );
+                                session.transfer(new_ff, &REL_SUCCESS);
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    error = %e,
+                                    partition = partition_value,
+                                    "Failed to write partition records"
+                                );
+                                session.transfer(flowfile, &REL_FAILURE);
+                                session.commit();
+                                return Ok(());
+                            }
+                        }
+                    }
+
+                    // Remove the original FlowFile (it has been replaced by partitions).
+                    session.remove(flowfile);
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to read records for partitioning");
+                    session.transfer(flowfile, &REL_FAILURE);
+                }
+            }
+        }
+
+        session.commit();
+        Ok(())
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS, REL_FAILURE]
+    }
+
+    fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
+        vec![PROP_FORMAT, PROP_PARTITION_FIELD]
+    }
+}
+
+/// Convert a [`RecordValue`] to a string key for partitioning.
+fn record_value_to_partition_key(value: &RecordValue) -> String {
+    match value {
+        RecordValue::Null => "__null__".to_string(),
+        RecordValue::String(s) => s.clone(),
+        RecordValue::Int(n) => n.to_string(),
+        RecordValue::Float(f) => f.to_string(),
+        RecordValue::Boolean(b) => b.to_string(),
+        RecordValue::Array(_) => "__array__".to_string(),
+        RecordValue::Record(_) => "__record__".to_string(),
+    }
+}
+
+fn build_reader(format: &str) -> Box<dyn RecordReader> {
+    match format {
+        "csv" => Box::new(CsvRecordReader::new()),
+        "tsv" => Box::new(CsvRecordReader::new().delimiter(b'\t')),
+        "json-lines" => Box::new(JsonRecordReader::new()),
+        _ => Box::new(JsonRecordReader::new()),
+    }
+}
+
+fn build_writer(format: &str) -> Box<dyn RecordWriter> {
+    match format {
+        "csv" => Box::new(CsvRecordWriter::new()),
+        "tsv" => Box::new(CsvRecordWriter::new().delimiter(b'\t')),
+        "json-lines" => Box::new(JsonRecordWriter::new(JsonOutputFormat::LineDelimited)),
+        _ => Box::new(JsonRecordWriter::new(JsonOutputFormat::Array)),
+    }
+}
+
+inventory::submit! {
+    ProcessorDescriptor {
+        type_name: "PartitionRecord",
+        description: "Splits records into groups by field value, creating one FlowFile per group",
+        factory: || Box::new(PartitionRecord::new()),
+        tags: &["Record", "Routing", "Partition"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runifi_plugin_api::FlowFile;
+    use runifi_plugin_api::property::PropertyValue;
+
+    struct TestContext {
+        format: String,
+        partition_field: String,
+    }
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, name: &str) -> PropertyValue {
+            match name {
+                "Record Format" => PropertyValue::String(self.format.clone()),
+                "Partition Field" => PropertyValue::String(self.partition_field.clone()),
+                _ => PropertyValue::Unset,
+            }
+        }
+        fn name(&self) -> &str {
+            "test-partition"
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    struct PartitionSession {
+        inputs: Vec<FlowFile>,
+        content: std::collections::HashMap<u64, Bytes>,
+        transferred: Vec<(FlowFile, &'static str)>,
+        removed: Vec<u64>,
+        next_id: u64,
+    }
+
+    impl PartitionSession {
+        fn new() -> Self {
+            Self {
+                inputs: Vec::new(),
+                content: std::collections::HashMap::new(),
+                transferred: Vec::new(),
+                removed: Vec::new(),
+                next_id: 100,
+            }
+        }
+
+        fn add_flowfile_with_content(&mut self, data: &[u8]) {
+            let id = self.next_id;
+            self.next_id += 1;
+            let ff = FlowFile {
+                id,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: data.len() as u64,
+                created_at_nanos: 0,
+                lineage_start_id: id,
+                penalized_until_nanos: 0,
+            };
+            self.content.insert(id, Bytes::from(data.to_vec()));
+            self.inputs.push(ff);
+        }
+    }
+
+    impl ProcessSession for PartitionSession {
+        fn get(&mut self) -> Option<FlowFile> {
+            if self.inputs.is_empty() {
+                None
+            } else {
+                Some(self.inputs.remove(0))
+            }
+        }
+        fn get_batch(&mut self, _max: usize) -> Vec<FlowFile> {
+            std::mem::take(&mut self.inputs)
+        }
+        fn read_content(&self, ff: &FlowFile) -> ProcessResult<Bytes> {
+            self.content
+                .get(&ff.id)
+                .cloned()
+                .ok_or(PluginError::ContentNotFound(ff.id))
+        }
+        fn write_content(&mut self, mut ff: FlowFile, data: Bytes) -> ProcessResult<FlowFile> {
+            ff.size = data.len() as u64;
+            self.content.insert(ff.id, data);
+            Ok(ff)
+        }
+        fn create(&mut self) -> FlowFile {
+            let id = self.next_id;
+            self.next_id += 1;
+            FlowFile {
+                id,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: 0,
+                created_at_nanos: 0,
+                lineage_start_id: id,
+                penalized_until_nanos: 0,
+            }
+        }
+        fn clone_flowfile(&mut self, ff: &FlowFile) -> FlowFile {
+            let id = self.next_id;
+            self.next_id += 1;
+            let mut cloned = ff.clone();
+            cloned.id = id;
+            if let Some(content) = self.content.get(&ff.id) {
+                self.content.insert(id, content.clone());
+            }
+            cloned
+        }
+        fn transfer(&mut self, ff: FlowFile, rel: &Relationship) {
+            self.transferred.push((ff, rel.name));
+        }
+        fn remove(&mut self, ff: FlowFile) {
+            self.removed.push(ff.id);
+        }
+        fn penalize(&mut self, ff: FlowFile) -> FlowFile {
+            ff
+        }
+        fn commit(&mut self) {}
+        fn rollback(&mut self) {}
+    }
+
+    #[test]
+    fn partitions_by_field() {
+        let mut proc = PartitionRecord::new();
+        let ctx = TestContext {
+            format: "json".to_string(),
+            partition_field: "dept".to_string(),
+        };
+
+        let mut session = PartitionSession::new();
+        session.add_flowfile_with_content(
+            br#"[{"name":"Alice","dept":"eng"},{"name":"Bob","dept":"sales"},{"name":"Carol","dept":"eng"}]"#,
+        );
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // Should produce 2 FlowFiles (eng, sales).
+        let success: Vec<_> = session
+            .transferred
+            .iter()
+            .filter(|(_, rel)| *rel == "success")
+            .collect();
+        assert_eq!(success.len(), 2);
+
+        // Check partition attributes.
+        let mut partition_values: Vec<String> = success
+            .iter()
+            .map(|(ff, _)| {
+                ff.get_attribute("partition.value")
+                    .unwrap()
+                    .as_ref()
+                    .to_string()
+            })
+            .collect();
+        partition_values.sort();
+        assert_eq!(partition_values, vec!["eng", "sales"]);
+
+        // Check record counts.
+        let eng = success
+            .iter()
+            .find(|(ff, _)| ff.get_attribute("partition.value").unwrap().as_ref() == "eng")
+            .unwrap();
+        assert_eq!(eng.0.get_attribute("record.count").unwrap().as_ref(), "2");
+
+        let sales = success
+            .iter()
+            .find(|(ff, _)| ff.get_attribute("partition.value").unwrap().as_ref() == "sales")
+            .unwrap();
+        assert_eq!(sales.0.get_attribute("record.count").unwrap().as_ref(), "1");
+
+        // Original should be removed.
+        assert_eq!(session.removed.len(), 1);
+    }
+
+    #[test]
+    fn handles_missing_partition_field() {
+        let mut proc = PartitionRecord::new();
+        let ctx = TestContext {
+            format: "json".to_string(),
+            partition_field: "missing_field".to_string(),
+        };
+
+        let mut session = PartitionSession::new();
+        session.add_flowfile_with_content(br#"[{"a":1},{"a":2}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        // All records should go into the "__null__" partition.
+        let success: Vec<_> = session
+            .transferred
+            .iter()
+            .filter(|(_, rel)| *rel == "success")
+            .collect();
+        assert_eq!(success.len(), 1);
+        assert_eq!(
+            success[0]
+                .0
+                .get_attribute("partition.value")
+                .unwrap()
+                .as_ref(),
+            "__null__"
+        );
+    }
+
+    #[test]
+    fn partitions_numeric_field() {
+        let mut proc = PartitionRecord::new();
+        let ctx = TestContext {
+            format: "json".to_string(),
+            partition_field: "level".to_string(),
+        };
+
+        let mut session = PartitionSession::new();
+        session.add_flowfile_with_content(
+            br#"[{"msg":"a","level":1},{"msg":"b","level":2},{"msg":"c","level":1}]"#,
+        );
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        let success: Vec<_> = session
+            .transferred
+            .iter()
+            .filter(|(_, rel)| *rel == "success")
+            .collect();
+        assert_eq!(success.len(), 2);
+    }
+
+    #[test]
+    fn invalid_input_goes_to_failure() {
+        let mut proc = PartitionRecord::new();
+        let ctx = TestContext {
+            format: "json".to_string(),
+            partition_field: "x".to_string(),
+        };
+
+        let mut session = PartitionSession::new();
+        session.add_flowfile_with_content(b"not json");
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "failure");
+    }
+
+    #[test]
+    fn copies_original_attributes() {
+        let mut proc = PartitionRecord::new();
+        let ctx = TestContext {
+            format: "json".to_string(),
+            partition_field: "type".to_string(),
+        };
+
+        let mut session = PartitionSession::new();
+        let id = session.next_id;
+        session.next_id += 1;
+        let mut ff = FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        };
+        ff.set_attribute(Arc::from("source"), Arc::from("test-source"));
+        let data = br#"[{"type":"a"}]"#;
+        session.content.insert(id, Bytes::from(data.to_vec()));
+        ff.size = data.len() as u64;
+        session.inputs.push(ff);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        let success = &session.transferred[0];
+        assert_eq!(success.1, "success");
+        assert_eq!(
+            success.0.get_attribute("source").unwrap().as_ref(),
+            "test-source"
+        );
+    }
+}

--- a/crates/runifi-processors/src/record/schema_registry.rs
+++ b/crates/runifi-processors/src/record/schema_registry.rs
@@ -1,0 +1,248 @@
+//! In-memory SchemaRegistry — a ControllerService for managing RecordSchemas.
+//!
+//! Processors can look up schemas by name through the service registry.
+//! Schemas can be registered programmatically or inferred from data.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use runifi_plugin_api::property::PropertyDescriptor;
+use runifi_plugin_api::record::{Record, RecordSchema};
+use runifi_plugin_api::result::ProcessResult;
+use runifi_plugin_api::service::{ControllerService, ControllerServiceDescriptor};
+
+/// In-memory schema registry.
+///
+/// Provides thread-safe storage and retrieval of [`RecordSchema`]s by name.
+/// Registered as a controller service so processors can look up shared schemas.
+pub struct SchemaRegistry {
+    schemas: Arc<RwLock<HashMap<String, Arc<RecordSchema>>>>,
+    enabled: bool,
+}
+
+impl SchemaRegistry {
+    pub fn new() -> Self {
+        Self {
+            schemas: Arc::new(RwLock::new(HashMap::new())),
+            enabled: false,
+        }
+    }
+
+    /// Register a schema by name. Overwrites any existing schema with the same name.
+    pub fn register(&self, name: String, schema: RecordSchema) {
+        let mut schemas = self.schemas.write();
+        let mut named_schema = schema;
+        named_schema.name = Some(name.clone());
+        schemas.insert(name, Arc::new(named_schema));
+    }
+
+    /// Look up a schema by name.
+    pub fn get_schema(&self, name: &str) -> Option<Arc<RecordSchema>> {
+        let schemas = self.schemas.read();
+        schemas.get(name).cloned()
+    }
+
+    /// Remove a schema by name.
+    pub fn remove_schema(&self, name: &str) -> Option<Arc<RecordSchema>> {
+        let mut schemas = self.schemas.write();
+        schemas.remove(name)
+    }
+
+    /// List all registered schema names.
+    pub fn schema_names(&self) -> Vec<String> {
+        let schemas = self.schemas.read();
+        schemas.keys().cloned().collect()
+    }
+
+    /// Infer a schema from a batch of records and optionally register it.
+    ///
+    /// Examines up to `sample_size` records to build a merged schema that
+    /// covers all observed field names and types.
+    pub fn infer_schema(
+        records: &[Record],
+        sample_size: usize,
+        name: Option<String>,
+    ) -> RecordSchema {
+        let sample = &records[..records.len().min(sample_size)];
+
+        if sample.is_empty() {
+            return RecordSchema::new(name, Vec::new());
+        }
+
+        let mut schema = RecordSchema::infer_from_record(&sample[0]);
+        for record in &sample[1..] {
+            let record_schema = RecordSchema::infer_from_record(record);
+            schema = schema.merge(&record_schema);
+        }
+        schema.name = name;
+        schema
+    }
+}
+
+impl Default for SchemaRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ControllerService for SchemaRegistry {
+    fn on_configure(&mut self, _properties: &HashMap<String, String>) -> ProcessResult {
+        Ok(())
+    }
+
+    fn validate(&self) -> ProcessResult {
+        Ok(())
+    }
+
+    fn enable(&mut self) -> ProcessResult {
+        self.enabled = true;
+        tracing::info!("SchemaRegistry enabled");
+        Ok(())
+    }
+
+    fn disable(&mut self) -> ProcessResult {
+        self.enabled = false;
+        tracing::info!("SchemaRegistry disabled");
+        Ok(())
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
+        Vec::new()
+    }
+}
+
+inventory::submit! {
+    ControllerServiceDescriptor {
+        type_name: "SchemaRegistry",
+        description: "In-memory schema registry for record-oriented processing",
+        factory: || Box::new(SchemaRegistry::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runifi_plugin_api::record::{RecordFieldType, RecordValue};
+
+    fn make_record(fields: Vec<(&str, RecordValue)>) -> Record {
+        Record::from_fields(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn register_and_lookup() {
+        let registry = SchemaRegistry::new();
+        let schema = RecordSchema::infer_from_record(&make_record(vec![
+            ("name", RecordValue::String("test".to_string())),
+            ("age", RecordValue::Int(25)),
+        ]));
+
+        registry.register("person".to_string(), schema);
+
+        let found = registry.get_schema("person").unwrap();
+        assert_eq!(
+            found.field("name").unwrap().field_type,
+            RecordFieldType::String
+        );
+        assert_eq!(found.field("age").unwrap().field_type, RecordFieldType::Int);
+        assert_eq!(found.name, Some("person".to_string()));
+    }
+
+    #[test]
+    fn lookup_missing() {
+        let registry = SchemaRegistry::new();
+        assert!(registry.get_schema("nonexistent").is_none());
+    }
+
+    #[test]
+    fn remove_schema() {
+        let registry = SchemaRegistry::new();
+        let schema = RecordSchema::new(None, Vec::new());
+        registry.register("test".to_string(), schema);
+        assert!(registry.get_schema("test").is_some());
+
+        registry.remove_schema("test");
+        assert!(registry.get_schema("test").is_none());
+    }
+
+    #[test]
+    fn schema_names() {
+        let registry = SchemaRegistry::new();
+        registry.register("a".to_string(), RecordSchema::new(None, Vec::new()));
+        registry.register("b".to_string(), RecordSchema::new(None, Vec::new()));
+
+        let mut names = registry.schema_names();
+        names.sort();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn infer_schema_from_records() {
+        let records = vec![
+            make_record(vec![
+                ("name", RecordValue::String("Alice".to_string())),
+                ("age", RecordValue::Int(30)),
+            ]),
+            make_record(vec![
+                ("name", RecordValue::String("Bob".to_string())),
+                ("age", RecordValue::Int(25)),
+                ("email", RecordValue::String("bob@example.com".to_string())),
+            ]),
+        ];
+
+        let schema = SchemaRegistry::infer_schema(&records, 10, Some("inferred".to_string()));
+
+        assert_eq!(schema.name, Some("inferred".to_string()));
+        assert!(schema.field("name").is_some());
+        assert!(schema.field("age").is_some());
+        assert!(schema.field("email").is_some());
+        // "email" only in second record -> nullable.
+        assert!(schema.field("email").unwrap().nullable);
+    }
+
+    #[test]
+    fn infer_schema_empty() {
+        let schema = SchemaRegistry::infer_schema(&[], 10, None);
+        assert!(schema.fields.is_empty());
+    }
+
+    #[test]
+    fn controller_service_lifecycle() {
+        let mut registry = SchemaRegistry::new();
+        assert!(!registry.is_enabled());
+
+        registry.enable().unwrap();
+        assert!(registry.is_enabled());
+
+        registry.disable().unwrap();
+        assert!(!registry.is_enabled());
+    }
+
+    #[test]
+    fn overwrite_schema() {
+        let registry = SchemaRegistry::new();
+        let schema1 =
+            RecordSchema::infer_from_record(&make_record(vec![("a", RecordValue::Int(1))]));
+        registry.register("test".to_string(), schema1);
+
+        let schema2 = RecordSchema::infer_from_record(&make_record(vec![(
+            "b",
+            RecordValue::String("x".to_string()),
+        )]));
+        registry.register("test".to_string(), schema2);
+
+        let found = registry.get_schema("test").unwrap();
+        // Should have the second schema's fields.
+        assert!(found.field("b").is_some());
+        assert!(found.field("a").is_none());
+    }
+}

--- a/crates/runifi-processors/src/record/update_record.rs
+++ b/crates/runifi-processors/src/record/update_record.rs
@@ -1,0 +1,427 @@
+//! UpdateRecord processor — modifies record fields within FlowFile content.
+//!
+//! Reads records from a FlowFile, applies field-level modifications configured
+//! as dynamic properties, and writes the modified records back. Supports
+//! setting, removing, and renaming fields.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use runifi_plugin_api::context::ProcessContext;
+use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::property::PropertyDescriptor;
+use runifi_plugin_api::record::{RecordReader, RecordValue, RecordWriter};
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::ProcessResult;
+use runifi_plugin_api::session::ProcessSession;
+use runifi_plugin_api::{REL_FAILURE, REL_SUCCESS};
+
+use super::csv_reader::CsvRecordReader;
+use super::csv_writer::CsvRecordWriter;
+use super::json_reader::JsonRecordReader;
+use super::json_writer::{JsonOutputFormat, JsonRecordWriter};
+
+const PROP_FORMAT: PropertyDescriptor = PropertyDescriptor::new(
+    "Record Format",
+    "Data format: 'json', 'json-lines', 'csv', 'tsv'",
+)
+.required()
+.default_value("json")
+.allowed_values(&["json", "json-lines", "csv", "tsv"]);
+
+const PROP_REMOVE_FIELDS: PropertyDescriptor = PropertyDescriptor::new(
+    "Remove Fields",
+    "Comma-separated list of field names to remove from each record",
+);
+
+/// The set of property names owned by this processor (not treated as field updates).
+const OWN_PROPERTY_NAMES: &[&str] = &["Record Format", "Remove Fields"];
+
+/// Modifies record fields within FlowFile content.
+///
+/// Dynamic properties (any property not in the processor's own descriptor list)
+/// are treated as field assignments: property name = field name, property value = new value.
+///
+/// The "Remove Fields" property specifies a comma-separated list of field names
+/// to remove from each record.
+///
+/// All updates are applied in-place: the FlowFile retains its identity but gets
+/// updated content with the modified records.
+pub struct UpdateRecord;
+
+impl UpdateRecord {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for UpdateRecord {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Processor for UpdateRecord {
+    fn on_trigger(
+        &mut self,
+        context: &dyn ProcessContext,
+        session: &mut dyn ProcessSession,
+    ) -> ProcessResult {
+        let format = context
+            .get_property("Record Format")
+            .unwrap_or("json")
+            .to_string();
+
+        let remove_fields: Vec<String> = context
+            .get_property("Remove Fields")
+            .as_str()
+            .map(|s| {
+                s.split(',')
+                    .map(|f| f.trim().to_string())
+                    .filter(|f| !f.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Collect field assignments from dynamic properties.
+        let all_names = context.property_names();
+        let field_updates: Vec<(String, String)> = all_names
+            .into_iter()
+            .filter(|name| !OWN_PROPERTY_NAMES.contains(&name.as_str()))
+            .filter_map(|name| {
+                context
+                    .get_property(&name)
+                    .as_str()
+                    .map(|v| (name, v.to_string()))
+            })
+            .collect();
+
+        let reader = build_reader(&format);
+        let writer = build_writer(&format);
+
+        while let Some(flowfile) = session.get() {
+            let content = session.read_content(&flowfile)?;
+
+            match reader.read_records(&content, None) {
+                Ok(mut records) => {
+                    // Apply modifications to each record.
+                    for record in &mut records {
+                        // Set/update fields.
+                        for (field_name, value_str) in &field_updates {
+                            let value = parse_value_string(value_str);
+                            record.set(field_name.clone(), value);
+                        }
+                        // Remove fields.
+                        for field_name in &remove_fields {
+                            record.remove(field_name);
+                        }
+                    }
+
+                    let record_count = records.len();
+                    match writer.write_records(&records, None) {
+                        Ok(output) => {
+                            let mut ff = session.write_content(flowfile, Bytes::from(output))?;
+                            ff.set_attribute(
+                                Arc::from("record.count"),
+                                Arc::from(record_count.to_string().as_str()),
+                            );
+                            session.transfer(ff, &REL_SUCCESS);
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "Failed to write updated records");
+                            session.transfer(flowfile, &REL_FAILURE);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to read records for update");
+                    session.transfer(flowfile, &REL_FAILURE);
+                }
+            }
+        }
+
+        session.commit();
+        Ok(())
+    }
+
+    fn relationships(&self) -> Vec<Relationship> {
+        vec![REL_SUCCESS, REL_FAILURE]
+    }
+
+    fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
+        vec![PROP_FORMAT, PROP_REMOVE_FIELDS]
+    }
+}
+
+/// Parse a string property value into a [`RecordValue`].
+///
+/// Attempts numeric and boolean parsing; falls back to string.
+fn parse_value_string(s: &str) -> RecordValue {
+    if s.eq_ignore_ascii_case("null") {
+        return RecordValue::Null;
+    }
+    if let Ok(i) = s.parse::<i64>() {
+        return RecordValue::Int(i);
+    }
+    if let Ok(f) = s.parse::<f64>() {
+        return RecordValue::Float(f);
+    }
+    match s.to_lowercase().as_str() {
+        "true" => RecordValue::Boolean(true),
+        "false" => RecordValue::Boolean(false),
+        _ => RecordValue::String(s.to_string()),
+    }
+}
+
+fn build_reader(format: &str) -> Box<dyn RecordReader> {
+    match format {
+        "csv" => Box::new(CsvRecordReader::new()),
+        "tsv" => Box::new(CsvRecordReader::new().delimiter(b'\t')),
+        "json-lines" => Box::new(JsonRecordReader::new()),
+        _ => Box::new(JsonRecordReader::new()),
+    }
+}
+
+fn build_writer(format: &str) -> Box<dyn RecordWriter> {
+    match format {
+        "csv" => Box::new(CsvRecordWriter::new()),
+        "tsv" => Box::new(CsvRecordWriter::new().delimiter(b'\t')),
+        "json-lines" => Box::new(JsonRecordWriter::new(JsonOutputFormat::LineDelimited)),
+        _ => Box::new(JsonRecordWriter::new(JsonOutputFormat::Array)),
+    }
+}
+
+inventory::submit! {
+    ProcessorDescriptor {
+        type_name: "UpdateRecord",
+        description: "Modifies record fields within FlowFile content using dynamic properties",
+        factory: || Box::new(UpdateRecord::new()),
+        tags: &["Record", "Transformation", "Update"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runifi_plugin_api::FlowFile;
+    use runifi_plugin_api::property::PropertyValue;
+    use runifi_plugin_api::result::PluginError;
+
+    struct TestContext {
+        properties: Vec<(String, String)>,
+    }
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, name: &str) -> PropertyValue {
+            for (k, v) in &self.properties {
+                if k == name {
+                    return PropertyValue::String(v.clone());
+                }
+            }
+            PropertyValue::Unset
+        }
+        fn property_names(&self) -> Vec<String> {
+            self.properties.iter().map(|(k, _)| k.clone()).collect()
+        }
+        fn name(&self) -> &str {
+            "test-update-record"
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    struct UpdateRecordSession {
+        inputs: Vec<FlowFile>,
+        content: std::collections::HashMap<u64, Bytes>,
+        transferred: Vec<(FlowFile, &'static str)>,
+        next_id: u64,
+    }
+
+    impl UpdateRecordSession {
+        fn new() -> Self {
+            Self {
+                inputs: Vec::new(),
+                content: std::collections::HashMap::new(),
+                transferred: Vec::new(),
+                next_id: 100,
+            }
+        }
+
+        fn add_flowfile_with_content(&mut self, data: &[u8]) {
+            let id = self.next_id;
+            self.next_id += 1;
+            let ff = FlowFile {
+                id,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: data.len() as u64,
+                created_at_nanos: 0,
+                lineage_start_id: id,
+                penalized_until_nanos: 0,
+            };
+            self.content.insert(id, Bytes::from(data.to_vec()));
+            self.inputs.push(ff);
+        }
+    }
+
+    impl ProcessSession for UpdateRecordSession {
+        fn get(&mut self) -> Option<FlowFile> {
+            if self.inputs.is_empty() {
+                None
+            } else {
+                Some(self.inputs.remove(0))
+            }
+        }
+        fn get_batch(&mut self, _max: usize) -> Vec<FlowFile> {
+            std::mem::take(&mut self.inputs)
+        }
+        fn read_content(&self, ff: &FlowFile) -> ProcessResult<Bytes> {
+            self.content
+                .get(&ff.id)
+                .cloned()
+                .ok_or(PluginError::ContentNotFound(ff.id))
+        }
+        fn write_content(&mut self, mut ff: FlowFile, data: Bytes) -> ProcessResult<FlowFile> {
+            ff.size = data.len() as u64;
+            self.content.insert(ff.id, data);
+            Ok(ff)
+        }
+        fn create(&mut self) -> FlowFile {
+            let id = self.next_id;
+            self.next_id += 1;
+            FlowFile {
+                id,
+                attributes: Vec::new(),
+                content_claim: None,
+                size: 0,
+                created_at_nanos: 0,
+                lineage_start_id: id,
+                penalized_until_nanos: 0,
+            }
+        }
+        fn clone_flowfile(&mut self, ff: &FlowFile) -> FlowFile {
+            let id = self.next_id;
+            self.next_id += 1;
+            let mut cloned = ff.clone();
+            cloned.id = id;
+            if let Some(content) = self.content.get(&ff.id) {
+                self.content.insert(id, content.clone());
+            }
+            cloned
+        }
+        fn transfer(&mut self, ff: FlowFile, rel: &Relationship) {
+            self.transferred.push((ff, rel.name));
+        }
+        fn remove(&mut self, _ff: FlowFile) {}
+        fn penalize(&mut self, ff: FlowFile) -> FlowFile {
+            ff
+        }
+        fn commit(&mut self) {}
+        fn rollback(&mut self) {}
+    }
+
+    #[test]
+    fn adds_field_to_records() {
+        let mut proc = UpdateRecord::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Record Format".to_string(), "json".to_string()),
+                ("status".to_string(), "processed".to_string()),
+            ],
+        };
+
+        let mut session = UpdateRecordSession::new();
+        session.add_flowfile_with_content(br#"[{"name":"Alice"}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred[0].1, "success");
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(output).unwrap();
+        assert_eq!(parsed[0]["status"], "processed");
+        assert_eq!(parsed[0]["name"], "Alice");
+    }
+
+    #[test]
+    fn removes_fields() {
+        let mut proc = UpdateRecord::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Record Format".to_string(), "json".to_string()),
+                ("Remove Fields".to_string(), "secret, temp".to_string()),
+            ],
+        };
+
+        let mut session = UpdateRecordSession::new();
+        session.add_flowfile_with_content(br#"[{"name":"Alice","secret":"xxx","temp":"yyy"}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(output).unwrap();
+        assert_eq!(parsed[0]["name"], "Alice");
+        assert!(parsed[0].get("secret").is_none());
+        assert!(parsed[0].get("temp").is_none());
+    }
+
+    #[test]
+    fn updates_existing_field() {
+        let mut proc = UpdateRecord::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Record Format".to_string(), "json".to_string()),
+                ("age".to_string(), "99".to_string()),
+            ],
+        };
+
+        let mut session = UpdateRecordSession::new();
+        session.add_flowfile_with_content(br#"[{"name":"Alice","age":30}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(output).unwrap();
+        assert_eq!(parsed[0]["age"], 99);
+    }
+
+    #[test]
+    fn sets_null_value() {
+        let mut proc = UpdateRecord::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Record Format".to_string(), "json".to_string()),
+                ("field".to_string(), "null".to_string()),
+            ],
+        };
+
+        let mut session = UpdateRecordSession::new();
+        session.add_flowfile_with_content(br#"[{"field":"value"}]"#);
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        let ff = &session.transferred[0].0;
+        let output = session.content.get(&ff.id).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(output).unwrap();
+        assert!(parsed[0]["field"].is_null());
+    }
+
+    #[test]
+    fn parse_value_string_types() {
+        assert_eq!(parse_value_string("42"), RecordValue::Int(42));
+        assert_eq!(parse_value_string("3.14"), RecordValue::Float(3.14));
+        assert_eq!(parse_value_string("true"), RecordValue::Boolean(true));
+        assert_eq!(parse_value_string("false"), RecordValue::Boolean(false));
+        assert_eq!(parse_value_string("null"), RecordValue::Null);
+        assert_eq!(
+            parse_value_string("hello"),
+            RecordValue::String("hello".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the record-oriented processing framework for RuniFi, enabling structured data transformation without creating individual FlowFiles per record.

### Record Types (in `runifi-plugin-api`)
- `Record` — ordered map of field names to `RecordValue` (BTreeMap for deterministic field ordering)
- `RecordValue` — String, Int, Float, Boolean, Array, Record (nested), Null
- `RecordSchema` — field names + types with nested schema support, validation, inference, and merge
- `RecordReader` / `RecordWriter` traits — parse/serialize records from/to bytes

### Built-in Readers/Writers (in `runifi-processors`)
- **JSON reader/writer** — array format (`[{...}, {...}]`) and NDJSON (newline-delimited)
- **CSV reader/writer** — configurable delimiter, header handling, type inference (int/float/bool)

### Schema Registry
- `SchemaRegistry` controller service — register/lookup/remove schemas by name
- Schema inference from records with configurable sample size
- Schema merge for unifying heterogeneous record batches
- Schema validation (required fields, type checking with implicit int->float widening)

### Record Processors
- `ConvertRecord` — read with one format, write with another (e.g., CSV -> JSON, JSON -> NDJSON)
- `UpdateRecord` — modify record fields via dynamic properties, remove fields by name
- `PartitionRecord` — split records into groups by field value, one FlowFile per group

### Test Coverage
35 new tests covering all components:
- Record type operations and schema validation
- JSON reader/writer including roundtrip, nested objects, NDJSON
- CSV reader/writer including type inference, delimiter config, schema ordering
- Schema registry CRUD, inference, merge, service lifecycle
- ConvertRecord format conversions (CSV<->JSON, JSON<->NDJSON)
- UpdateRecord field set/update/remove/null
- PartitionRecord grouping, attribute propagation, error handling

### Quality Gates
- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace -- -D warnings` — pass
- `cargo test --workspace` — all tests pass

Closes #33