### PR TITLE
feat: implement multi-node clustering with zero-leader architecture (#31)

### DIFF
--- a/crates/runifi-core/src/cluster/config.rs
+++ b/crates/runifi-core/src/cluster/config.rs
@@ -1,0 +1,226 @@
+use std::net::SocketAddr;
+
+use serde::Deserialize;
+
+/// Cluster configuration, typically loaded from the `[cluster]` section of a
+/// TOML config file.
+///
+/// ```toml
+/// [cluster]
+/// enabled = true
+/// node_id = "node-1"
+/// bind_address = "0.0.0.0:9443"
+/// nodes = ["node-1:9443", "node-2:9443", "node-3:9443"]
+/// heartbeat_interval_ms = 5000
+/// heartbeat_miss_threshold = 3
+/// election_timeout_ms = 10000
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClusterConfig {
+    /// Whether clustering is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Unique identifier for this node within the cluster.
+    #[serde(default = "default_node_id")]
+    pub node_id: String,
+
+    /// Address this node listens on for cluster traffic.
+    #[serde(default = "default_bind_address")]
+    pub bind_address: String,
+
+    /// Static list of all cluster node addresses (`host:port`).
+    #[serde(default)]
+    pub nodes: Vec<String>,
+
+    /// Heartbeat interval in milliseconds (default: 5000).
+    #[serde(default = "default_heartbeat_interval_ms")]
+    pub heartbeat_interval_ms: u64,
+
+    /// Number of missed heartbeats before a node is considered disconnected
+    /// (default: 3).
+    #[serde(default = "default_heartbeat_miss_threshold")]
+    pub heartbeat_miss_threshold: u32,
+
+    /// Election timeout in milliseconds (default: 10000).
+    /// A random jitter of 0..election_timeout_ms is added to prevent
+    /// simultaneous elections.
+    #[serde(default = "default_election_timeout_ms")]
+    pub election_timeout_ms: u64,
+}
+
+impl Default for ClusterConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            node_id: default_node_id(),
+            bind_address: default_bind_address(),
+            nodes: Vec::new(),
+            heartbeat_interval_ms: default_heartbeat_interval_ms(),
+            heartbeat_miss_threshold: default_heartbeat_miss_threshold(),
+            election_timeout_ms: default_election_timeout_ms(),
+        }
+    }
+}
+
+impl ClusterConfig {
+    /// Parse the bind address into a `SocketAddr`.
+    ///
+    /// Returns `None` if the address is invalid.
+    pub fn bind_socket_addr(&self) -> Option<SocketAddr> {
+        self.bind_address.parse().ok()
+    }
+
+    /// Resolve peer addresses (all configured nodes except this node).
+    pub fn peer_addresses(&self) -> Vec<String> {
+        self.nodes
+            .iter()
+            .filter(|addr| !self.is_self(addr))
+            .cloned()
+            .collect()
+    }
+
+    /// Check whether a given address string refers to this node.
+    ///
+    /// Matches by node_id prefix (e.g. "node-1:9443" starts with "node-1")
+    /// or by exact bind_address match.
+    fn is_self(&self, addr: &str) -> bool {
+        addr.starts_with(&self.node_id) || addr == self.bind_address
+    }
+
+    /// Validate the cluster configuration.
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if self.node_id.is_empty() {
+            return Err("cluster.node_id must not be empty".into());
+        }
+
+        if self.bind_address.is_empty() {
+            return Err("cluster.bind_address must not be empty".into());
+        }
+
+        if self.nodes.is_empty() {
+            return Err("cluster.nodes must contain at least one node address".into());
+        }
+
+        if self.nodes.len() < 2 {
+            return Err("cluster.nodes must contain at least 2 nodes for clustering".into());
+        }
+
+        if self.heartbeat_interval_ms == 0 {
+            return Err("cluster.heartbeat_interval_ms must be > 0".into());
+        }
+
+        if self.heartbeat_miss_threshold == 0 {
+            return Err("cluster.heartbeat_miss_threshold must be > 0".into());
+        }
+
+        Ok(())
+    }
+}
+
+fn default_node_id() -> String {
+    "node-1".to_string()
+}
+
+fn default_bind_address() -> String {
+    "0.0.0.0:9443".to_string()
+}
+
+fn default_heartbeat_interval_ms() -> u64 {
+    5000
+}
+
+fn default_heartbeat_miss_threshold() -> u32 {
+    3
+}
+
+fn default_election_timeout_ms() -> u64 {
+    10_000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_cluster_config_is_disabled() {
+        let config = ClusterConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.heartbeat_interval_ms, 5000);
+        assert_eq!(config.heartbeat_miss_threshold, 3);
+    }
+
+    #[test]
+    fn validate_disabled_cluster_always_ok() {
+        let config = ClusterConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_enabled_requires_nodes() {
+        let config = ClusterConfig {
+            enabled: true,
+            nodes: vec![],
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_enabled_requires_two_nodes() {
+        let config = ClusterConfig {
+            enabled: true,
+            nodes: vec!["node-1:9443".into()],
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_enabled_with_two_nodes_ok() {
+        let config = ClusterConfig {
+            enabled: true,
+            nodes: vec!["node-1:9443".into(), "node-2:9443".into()],
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn peer_addresses_excludes_self() {
+        let config = ClusterConfig {
+            node_id: "node-1".into(),
+            nodes: vec![
+                "node-1:9443".into(),
+                "node-2:9443".into(),
+                "node-3:9443".into(),
+            ],
+            ..Default::default()
+        };
+        let peers = config.peer_addresses();
+        assert_eq!(peers.len(), 2);
+        assert!(!peers.contains(&"node-1:9443".to_string()));
+    }
+
+    #[test]
+    fn deserialize_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            node_id = "node-2"
+            bind_address = "0.0.0.0:9443"
+            nodes = ["node-1:9443", "node-2:9443", "node-3:9443"]
+            heartbeat_interval_ms = 3000
+            heartbeat_miss_threshold = 5
+        "#;
+        let config: ClusterConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.node_id, "node-2");
+        assert_eq!(config.nodes.len(), 3);
+        assert_eq!(config.heartbeat_interval_ms, 3000);
+        assert_eq!(config.heartbeat_miss_threshold, 5);
+    }
+}

--- a/crates/runifi-core/src/cluster/coordinator.rs
+++ b/crates/runifi-core/src/cluster/coordinator.rs
@@ -1,0 +1,1118 @@
+//! Cluster coordinator — the main entry point for cluster operations.
+//!
+//! The `ClusterCoordinator` manages:
+//! - Node membership and state tracking
+//! - Heartbeat monitoring
+//! - Coordinator and primary node election
+//! - Flow configuration replication
+//! - TCP-based inter-node communication
+//!
+//! It is designed to be created once per RuniFi instance and driven by
+//! the engine's lifecycle (start/stop).
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::config::ClusterConfig;
+use super::election::{ElectionRole, ElectionState, RaftState};
+use super::heartbeat::{HeartbeatEvent, HeartbeatManager};
+use super::load_balance::{LoadBalanceStrategy, LoadBalancer};
+use super::node::{ClusterNodeId, ClusterRole, ClusterStatus, NodeInfo, NodeState, NodeSummary};
+use super::protocol::{
+    ClusterMessage, ElectionWonData, FlowSyncResponseData, FlowUpdateData, HeartbeatAckData,
+    HeartbeatData, JoinResponseData, MessagePayload, VoteRequestData, VoteResponseData,
+};
+use super::replication::FlowReplicator;
+
+/// The cluster coordinator manages all cluster operations for this node.
+pub struct ClusterCoordinator {
+    /// Cluster configuration.
+    config: ClusterConfig,
+
+    /// This node's ID.
+    self_id: ClusterNodeId,
+
+    /// All known cluster nodes, keyed by node ID.
+    nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+
+    /// Heartbeat manager.
+    heartbeat_manager: Arc<HeartbeatManager>,
+
+    /// Election state for the coordinator role.
+    coordinator_election: Arc<ElectionState>,
+
+    /// Election state for the primary node role.
+    primary_election: Arc<ElectionState>,
+
+    /// Flow replicator.
+    flow_replicator: Arc<FlowReplicator>,
+
+    /// Monotonic message sequence counter.
+    seq_counter: AtomicU64,
+
+    /// Cancellation token for all background tasks.
+    cancel_token: CancellationToken,
+
+    /// Handles for spawned background tasks.
+    task_handles: Vec<JoinHandle<()>>,
+}
+
+impl ClusterCoordinator {
+    /// Create a new cluster coordinator.
+    ///
+    /// This does not start any background tasks. Call `start()` to begin
+    /// cluster operations.
+    pub fn new(config: ClusterConfig) -> Self {
+        let self_id = config.node_id.clone();
+        let cluster_size = config.nodes.len();
+
+        // Initialize the node map with all configured nodes.
+        let mut node_map = HashMap::new();
+        for node_addr in &config.nodes {
+            let node_id = extract_node_id(node_addr);
+            let node = NodeInfo::new(node_id.clone(), node_addr.clone());
+            node_map.insert(node_id, node);
+        }
+
+        // Mark self as connected immediately.
+        if let Some(self_node) = node_map.get_mut(&self_id) {
+            self_node.state = NodeState::Connected;
+        }
+
+        let nodes = Arc::new(RwLock::new(node_map));
+
+        let heartbeat_manager = Arc::new(HeartbeatManager::new(&config, nodes.clone()));
+        let coordinator_election =
+            Arc::new(ElectionState::new(ElectionRole::Coordinator, cluster_size));
+        let primary_election =
+            Arc::new(ElectionState::new(ElectionRole::PrimaryNode, cluster_size));
+        let flow_replicator = Arc::new(FlowReplicator::new(nodes.clone()));
+
+        Self {
+            config,
+            self_id,
+            nodes,
+            heartbeat_manager,
+            coordinator_election,
+            primary_election,
+            flow_replicator,
+            seq_counter: AtomicU64::new(0),
+            cancel_token: CancellationToken::new(),
+            task_handles: Vec::new(),
+        }
+    }
+
+    /// Start the cluster coordinator.
+    ///
+    /// Spawns:
+    /// 1. TCP listener for incoming cluster messages.
+    /// 2. Heartbeat check loop.
+    /// 3. Heartbeat sender loop.
+    /// 4. Election timeout watcher.
+    /// 5. Heartbeat event handler.
+    pub async fn start(&mut self) -> io::Result<()> {
+        if !self.config.enabled {
+            tracing::info!("Clustering is disabled");
+            return Ok(());
+        }
+
+        tracing::info!(
+            node_id = %self.self_id,
+            bind_address = %self.config.bind_address,
+            cluster_size = self.config.nodes.len(),
+            "Starting cluster coordinator"
+        );
+
+        // Channel for heartbeat events.
+        let (event_tx, event_rx) = mpsc::channel::<HeartbeatEvent>(64);
+
+        // 1. TCP listener.
+        let listener = TcpListener::bind(&self.config.bind_address).await?;
+        let listener_cancel = self.cancel_token.child_token();
+        let nodes_listener = self.nodes.clone();
+        let coord_election_listener = self.coordinator_election.clone();
+        let primary_election_listener = self.primary_election.clone();
+        let flow_replicator_listener = self.flow_replicator.clone();
+        let self_id_listener = self.self_id.clone();
+        let heartbeat_mgr_listener = self.heartbeat_manager.clone();
+
+        let listener_handle = tokio::spawn(async move {
+            run_tcp_listener(
+                listener,
+                listener_cancel,
+                nodes_listener,
+                coord_election_listener,
+                primary_election_listener,
+                flow_replicator_listener,
+                heartbeat_mgr_listener,
+                self_id_listener,
+            )
+            .await;
+        });
+        self.task_handles.push(listener_handle);
+
+        // 2. Heartbeat check loop.
+        let hb_manager = self.heartbeat_manager.clone();
+        let hb_cancel = self.cancel_token.child_token();
+        let hb_event_tx = event_tx.clone();
+        let hb_handle = tokio::spawn(async move {
+            hb_manager.run_check_loop(hb_event_tx, hb_cancel).await;
+        });
+        self.task_handles.push(hb_handle);
+
+        // 3. Heartbeat sender loop.
+        let sender_cancel = self.cancel_token.child_token();
+        let sender_config = self.config.clone();
+        let sender_self_id = self.self_id.clone();
+        let sender_coord_election = self.coordinator_election.clone();
+        let sender_primary_election = self.primary_election.clone();
+        let sender_flow_replicator = self.flow_replicator.clone();
+        let sender_nodes = self.nodes.clone();
+        let sender_seq = Arc::new(AtomicU64::new(0));
+
+        let sender_handle = tokio::spawn(async move {
+            run_heartbeat_sender(
+                sender_cancel,
+                sender_config,
+                sender_self_id,
+                sender_coord_election,
+                sender_primary_election,
+                sender_flow_replicator,
+                sender_nodes,
+                sender_seq,
+            )
+            .await;
+        });
+        self.task_handles.push(sender_handle);
+
+        // 4. Election timeout watcher.
+        let election_cancel = self.cancel_token.child_token();
+        let election_config = self.config.clone();
+        let election_self_id = self.self_id.clone();
+        let election_coord = self.coordinator_election.clone();
+        let election_primary = self.primary_election.clone();
+        let election_nodes = self.nodes.clone();
+
+        let election_handle = tokio::spawn(async move {
+            run_election_watcher(
+                election_cancel,
+                election_config,
+                election_self_id,
+                election_coord,
+                election_primary,
+                election_nodes,
+            )
+            .await;
+        });
+        self.task_handles.push(election_handle);
+
+        // 5. Heartbeat event handler.
+        let event_cancel = self.cancel_token.child_token();
+        let event_self_id = self.self_id.clone();
+        let event_hb_mgr = self.heartbeat_manager.clone();
+        let event_nodes = self.nodes.clone();
+
+        let event_handle = tokio::spawn(async move {
+            run_event_handler(
+                event_rx,
+                event_cancel,
+                event_self_id,
+                event_hb_mgr,
+                event_nodes,
+            )
+            .await;
+        });
+        self.task_handles.push(event_handle);
+
+        tracing::info!(
+            node_id = %self.self_id,
+            "Cluster coordinator started — {} background tasks",
+            self.task_handles.len()
+        );
+
+        Ok(())
+    }
+
+    /// Stop the cluster coordinator gracefully.
+    pub async fn stop(&mut self) {
+        if !self.config.enabled {
+            return;
+        }
+
+        tracing::info!(node_id = %self.self_id, "Stopping cluster coordinator");
+
+        // Broadcast disconnect notice to peers.
+        let _ = self.broadcast_disconnect().await;
+
+        self.cancel_token.cancel();
+        for handle in self.task_handles.drain(..) {
+            let _ = handle.await;
+        }
+
+        // Reset election state.
+        self.coordinator_election.reset();
+        self.primary_election.reset();
+
+        tracing::info!(node_id = %self.self_id, "Cluster coordinator stopped");
+    }
+
+    /// Get the current cluster status.
+    pub fn status(&self) -> ClusterStatus {
+        let nodes = self.nodes.read();
+        let self_node = nodes.get(&self.self_id);
+
+        ClusterStatus {
+            enabled: self.config.enabled,
+            node_id: self.self_id.clone(),
+            state: self_node
+                .map(|n| n.state)
+                .unwrap_or(NodeState::Disconnected),
+            roles: self_node.map(|n| n.roles.clone()).unwrap_or_default(),
+            nodes: nodes.values().map(NodeSummary::from).collect(),
+            flow_version: self.flow_replicator.current_version(),
+            election_term: self.coordinator_election.term(),
+        }
+    }
+
+    /// Replicate a flow configuration change to all cluster nodes.
+    ///
+    /// Only the coordinator should call this. Returns `None` if this node
+    /// is not the coordinator.
+    pub async fn replicate_flow(&self, config: String) -> Option<u64> {
+        if !self.coordinator_election.is_leader() {
+            tracing::warn!("Cannot replicate flow — not the coordinator");
+            return None;
+        }
+
+        let term = self.coordinator_election.term();
+        let update = self.flow_replicator.prepare_update(config, term)?;
+        let version = update.version;
+
+        // Broadcast to all connected peers.
+        self.broadcast_flow_update(&update).await;
+
+        Some(version)
+    }
+
+    /// Get a reference to the flow replicator.
+    pub fn flow_replicator(&self) -> &Arc<FlowReplicator> {
+        &self.flow_replicator
+    }
+
+    /// Check if this node is the coordinator.
+    pub fn is_coordinator(&self) -> bool {
+        self.coordinator_election.is_leader()
+    }
+
+    /// Check if this node is the primary node.
+    pub fn is_primary(&self) -> bool {
+        self.primary_election.is_leader()
+    }
+
+    /// Create a load balancer for the given strategy.
+    pub fn create_load_balancer(&self, strategy: LoadBalanceStrategy) -> LoadBalancer {
+        LoadBalancer::new(strategy)
+    }
+
+    /// Get the list of connected node IDs.
+    pub fn connected_nodes(&self) -> Vec<ClusterNodeId> {
+        self.nodes
+            .read()
+            .iter()
+            .filter(|(_, n)| n.state == NodeState::Connected)
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────
+
+    fn next_seq(&self) -> u64 {
+        self.seq_counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    async fn broadcast_disconnect(&self) {
+        let msg = ClusterMessage {
+            sender_id: self.self_id.clone(),
+            seq: self.next_seq(),
+            payload: MessagePayload::DisconnectNotice,
+        };
+
+        let peers = self.config.peer_addresses();
+        for peer_addr in peers {
+            if let Err(e) = send_message(&peer_addr, &msg).await {
+                tracing::debug!(peer = %peer_addr, error = %e, "Failed to send disconnect notice");
+            }
+        }
+    }
+
+    async fn broadcast_flow_update(&self, update: &FlowUpdateData) {
+        let msg = ClusterMessage {
+            sender_id: self.self_id.clone(),
+            seq: self.next_seq(),
+            payload: MessagePayload::FlowUpdate(update.clone()),
+        };
+
+        let peers = self.config.peer_addresses();
+        for peer_addr in peers {
+            if let Err(e) = send_message(&peer_addr, &msg).await {
+                tracing::warn!(peer = %peer_addr, error = %e, "Failed to send flow update");
+            }
+        }
+    }
+}
+
+// ── TCP listener ─────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+async fn run_tcp_listener(
+    listener: TcpListener,
+    cancel: CancellationToken,
+    nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+    coord_election: Arc<ElectionState>,
+    primary_election: Arc<ElectionState>,
+    flow_replicator: Arc<FlowReplicator>,
+    heartbeat_mgr: Arc<HeartbeatManager>,
+    self_id: ClusterNodeId,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::debug!("TCP listener cancelled");
+                break;
+            }
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, addr)) => {
+                        tracing::trace!(peer = %addr, "Accepted cluster connection");
+                        let nodes = nodes.clone();
+                        let coord = coord_election.clone();
+                        let primary = primary_election.clone();
+                        let replicator = flow_replicator.clone();
+                        let hb_mgr = heartbeat_mgr.clone();
+                        let self_id = self_id.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_connection(
+                                stream, nodes, coord, primary, replicator, hb_mgr, self_id,
+                            ).await {
+                                tracing::debug!(peer = %addr, error = %e, "Connection handler error");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "TCP accept error");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Handle a single inbound TCP connection.
+#[allow(clippy::too_many_arguments)]
+async fn handle_connection(
+    mut stream: TcpStream,
+    nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+    coord_election: Arc<ElectionState>,
+    primary_election: Arc<ElectionState>,
+    flow_replicator: Arc<FlowReplicator>,
+    heartbeat_mgr: Arc<HeartbeatManager>,
+    self_id: ClusterNodeId,
+) -> io::Result<()> {
+    // Read length-prefixed message.
+    let msg = read_message(&mut stream).await?;
+
+    // Process the message and optionally send a response.
+    let response = process_message(
+        &msg,
+        &nodes,
+        &coord_election,
+        &primary_election,
+        &flow_replicator,
+        &heartbeat_mgr,
+        &self_id,
+    );
+
+    if let Some(resp) = response {
+        let encoded = resp
+            .encode()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        stream.write_all(&encoded).await?;
+    }
+
+    Ok(())
+}
+
+/// Process an incoming cluster message and return an optional response.
+#[allow(clippy::too_many_arguments)]
+fn process_message(
+    msg: &ClusterMessage,
+    nodes: &Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+    coord_election: &Arc<ElectionState>,
+    primary_election: &Arc<ElectionState>,
+    flow_replicator: &Arc<FlowReplicator>,
+    heartbeat_mgr: &Arc<HeartbeatManager>,
+    self_id: &ClusterNodeId,
+) -> Option<ClusterMessage> {
+    match &msg.payload {
+        MessagePayload::Heartbeat(data) => {
+            heartbeat_mgr.record_heartbeat(&msg.sender_id, data.flow_version);
+
+            let response = ClusterMessage {
+                sender_id: self_id.clone(),
+                seq: 0,
+                payload: MessagePayload::HeartbeatAck(HeartbeatAckData {
+                    accepted: true,
+                    coordinator_id: coord_election.leader_id(),
+                    primary_id: primary_election.leader_id(),
+                    election_term: coord_election.term(),
+                }),
+            };
+            Some(response)
+        }
+
+        MessagePayload::VoteRequest(data) => {
+            let election = match data.role {
+                ElectionRole::Coordinator => coord_election,
+                ElectionRole::PrimaryNode => primary_election,
+            };
+
+            let (vote_granted, term) = election.handle_vote_request(&data.candidate_id, data.term);
+
+            let response = ClusterMessage {
+                sender_id: self_id.clone(),
+                seq: 0,
+                payload: MessagePayload::VoteResponse(VoteResponseData {
+                    term,
+                    vote_granted,
+                    role: data.role,
+                }),
+            };
+            Some(response)
+        }
+
+        MessagePayload::ElectionWon(data) => {
+            let election = match data.role {
+                ElectionRole::Coordinator => coord_election,
+                ElectionRole::PrimaryNode => primary_election,
+            };
+            election.accept_leader(&data.winner_id, data.term);
+
+            // Update node roles.
+            let role = match data.role {
+                ElectionRole::Coordinator => ClusterRole::Coordinator,
+                ElectionRole::PrimaryNode => ClusterRole::PrimaryNode,
+            };
+
+            let mut nodes = nodes.write();
+            // Remove role from all nodes first.
+            for node in nodes.values_mut() {
+                node.remove_role(role);
+            }
+            // Add role to the winner.
+            if let Some(winner) = nodes.get_mut(&data.winner_id) {
+                winner.add_role(role);
+            }
+
+            None // No response needed.
+        }
+
+        MessagePayload::FlowUpdate(data) => {
+            let ack = flow_replicator.apply_update(data);
+
+            let response = ClusterMessage {
+                sender_id: self_id.clone(),
+                seq: 0,
+                payload: MessagePayload::FlowUpdateAck(ack),
+            };
+            Some(response)
+        }
+
+        MessagePayload::FlowUpdateAck(data) => {
+            flow_replicator.record_ack(data, &msg.sender_id);
+            None
+        }
+
+        MessagePayload::FlowSyncRequest => {
+            let response = ClusterMessage {
+                sender_id: self_id.clone(),
+                seq: 0,
+                payload: MessagePayload::FlowSyncResponse(FlowSyncResponseData {
+                    version: flow_replicator.current_version(),
+                    flow_config: flow_replicator.current_config(),
+                    coordinator_id: coord_election.leader_id(),
+                    primary_id: primary_election.leader_id(),
+                    election_term: coord_election.term(),
+                }),
+            };
+            Some(response)
+        }
+
+        MessagePayload::JoinRequest(data) => {
+            tracing::info!(
+                node = %msg.sender_id,
+                address = %data.address,
+                "Node join request received"
+            );
+
+            // Add the joining node to our node map.
+            let mut nodes = nodes.write();
+            let node = nodes
+                .entry(msg.sender_id.clone())
+                .or_insert_with(|| NodeInfo::new(msg.sender_id.clone(), data.address.clone()));
+            let _ = node.transition_to(NodeState::Connected);
+
+            let response = ClusterMessage {
+                sender_id: self_id.clone(),
+                seq: 0,
+                payload: MessagePayload::JoinResponse(JoinResponseData {
+                    accepted: true,
+                    reason: None,
+                    flow_version: flow_replicator.current_version(),
+                    flow_config: Some(flow_replicator.current_config()),
+                }),
+            };
+            Some(response)
+        }
+
+        MessagePayload::DisconnectNotice => {
+            tracing::info!(node = %msg.sender_id, "Node disconnect notice received");
+            heartbeat_mgr.disconnect_node(&msg.sender_id);
+            None
+        }
+
+        _ => None,
+    }
+}
+
+// ── Heartbeat sender ─────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+async fn run_heartbeat_sender(
+    cancel: CancellationToken,
+    config: ClusterConfig,
+    self_id: ClusterNodeId,
+    coord_election: Arc<ElectionState>,
+    primary_election: Arc<ElectionState>,
+    flow_replicator: Arc<FlowReplicator>,
+    _nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+    seq: Arc<AtomicU64>,
+) {
+    let interval = Duration::from_millis(config.heartbeat_interval_ms);
+    let mut ticker = tokio::time::interval(interval);
+    // Skip the first immediate tick.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::debug!("Heartbeat sender cancelled");
+                break;
+            }
+            _ = ticker.tick() => {
+                let mut roles = Vec::new();
+                if coord_election.is_leader() {
+                    roles.push(ClusterRole::Coordinator);
+                }
+                if primary_election.is_leader() {
+                    roles.push(ClusterRole::PrimaryNode);
+                }
+
+                let msg = ClusterMessage {
+                    sender_id: self_id.clone(),
+                    seq: seq.fetch_add(1, Ordering::Relaxed),
+                    payload: MessagePayload::Heartbeat(HeartbeatData {
+                        state: NodeState::Connected,
+                        roles,
+                        flow_version: flow_replicator.current_version(),
+                        election_term: coord_election.term(),
+                        metrics: None,
+                    }),
+                };
+
+                let peers = config.peer_addresses();
+                for peer_addr in peers {
+                    if let Err(e) = send_message(&peer_addr, &msg).await {
+                        tracing::trace!(
+                            peer = %peer_addr,
+                            error = %e,
+                            "Failed to send heartbeat"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Election watcher ─────────────────────────────────────────────────────────
+
+async fn run_election_watcher(
+    cancel: CancellationToken,
+    config: ClusterConfig,
+    self_id: ClusterNodeId,
+    coord_election: Arc<ElectionState>,
+    primary_election: Arc<ElectionState>,
+    nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+) {
+    // Add random jitter to prevent simultaneous elections.
+    let base_timeout = Duration::from_millis(config.election_timeout_ms);
+
+    // Initial delay before first election attempt — allow time for heartbeats.
+    tokio::select! {
+        _ = cancel.cancelled() => return,
+        _ = tokio::time::sleep(base_timeout) => {}
+    }
+
+    loop {
+        // Check if we need to start an election.
+        let needs_coordinator = coord_election.leader_id().is_none();
+        let needs_primary = primary_election.leader_id().is_none();
+
+        if needs_coordinator {
+            run_election(&coord_election, &self_id, &config, &nodes).await;
+        }
+
+        if needs_primary {
+            run_election(&primary_election, &self_id, &config, &nodes).await;
+        }
+
+        // Sleep before checking again.
+        let jitter = base_timeout / 2
+            + Duration::from_millis(
+                (std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .subsec_millis() as u64)
+                    % (config.election_timeout_ms / 2),
+            );
+
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::debug!("Election watcher cancelled");
+                break;
+            }
+            _ = tokio::time::sleep(jitter) => {}
+        }
+    }
+}
+
+/// Run an election for a specific role.
+async fn run_election(
+    election: &Arc<ElectionState>,
+    self_id: &ClusterNodeId,
+    config: &ClusterConfig,
+    nodes: &Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+) {
+    // Already have a leader or we're already the leader.
+    if election.leader_id().is_some() || election.is_leader() {
+        return;
+    }
+
+    let term = election.start_election(self_id);
+    let role = election.role();
+
+    // Send vote requests to all peers.
+    let vote_request = ClusterMessage {
+        sender_id: self_id.clone(),
+        seq: 0,
+        payload: MessagePayload::VoteRequest(VoteRequestData {
+            term,
+            role,
+            candidate_id: self_id.clone(),
+        }),
+    };
+
+    let peers = config.peer_addresses();
+    for peer_addr in &peers {
+        match send_and_receive(peer_addr, &vote_request).await {
+            Ok(response) => {
+                if let MessagePayload::VoteResponse(data) = response.payload
+                    && data.vote_granted
+                    && data.term == term
+                {
+                    let majority = election.record_vote(&response.sender_id, term);
+                    if majority {
+                        // Won the election.
+                        election.become_leader(self_id);
+
+                        // Update node roles.
+                        let cluster_role = match role {
+                            ElectionRole::Coordinator => ClusterRole::Coordinator,
+                            ElectionRole::PrimaryNode => ClusterRole::PrimaryNode,
+                        };
+                        {
+                            let mut nodes = nodes.write();
+                            for node in nodes.values_mut() {
+                                node.remove_role(cluster_role);
+                            }
+                            if let Some(self_node) = nodes.get_mut(self_id) {
+                                self_node.add_role(cluster_role);
+                            }
+                        }
+
+                        // Broadcast the win to all peers.
+                        let won_msg = ClusterMessage {
+                            sender_id: self_id.clone(),
+                            seq: 0,
+                            payload: MessagePayload::ElectionWon(ElectionWonData {
+                                term,
+                                role,
+                                winner_id: self_id.clone(),
+                            }),
+                        };
+                        for other_peer in &peers {
+                            let _ = send_message(other_peer, &won_msg).await;
+                        }
+
+                        tracing::info!(
+                            role = %role,
+                            term = term,
+                            "Election won — broadcasting to cluster"
+                        );
+                        return;
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::trace!(
+                    peer = %peer_addr,
+                    role = %role,
+                    error = %e,
+                    "Vote request failed"
+                );
+            }
+        }
+    }
+
+    // If we didn't win, step down.
+    if election.raft_state() == RaftState::Candidate {
+        election.step_down();
+    }
+}
+
+// ── Heartbeat event handler ──────────────────────────────────────────────────
+
+async fn run_event_handler(
+    mut rx: mpsc::Receiver<HeartbeatEvent>,
+    cancel: CancellationToken,
+    _self_id: ClusterNodeId,
+    heartbeat_mgr: Arc<HeartbeatManager>,
+    _nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                tracing::debug!("Event handler cancelled");
+                break;
+            }
+            event = rx.recv() => {
+                let Some(event) = event else { break };
+                match event {
+                    HeartbeatEvent::NodeTimedOut { node_id } => {
+                        tracing::warn!(node = %node_id, "Disconnecting node due to heartbeat timeout");
+                        heartbeat_mgr.disconnect_node(&node_id);
+                    }
+                    HeartbeatEvent::HeartbeatReceived { node_id, flow_version } => {
+                        tracing::trace!(
+                            node = %node_id,
+                            flow_version = flow_version,
+                            "Heartbeat received"
+                        );
+                    }
+                    HeartbeatEvent::NodeReconnecting { node_id } => {
+                        tracing::info!(node = %node_id, "Node attempting to reconnect");
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Wire helpers ─────────────────────────────────────────────────────────────
+
+/// Send a message to a peer via TCP (fire-and-forget).
+async fn send_message(addr: &str, msg: &ClusterMessage) -> io::Result<()> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let encoded = msg
+        .encode()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    stream.write_all(&encoded).await?;
+    Ok(())
+}
+
+/// Send a message and read a response.
+async fn send_and_receive(addr: &str, msg: &ClusterMessage) -> io::Result<ClusterMessage> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let encoded = msg
+        .encode()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    stream.write_all(&encoded).await?;
+    read_message(&mut stream).await
+}
+
+/// Read a length-prefixed message from a TCP stream.
+async fn read_message(stream: &mut TcpStream) -> io::Result<ClusterMessage> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+
+    if len > 10 * 1024 * 1024 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Message too large: {} bytes", len),
+        ));
+    }
+
+    let mut data = vec![0u8; len];
+    stream.read_exact(&mut data).await?;
+
+    ClusterMessage::decode(&data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Extract a node ID from an address string like "node-1:9443".
+fn extract_node_id(addr: &str) -> String {
+    addr.split(':').next().unwrap_or(addr).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_node_id_from_address() {
+        assert_eq!(extract_node_id("node-1:9443"), "node-1");
+        assert_eq!(extract_node_id("node-1"), "node-1");
+        assert_eq!(extract_node_id("192.168.1.1:9443"), "192.168.1.1");
+    }
+
+    #[test]
+    fn coordinator_creation() {
+        let config = ClusterConfig {
+            enabled: true,
+            node_id: "node-1".into(),
+            bind_address: "0.0.0.0:9443".into(),
+            nodes: vec![
+                "node-1:9443".into(),
+                "node-2:9443".into(),
+                "node-3:9443".into(),
+            ],
+            ..Default::default()
+        };
+
+        let coordinator = ClusterCoordinator::new(config);
+
+        assert_eq!(coordinator.self_id, "node-1");
+        assert!(!coordinator.is_coordinator());
+        assert!(!coordinator.is_primary());
+
+        let status = coordinator.status();
+        assert!(status.enabled);
+        assert_eq!(status.nodes.len(), 3);
+    }
+
+    #[test]
+    fn coordinator_status_reports_all_nodes() {
+        let config = ClusterConfig {
+            enabled: true,
+            node_id: "node-1".into(),
+            bind_address: "0.0.0.0:9443".into(),
+            nodes: vec!["node-1:9443".into(), "node-2:9443".into()],
+            ..Default::default()
+        };
+
+        let coordinator = ClusterCoordinator::new(config);
+        let status = coordinator.status();
+
+        assert_eq!(status.node_id, "node-1");
+        assert_eq!(status.state, NodeState::Connected);
+        assert_eq!(status.nodes.len(), 2);
+    }
+
+    #[test]
+    fn coordinator_disabled() {
+        let config = ClusterConfig::default();
+        let coordinator = ClusterCoordinator::new(config);
+        let status = coordinator.status();
+        assert!(!status.enabled);
+    }
+
+    #[test]
+    fn process_heartbeat_message() {
+        let nodes = Arc::new(RwLock::new(HashMap::new()));
+        let mut n1 = NodeInfo::new("node-1".into(), "node-1:9443".into());
+        n1.state = NodeState::Connected;
+        nodes.write().insert("node-1".into(), n1);
+        let mut n2 = NodeInfo::new("node-2".into(), "node-2:9443".into());
+        n2.state = NodeState::Connected;
+        nodes.write().insert("node-2".into(), n2);
+
+        let config = ClusterConfig {
+            node_id: "node-1".into(),
+            nodes: vec!["node-1:9443".into(), "node-2:9443".into()],
+            ..Default::default()
+        };
+
+        let coord = Arc::new(ElectionState::new(ElectionRole::Coordinator, 2));
+        let primary = Arc::new(ElectionState::new(ElectionRole::PrimaryNode, 2));
+        let replicator = Arc::new(FlowReplicator::new(nodes.clone()));
+        let hb_mgr = Arc::new(HeartbeatManager::new(&config, nodes.clone()));
+
+        let msg = ClusterMessage {
+            sender_id: "node-2".into(),
+            seq: 1,
+            payload: MessagePayload::Heartbeat(HeartbeatData {
+                state: NodeState::Connected,
+                roles: vec![],
+                flow_version: 3,
+                election_term: 1,
+                metrics: None,
+            }),
+        };
+
+        let response = process_message(
+            &msg,
+            &nodes,
+            &coord,
+            &primary,
+            &replicator,
+            &hb_mgr,
+            &"node-1".into(),
+        );
+
+        assert!(response.is_some());
+        match response.unwrap().payload {
+            MessagePayload::HeartbeatAck(data) => {
+                assert!(data.accepted);
+            }
+            _ => panic!("Expected HeartbeatAck"),
+        }
+    }
+
+    #[test]
+    fn process_vote_request_message() {
+        let nodes = Arc::new(RwLock::new(HashMap::new()));
+        let config = ClusterConfig {
+            node_id: "node-1".into(),
+            nodes: vec!["node-1:9443".into(), "node-2:9443".into()],
+            ..Default::default()
+        };
+
+        let coord = Arc::new(ElectionState::new(ElectionRole::Coordinator, 2));
+        let primary = Arc::new(ElectionState::new(ElectionRole::PrimaryNode, 2));
+        let replicator = Arc::new(FlowReplicator::new(nodes.clone()));
+        let hb_mgr = Arc::new(HeartbeatManager::new(&config, nodes.clone()));
+
+        let msg = ClusterMessage {
+            sender_id: "node-2".into(),
+            seq: 1,
+            payload: MessagePayload::VoteRequest(VoteRequestData {
+                term: 1,
+                role: ElectionRole::Coordinator,
+                candidate_id: "node-2".into(),
+            }),
+        };
+
+        let response = process_message(
+            &msg,
+            &nodes,
+            &coord,
+            &primary,
+            &replicator,
+            &hb_mgr,
+            &"node-1".into(),
+        );
+
+        assert!(response.is_some());
+        match response.unwrap().payload {
+            MessagePayload::VoteResponse(data) => {
+                assert!(data.vote_granted);
+                assert_eq!(data.term, 1);
+            }
+            _ => panic!("Expected VoteResponse"),
+        }
+    }
+
+    #[test]
+    fn process_flow_sync_request() {
+        let nodes = Arc::new(RwLock::new(HashMap::new()));
+        let config = ClusterConfig {
+            node_id: "node-1".into(),
+            ..Default::default()
+        };
+
+        let coord = Arc::new(ElectionState::new(ElectionRole::Coordinator, 2));
+        let primary = Arc::new(ElectionState::new(ElectionRole::PrimaryNode, 2));
+        let replicator = Arc::new(FlowReplicator::new(nodes.clone()));
+        replicator.set_initial_config("[flow]\nname = \"test\"".into(), 5);
+        let hb_mgr = Arc::new(HeartbeatManager::new(&config, nodes.clone()));
+
+        let msg = ClusterMessage {
+            sender_id: "node-3".into(),
+            seq: 1,
+            payload: MessagePayload::FlowSyncRequest,
+        };
+
+        let response = process_message(
+            &msg,
+            &nodes,
+            &coord,
+            &primary,
+            &replicator,
+            &hb_mgr,
+            &"node-1".into(),
+        );
+
+        assert!(response.is_some());
+        match response.unwrap().payload {
+            MessagePayload::FlowSyncResponse(data) => {
+                assert_eq!(data.version, 5);
+                assert!(data.flow_config.contains("test"));
+            }
+            _ => panic!("Expected FlowSyncResponse"),
+        }
+    }
+
+    #[tokio::test]
+    async fn coordinator_start_stop_disabled() {
+        let config = ClusterConfig::default();
+        let mut coordinator = ClusterCoordinator::new(config);
+
+        // Should succeed silently when disabled.
+        assert!(coordinator.start().await.is_ok());
+        coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    async fn coordinator_start_stop_enabled() {
+        let config = ClusterConfig {
+            enabled: true,
+            node_id: "node-1".into(),
+            bind_address: "127.0.0.1:0".into(), // OS-assigned port
+            nodes: vec!["node-1:0".into(), "node-2:0".into()],
+            heartbeat_interval_ms: 100,
+            heartbeat_miss_threshold: 3,
+            election_timeout_ms: 500,
+        };
+
+        let mut coordinator = ClusterCoordinator::new(config);
+
+        // Bind to port 0 — the OS will assign an ephemeral port.
+        // This test mainly verifies startup/shutdown doesn't panic.
+        let result = coordinator.start().await;
+        // May fail if port 0 isn't resolved correctly in the address.
+        // That's acceptable for unit tests — integration tests use real ports.
+        if result.is_ok() {
+            coordinator.stop().await;
+        }
+    }
+}

--- a/crates/runifi-core/src/cluster/election.rs
+++ b/crates/runifi-core/src/cluster/election.rs
@@ -1,0 +1,397 @@
+//! Raft-inspired leader election for cluster coordinator and primary node
+//! roles.
+//!
+//! This is a simplified Raft election (no log replication — only role election).
+//! The full Raft log is unnecessary because RuniFi only needs consensus on:
+//! 1. Who is the cluster coordinator.
+//! 2. Who is the primary node.
+//!
+//! The election protocol:
+//! 1. Each node starts as a **Follower**.
+//! 2. If a follower does not receive a heartbeat from the coordinator within
+//!    the election timeout (with random jitter), it becomes a **Candidate**.
+//! 3. The candidate increments its term and sends `VoteRequest` to all peers.
+//! 4. Each node votes for at most one candidate per term (first-come).
+//! 5. A candidate that receives a majority of votes becomes the leader for
+//!    that role and broadcasts `ElectionWon`.
+//! 6. If the election times out (no majority), a new term begins.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+use super::node::ClusterNodeId;
+
+/// The role being elected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ElectionRole {
+    /// Cluster coordinator (heartbeat monitor, flow replicator).
+    Coordinator,
+    /// Primary node (runs primary-only processors).
+    PrimaryNode,
+}
+
+/// Raft-like election state for a single role.
+#[derive(Debug)]
+pub struct ElectionState {
+    /// The role this election is for.
+    role: ElectionRole,
+
+    /// Current election term (monotonically increasing).
+    term: AtomicU64,
+
+    /// Mutable election state protected by a mutex.
+    inner: Mutex<ElectionInner>,
+}
+
+#[derive(Debug)]
+struct ElectionInner {
+    /// Current state of this node in the election.
+    state: RaftState,
+
+    /// Node ID this node voted for in the current term (at most one per term).
+    voted_for: Option<ClusterNodeId>,
+
+    /// Set of nodes that have voted for us (when we are a candidate).
+    votes_received: HashSet<ClusterNodeId>,
+
+    /// The current leader for this role.
+    leader_id: Option<ClusterNodeId>,
+
+    /// Total number of voting nodes in the cluster.
+    cluster_size: usize,
+}
+
+/// Raft node states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RaftState {
+    /// Passive — waits for heartbeats from the leader.
+    Follower,
+    /// Actively requesting votes.
+    Candidate,
+    /// Won the election — holds the role.
+    Leader,
+}
+
+impl ElectionState {
+    /// Create a new election state for the given role.
+    pub fn new(role: ElectionRole, cluster_size: usize) -> Self {
+        Self {
+            role,
+            term: AtomicU64::new(0),
+            inner: Mutex::new(ElectionInner {
+                state: RaftState::Follower,
+                voted_for: None,
+                votes_received: HashSet::new(),
+                leader_id: None,
+                cluster_size,
+            }),
+        }
+    }
+
+    /// Get the role this election is for.
+    pub fn role(&self) -> ElectionRole {
+        self.role
+    }
+
+    /// Get the current election term.
+    pub fn term(&self) -> u64 {
+        self.term.load(Ordering::Relaxed)
+    }
+
+    /// Get the current Raft state.
+    pub fn raft_state(&self) -> RaftState {
+        self.inner.lock().state
+    }
+
+    /// Get the current leader ID for this role.
+    pub fn leader_id(&self) -> Option<ClusterNodeId> {
+        self.inner.lock().leader_id.clone()
+    }
+
+    /// Update the cluster size (used when nodes join/leave).
+    pub fn set_cluster_size(&mut self, size: usize) {
+        self.inner.lock().cluster_size = size;
+    }
+
+    /// Start a new election: increment term, become candidate, vote for self.
+    ///
+    /// Returns the new term number.
+    pub fn start_election(&self, self_id: &ClusterNodeId) -> u64 {
+        let new_term = self.term.fetch_add(1, Ordering::Relaxed) + 1;
+        let mut inner = self.inner.lock();
+        inner.state = RaftState::Candidate;
+        inner.voted_for = Some(self_id.clone());
+        inner.votes_received.clear();
+        inner.votes_received.insert(self_id.clone());
+        inner.leader_id = None;
+        tracing::info!(
+            role = %self.role,
+            term = new_term,
+            node = %self_id,
+            "Starting election"
+        );
+        new_term
+    }
+
+    /// Handle a vote request from another candidate.
+    ///
+    /// Returns `(vote_granted, current_term)`.
+    ///
+    /// A vote is granted if:
+    /// - The request term >= our current term
+    /// - We have not voted for anyone else in this term
+    pub fn handle_vote_request(
+        &self,
+        candidate_id: &ClusterNodeId,
+        request_term: u64,
+    ) -> (bool, u64) {
+        let current_term = self.term.load(Ordering::Relaxed);
+
+        if request_term < current_term {
+            // Stale term — reject.
+            return (false, current_term);
+        }
+
+        let mut inner = self.inner.lock();
+
+        if request_term > current_term {
+            // Higher term — step down to follower and update term.
+            self.term.store(request_term, Ordering::Relaxed);
+            inner.state = RaftState::Follower;
+            inner.voted_for = None;
+            inner.leader_id = None;
+        }
+
+        // Vote if we haven't voted yet or already voted for this candidate.
+        let grant = match &inner.voted_for {
+            None => true,
+            Some(id) => id == candidate_id,
+        };
+
+        if grant {
+            inner.voted_for = Some(candidate_id.clone());
+            tracing::debug!(
+                role = %self.role,
+                term = request_term,
+                candidate = %candidate_id,
+                "Granted vote"
+            );
+        }
+
+        (grant, request_term)
+    }
+
+    /// Record a vote received from a peer.
+    ///
+    /// Returns `true` if a majority has been reached (election won).
+    pub fn record_vote(&self, voter_id: &ClusterNodeId, vote_term: u64) -> bool {
+        let current_term = self.term.load(Ordering::Relaxed);
+        if vote_term != current_term {
+            return false;
+        }
+
+        let mut inner = self.inner.lock();
+        if inner.state != RaftState::Candidate {
+            return false;
+        }
+
+        inner.votes_received.insert(voter_id.clone());
+        let votes = inner.votes_received.len();
+        let majority = (inner.cluster_size / 2) + 1;
+
+        tracing::debug!(
+            role = %self.role,
+            term = current_term,
+            votes = votes,
+            majority = majority,
+            voter = %voter_id,
+            "Vote received"
+        );
+
+        votes >= majority
+    }
+
+    /// Transition to leader state after winning an election.
+    pub fn become_leader(&self, self_id: &ClusterNodeId) {
+        let mut inner = self.inner.lock();
+        inner.state = RaftState::Leader;
+        inner.leader_id = Some(self_id.clone());
+        tracing::info!(
+            role = %self.role,
+            term = self.term.load(Ordering::Relaxed),
+            node = %self_id,
+            "Won election — became leader"
+        );
+    }
+
+    /// Step down from leader to follower (e.g. when a higher term is seen).
+    pub fn step_down(&self) {
+        let mut inner = self.inner.lock();
+        if inner.state == RaftState::Leader {
+            tracing::info!(
+                role = %self.role,
+                term = self.term.load(Ordering::Relaxed),
+                "Stepping down from leader"
+            );
+        }
+        inner.state = RaftState::Follower;
+        inner.voted_for = None;
+    }
+
+    /// Accept a leader announcement from another node.
+    ///
+    /// If the announced term >= our term, we step down and record the leader.
+    pub fn accept_leader(&self, leader_id: &ClusterNodeId, leader_term: u64) {
+        let current_term = self.term.load(Ordering::Relaxed);
+        if leader_term >= current_term {
+            self.term.store(leader_term, Ordering::Relaxed);
+            let mut inner = self.inner.lock();
+            inner.state = RaftState::Follower;
+            inner.leader_id = Some(leader_id.clone());
+            inner.voted_for = None;
+            tracing::info!(
+                role = %self.role,
+                term = leader_term,
+                leader = %leader_id,
+                "Accepted leader"
+            );
+        }
+    }
+
+    /// Check if this node is currently the leader.
+    pub fn is_leader(&self) -> bool {
+        self.inner.lock().state == RaftState::Leader
+    }
+
+    /// Reset election state (used when the node leaves the cluster).
+    pub fn reset(&self) {
+        self.term.store(0, Ordering::Relaxed);
+        let mut inner = self.inner.lock();
+        inner.state = RaftState::Follower;
+        inner.voted_for = None;
+        inner.votes_received.clear();
+        inner.leader_id = None;
+    }
+}
+
+impl std::fmt::Display for ElectionRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coordinator => write!(f, "coordinator"),
+            Self::PrimaryNode => write!(f, "primary_node"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn election_basic_flow() {
+        let election = ElectionState::new(ElectionRole::Coordinator, 3);
+
+        // Initially a follower.
+        assert_eq!(election.raft_state(), RaftState::Follower);
+        assert_eq!(election.term(), 0);
+        assert!(!election.is_leader());
+
+        // Start election — becomes candidate at term 1.
+        let term = election.start_election(&"node-1".into());
+        assert_eq!(term, 1);
+        assert_eq!(election.raft_state(), RaftState::Candidate);
+
+        // Record own vote (already counted in start_election).
+        // Need 2 votes for majority in a 3-node cluster.
+        assert!(!election.record_vote(&"node-1".into(), 1)); // already counted
+
+        // Second vote — majority reached.
+        assert!(election.record_vote(&"node-2".into(), 1));
+
+        // Become leader.
+        election.become_leader(&"node-1".into());
+        assert!(election.is_leader());
+        assert_eq!(election.leader_id(), Some("node-1".into()));
+    }
+
+    #[test]
+    fn election_vote_request_handling() {
+        let election = ElectionState::new(ElectionRole::Coordinator, 3);
+
+        // Grant vote to first requester.
+        let (granted, term) = election.handle_vote_request(&"node-2".into(), 1);
+        assert!(granted);
+        assert_eq!(term, 1);
+
+        // Reject vote to second requester in same term.
+        let (granted, _) = election.handle_vote_request(&"node-3".into(), 1);
+        assert!(!granted);
+
+        // Accept vote from higher term.
+        let (granted, term) = election.handle_vote_request(&"node-3".into(), 2);
+        assert!(granted);
+        assert_eq!(term, 2);
+    }
+
+    #[test]
+    fn election_step_down_on_higher_term() {
+        let election = ElectionState::new(ElectionRole::PrimaryNode, 3);
+
+        election.start_election(&"node-1".into());
+        assert_eq!(election.raft_state(), RaftState::Candidate);
+
+        // Higher term vote request forces step down.
+        let (granted, _) = election.handle_vote_request(&"node-2".into(), 10);
+        assert!(granted);
+        assert_eq!(election.raft_state(), RaftState::Follower);
+        assert_eq!(election.term(), 10);
+    }
+
+    #[test]
+    fn election_accept_leader() {
+        let election = ElectionState::new(ElectionRole::Coordinator, 3);
+
+        election.accept_leader(&"node-3".into(), 5);
+        assert_eq!(election.raft_state(), RaftState::Follower);
+        assert_eq!(election.leader_id(), Some("node-3".into()));
+        assert_eq!(election.term(), 5);
+    }
+
+    #[test]
+    fn election_stale_vote_rejected() {
+        let election = ElectionState::new(ElectionRole::Coordinator, 3);
+
+        // Advance term to 5.
+        election.handle_vote_request(&"node-2".into(), 5);
+
+        // Stale term 3 is rejected.
+        let (granted, term) = election.handle_vote_request(&"node-3".into(), 3);
+        assert!(!granted);
+        assert_eq!(term, 5);
+    }
+
+    #[test]
+    fn election_reset() {
+        let election = ElectionState::new(ElectionRole::Coordinator, 3);
+        election.start_election(&"node-1".into());
+        election.become_leader(&"node-1".into());
+
+        election.reset();
+        assert_eq!(election.term(), 0);
+        assert_eq!(election.raft_state(), RaftState::Follower);
+        assert!(election.leader_id().is_none());
+    }
+
+    #[test]
+    fn election_stale_vote_not_counted() {
+        let election = ElectionState::new(ElectionRole::Coordinator, 3);
+        election.start_election(&"node-1".into());
+
+        // Vote from a different term is ignored.
+        assert!(!election.record_vote(&"node-2".into(), 99));
+    }
+}

--- a/crates/runifi-core/src/cluster/heartbeat.rs
+++ b/crates/runifi-core/src/cluster/heartbeat.rs
@@ -1,0 +1,326 @@
+//! Heartbeat mechanism for cluster health monitoring.
+//!
+//! Each node periodically sends heartbeats to all peers. The coordinator
+//! monitors heartbeats and disconnects nodes that miss the configured
+//! threshold (default: 3 consecutive misses at 5 s intervals = 15 s timeout).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::config::ClusterConfig;
+use super::node::{ClusterNodeId, NodeInfo, NodeState};
+
+/// Events emitted by the heartbeat manager for the coordinator to handle.
+#[derive(Debug)]
+pub enum HeartbeatEvent {
+    /// A node has exceeded the missed heartbeat threshold and should be
+    /// disconnected.
+    NodeTimedOut { node_id: ClusterNodeId },
+
+    /// A heartbeat was received from a node.
+    HeartbeatReceived {
+        node_id: ClusterNodeId,
+        flow_version: u64,
+    },
+
+    /// A previously disconnected node has sent a heartbeat (possible rejoin).
+    NodeReconnecting { node_id: ClusterNodeId },
+}
+
+/// Manages heartbeat tracking for all known cluster nodes.
+///
+/// The heartbeat manager runs a periodic check loop that:
+/// 1. Increments the missed heartbeat count for all nodes that have not sent
+///    a heartbeat since the last check.
+/// 2. Emits `HeartbeatEvent::NodeTimedOut` for nodes exceeding the threshold.
+///
+/// Incoming heartbeats are recorded via `record_heartbeat()`.
+pub struct HeartbeatManager {
+    /// Heartbeat interval.
+    interval: Duration,
+    /// Number of missed heartbeats before disconnect.
+    miss_threshold: u32,
+    /// Shared node state map.
+    nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+    /// This node's ID.
+    self_id: ClusterNodeId,
+}
+
+impl HeartbeatManager {
+    /// Create a new heartbeat manager.
+    pub fn new(
+        config: &ClusterConfig,
+        nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+    ) -> Self {
+        Self {
+            interval: Duration::from_millis(config.heartbeat_interval_ms),
+            miss_threshold: config.heartbeat_miss_threshold,
+            nodes,
+            self_id: config.node_id.clone(),
+        }
+    }
+
+    /// Get the heartbeat interval.
+    pub fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    /// Run the heartbeat check loop.
+    ///
+    /// This should be spawned as a tokio task. It periodically checks all
+    /// tracked nodes and emits events for timed-out nodes.
+    pub async fn run_check_loop(
+        &self,
+        event_tx: mpsc::Sender<HeartbeatEvent>,
+        cancel: CancellationToken,
+    ) {
+        let mut interval = tokio::time::interval(self.interval);
+        // Skip the first immediate tick.
+        interval.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::debug!("Heartbeat check loop cancelled");
+                    break;
+                }
+                _ = interval.tick() => {
+                    self.check_heartbeats(&event_tx).await;
+                }
+            }
+        }
+    }
+
+    /// Check all nodes for missed heartbeats.
+    ///
+    /// For each non-self connected node, we check whether the elapsed time
+    /// since the last heartbeat exceeds `interval * miss_threshold`.  If a
+    /// node has never sent a heartbeat we increment its miss counter each
+    /// check cycle and disconnect once the threshold is reached.
+    async fn check_heartbeats(&self, event_tx: &mpsc::Sender<HeartbeatEvent>) {
+        let now = Instant::now();
+        let timeout_duration = self.interval * self.miss_threshold;
+        let mut timed_out = Vec::new();
+
+        {
+            let mut nodes = self.nodes.write();
+            for (id, node) in nodes.iter_mut() {
+                // Skip self.
+                if *id == self.self_id {
+                    continue;
+                }
+
+                // Only check connected/connecting nodes.
+                if !matches!(node.state, NodeState::Connected | NodeState::Connecting) {
+                    continue;
+                }
+
+                let exceeded = match node.last_heartbeat {
+                    Some(last) => {
+                        // Check if elapsed time exceeds the threshold.
+                        if now.duration_since(last) > timeout_duration {
+                            node.missed_heartbeats = self.miss_threshold;
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    None => {
+                        // Never received a heartbeat — increment miss
+                        // counter and check against threshold.
+                        node.record_missed_heartbeat(self.miss_threshold)
+                    }
+                };
+
+                if exceeded {
+                    timed_out.push(id.clone());
+                }
+            }
+        }
+
+        for node_id in timed_out {
+            tracing::warn!(
+                node = %node_id,
+                threshold = self.miss_threshold,
+                "Node exceeded heartbeat miss threshold"
+            );
+            let _ = event_tx
+                .send(HeartbeatEvent::NodeTimedOut {
+                    node_id: node_id.clone(),
+                })
+                .await;
+        }
+    }
+
+    /// Record a heartbeat received from a peer node.
+    ///
+    /// Returns `true` if this is a new/reconnecting node.
+    pub fn record_heartbeat(&self, node_id: &ClusterNodeId, flow_version: u64) -> bool {
+        let mut nodes = self.nodes.write();
+        if let Some(node) = nodes.get_mut(node_id) {
+            let was_disconnected = matches!(node.state, NodeState::Disconnected);
+            node.record_heartbeat(flow_version);
+            was_disconnected
+        } else {
+            false
+        }
+    }
+
+    /// Disconnect a node (set state to DISCONNECTED).
+    pub fn disconnect_node(&self, node_id: &ClusterNodeId) {
+        let mut nodes = self.nodes.write();
+        if let Some(node) = nodes.get_mut(node_id)
+            && node.transition_to(NodeState::Disconnecting)
+        {
+            let _ = node.transition_to(NodeState::Disconnected);
+            tracing::info!(node = %node_id, "Node disconnected due to heartbeat timeout");
+        }
+    }
+
+    /// Get the current state of a node.
+    pub fn node_state(&self, node_id: &ClusterNodeId) -> Option<NodeState> {
+        self.nodes.read().get(node_id).map(|n| n.state)
+    }
+
+    /// Get the count of connected nodes (including self).
+    pub fn connected_count(&self) -> usize {
+        self.nodes
+            .read()
+            .values()
+            .filter(|n| n.state == NodeState::Connected)
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_config() -> ClusterConfig {
+        ClusterConfig {
+            enabled: true,
+            node_id: "node-1".into(),
+            bind_address: "0.0.0.0:9443".into(),
+            nodes: vec![
+                "node-1:9443".into(),
+                "node-2:9443".into(),
+                "node-3:9443".into(),
+            ],
+            heartbeat_interval_ms: 100, // fast for tests
+            heartbeat_miss_threshold: 3,
+            election_timeout_ms: 500,
+        }
+    }
+
+    fn make_test_nodes() -> Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>> {
+        let mut nodes = HashMap::new();
+        let mut n1 = NodeInfo::new("node-1".into(), "node-1:9443".into());
+        n1.state = NodeState::Connected;
+        nodes.insert("node-1".into(), n1);
+
+        let mut n2 = NodeInfo::new("node-2".into(), "node-2:9443".into());
+        n2.state = NodeState::Connected;
+        nodes.insert("node-2".into(), n2);
+
+        let mut n3 = NodeInfo::new("node-3".into(), "node-3:9443".into());
+        n3.state = NodeState::Connected;
+        nodes.insert("node-3".into(), n3);
+
+        Arc::new(RwLock::new(nodes))
+    }
+
+    #[test]
+    fn heartbeat_manager_creation() {
+        let config = make_test_config();
+        let nodes = make_test_nodes();
+        let manager = HeartbeatManager::new(&config, nodes);
+
+        assert_eq!(manager.interval(), Duration::from_millis(100));
+        assert_eq!(manager.connected_count(), 3);
+    }
+
+    #[test]
+    fn record_heartbeat_updates_node() {
+        let config = make_test_config();
+        let nodes = make_test_nodes();
+        let manager = HeartbeatManager::new(&config, nodes.clone());
+
+        let was_reconnecting = manager.record_heartbeat(&"node-2".into(), 5);
+        assert!(!was_reconnecting);
+
+        let nodes_read = nodes.read();
+        let n2 = nodes_read.get("node-2").unwrap();
+        assert_eq!(n2.flow_version, 5);
+        assert!(n2.last_heartbeat.is_some());
+        assert_eq!(n2.missed_heartbeats, 0);
+    }
+
+    #[test]
+    fn disconnect_node_transitions_state() {
+        let config = make_test_config();
+        let nodes = make_test_nodes();
+        let manager = HeartbeatManager::new(&config, nodes.clone());
+
+        manager.disconnect_node(&"node-2".into());
+
+        assert_eq!(
+            manager.node_state(&"node-2".into()),
+            Some(NodeState::Disconnected)
+        );
+        assert_eq!(manager.connected_count(), 2);
+    }
+
+    #[test]
+    fn record_heartbeat_from_disconnected_returns_true() {
+        let config = make_test_config();
+        let nodes = make_test_nodes();
+        let manager = HeartbeatManager::new(&config, nodes.clone());
+
+        // Disconnect node-2.
+        manager.disconnect_node(&"node-2".into());
+
+        // Heartbeat from disconnected node signals reconnection.
+        let was_reconnecting = manager.record_heartbeat(&"node-2".into(), 1);
+        assert!(was_reconnecting);
+    }
+
+    #[tokio::test]
+    async fn check_loop_emits_timeout_events() {
+        let config = make_test_config();
+        let nodes = make_test_nodes();
+
+        // Set node-2 to have a heartbeat far in the past (beyond threshold).
+        {
+            let mut nodes_write = nodes.write();
+            let n2 = nodes_write.get_mut("node-2").unwrap();
+            n2.last_heartbeat = Some(Instant::now() - Duration::from_secs(60));
+            n2.missed_heartbeats = 0;
+        }
+
+        let manager = HeartbeatManager::new(&config, nodes);
+        let (event_tx, mut event_rx) = mpsc::channel(10);
+
+        // Run a single check.
+        manager.check_heartbeats(&event_tx).await;
+
+        // Should have timeout events (node-2 and node-3 both have stale heartbeats).
+        // Use try_recv to avoid blocking.
+        let mut timed_out_ids = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                HeartbeatEvent::NodeTimedOut { node_id } => {
+                    timed_out_ids.push(node_id);
+                }
+                _ => {}
+            }
+        }
+
+        // node-2 had a heartbeat 60s ago (exceeds 300ms threshold).
+        assert!(timed_out_ids.contains(&"node-2".to_string()));
+    }
+}

--- a/crates/runifi-core/src/cluster/load_balance.rs
+++ b/crates/runifi-core/src/cluster/load_balance.rs
@@ -1,0 +1,281 @@
+//! Connection load-balancing strategies for distributing FlowFiles across
+//! cluster nodes.
+//!
+//! When clustering is enabled, each connection can be configured with a load
+//! balancing strategy that determines how FlowFiles are distributed across
+//! the cluster.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+use super::node::ClusterNodeId;
+
+/// Load balancing strategy for distributing FlowFiles across cluster nodes.
+///
+/// ```toml
+/// [flow.connections.load_balancing]
+/// strategy = "round_robin"
+/// compression = true
+/// partition_attribute = "filename"   # only for partition_by_attribute
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadBalanceStrategy {
+    /// Data stays on the producing node (default).
+    #[default]
+    DoNotLoadBalance,
+
+    /// Distribute FlowFiles evenly across all connected nodes in round-robin
+    /// fashion.
+    RoundRobin,
+
+    /// Route FlowFiles to a deterministic node based on a hash of the
+    /// specified attribute value. This ensures FlowFiles with the same
+    /// attribute value always go to the same node.
+    PartitionByAttribute {
+        /// The FlowFile attribute name to partition on.
+        attribute: String,
+    },
+
+    /// Send all FlowFiles to a single designated node.
+    SingleNode {
+        /// The target node ID. If `None`, the primary node is used.
+        target_node: Option<ClusterNodeId>,
+    },
+}
+
+/// Load balancing configuration for a connection (TOML-friendly).
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct LoadBalanceConfig {
+    /// The strategy to use.
+    #[serde(default)]
+    pub strategy: LoadBalanceStrategy,
+    /// Whether to compress FlowFile content during inter-node transfer.
+    #[serde(default)]
+    pub compression: bool,
+}
+
+/// Runtime load balancer that selects target nodes for FlowFiles.
+///
+/// This struct is `Send + Sync` and designed to be shared across processor
+/// tasks via `Arc`.
+pub struct LoadBalancer {
+    strategy: LoadBalanceStrategy,
+    /// Atomic counter for round-robin distribution.
+    round_robin_counter: AtomicUsize,
+}
+
+impl LoadBalancer {
+    /// Create a new load balancer with the given strategy.
+    pub fn new(strategy: LoadBalanceStrategy) -> Self {
+        Self {
+            strategy,
+            round_robin_counter: AtomicUsize::new(0),
+        }
+    }
+
+    /// Select a target node for a FlowFile.
+    ///
+    /// # Arguments
+    /// * `local_node_id` — This node's identifier.
+    /// * `connected_nodes` — List of currently connected node IDs.
+    /// * `attribute_value` — Value of the partition attribute (for
+    ///   `PartitionByAttribute` strategy). `None` for other strategies.
+    ///
+    /// Returns the selected node ID, or `None` if no node is available.
+    pub fn select_node(
+        &self,
+        local_node_id: &ClusterNodeId,
+        connected_nodes: &[ClusterNodeId],
+        attribute_value: Option<&str>,
+    ) -> Option<ClusterNodeId> {
+        if connected_nodes.is_empty() {
+            return None;
+        }
+
+        match &self.strategy {
+            LoadBalanceStrategy::DoNotLoadBalance => {
+                // Always stay local.
+                Some(local_node_id.clone())
+            }
+
+            LoadBalanceStrategy::RoundRobin => {
+                let idx = self.round_robin_counter.fetch_add(1, Ordering::Relaxed);
+                let target_idx = idx % connected_nodes.len();
+                Some(connected_nodes[target_idx].clone())
+            }
+
+            LoadBalanceStrategy::PartitionByAttribute { attribute: _ } => {
+                // Hash the attribute value to select a deterministic node.
+                let value = attribute_value.unwrap_or("");
+                let mut hasher = DefaultHasher::new();
+                value.hash(&mut hasher);
+                let hash = hasher.finish();
+                let target_idx = (hash as usize) % connected_nodes.len();
+                Some(connected_nodes[target_idx].clone())
+            }
+
+            LoadBalanceStrategy::SingleNode { target_node } => {
+                if let Some(target) = target_node {
+                    // Use the specified target if it's connected.
+                    if connected_nodes.contains(target) {
+                        Some(target.clone())
+                    } else {
+                        // Target not connected — fall back to first connected.
+                        Some(connected_nodes[0].clone())
+                    }
+                } else {
+                    // No target specified — use the first connected node.
+                    Some(connected_nodes[0].clone())
+                }
+            }
+        }
+    }
+
+    /// Get the current strategy.
+    pub fn strategy(&self) -> &LoadBalanceStrategy {
+        &self.strategy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_nodes() -> Vec<ClusterNodeId> {
+        vec![
+            "node-1".to_string(),
+            "node-2".to_string(),
+            "node-3".to_string(),
+        ]
+    }
+
+    #[test]
+    fn do_not_load_balance_stays_local() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::DoNotLoadBalance);
+        let nodes = test_nodes();
+
+        for _ in 0..10 {
+            let target = lb.select_node(&"node-1".into(), &nodes, None);
+            assert_eq!(target, Some("node-1".to_string()));
+        }
+    }
+
+    #[test]
+    fn round_robin_distributes_evenly() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::RoundRobin);
+        let nodes = test_nodes();
+        let mut counts = [0u32; 3];
+
+        for _ in 0..30 {
+            let target = lb.select_node(&"node-1".into(), &nodes, None).unwrap();
+            let idx = nodes.iter().position(|n| *n == target).unwrap();
+            counts[idx] += 1;
+        }
+
+        // Each node should get exactly 10.
+        assert_eq!(counts[0], 10);
+        assert_eq!(counts[1], 10);
+        assert_eq!(counts[2], 10);
+    }
+
+    #[test]
+    fn partition_by_attribute_is_deterministic() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::PartitionByAttribute {
+            attribute: "filename".into(),
+        });
+        let nodes = test_nodes();
+
+        // Same attribute value always maps to the same node.
+        let target1 = lb.select_node(&"node-1".into(), &nodes, Some("report.csv"));
+        let target2 = lb.select_node(&"node-1".into(), &nodes, Some("report.csv"));
+        assert_eq!(target1, target2);
+
+        // Different attribute values may map to different nodes.
+        let target_a = lb.select_node(&"node-1".into(), &nodes, Some("file-a.csv"));
+        let target_b = lb.select_node(&"node-1".into(), &nodes, Some("file-b.csv"));
+        // They might be the same or different — just verify they're valid.
+        assert!(nodes.contains(&target_a.unwrap()));
+        assert!(nodes.contains(&target_b.unwrap()));
+    }
+
+    #[test]
+    fn partition_by_attribute_empty_value() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::PartitionByAttribute {
+            attribute: "key".into(),
+        });
+        let nodes = test_nodes();
+
+        let target = lb.select_node(&"node-1".into(), &nodes, None);
+        assert!(target.is_some());
+    }
+
+    #[test]
+    fn single_node_uses_target() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::SingleNode {
+            target_node: Some("node-2".into()),
+        });
+        let nodes = test_nodes();
+
+        for _ in 0..10 {
+            let target = lb.select_node(&"node-1".into(), &nodes, None);
+            assert_eq!(target, Some("node-2".to_string()));
+        }
+    }
+
+    #[test]
+    fn single_node_fallback_when_target_disconnected() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::SingleNode {
+            target_node: Some("node-4".into()), // not in connected list
+        });
+        let nodes = test_nodes();
+
+        let target = lb.select_node(&"node-1".into(), &nodes, None);
+        assert_eq!(target, Some("node-1".to_string())); // falls back to first
+    }
+
+    #[test]
+    fn single_node_no_target_uses_first() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::SingleNode { target_node: None });
+        let nodes = test_nodes();
+
+        let target = lb.select_node(&"node-1".into(), &nodes, None);
+        assert_eq!(target, Some("node-1".to_string()));
+    }
+
+    #[test]
+    fn empty_nodes_returns_none() {
+        let lb = LoadBalancer::new(LoadBalanceStrategy::RoundRobin);
+        let target = lb.select_node(&"node-1".into(), &[], None);
+        assert!(target.is_none());
+    }
+
+    #[test]
+    fn default_strategy_is_do_not_load_balance() {
+        assert_eq!(
+            LoadBalanceStrategy::default(),
+            LoadBalanceStrategy::DoNotLoadBalance
+        );
+    }
+
+    #[test]
+    fn load_balance_config_deserialize() {
+        let toml_str = r#"
+            strategy = "round_robin"
+            compression = true
+        "#;
+        let config: LoadBalanceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.strategy, LoadBalanceStrategy::RoundRobin);
+        assert!(config.compression);
+    }
+
+    #[test]
+    fn load_balance_config_default() {
+        let config = LoadBalanceConfig::default();
+        assert_eq!(config.strategy, LoadBalanceStrategy::DoNotLoadBalance);
+        assert!(!config.compression);
+    }
+}

--- a/crates/runifi-core/src/cluster/mod.rs
+++ b/crates/runifi-core/src/cluster/mod.rs
@@ -1,0 +1,37 @@
+//! Multi-node clustering with zero-leader architecture.
+//!
+//! Implements NiFi-style clustering where every node performs identical work on
+//! different data.  Two elected roles exist:
+//!
+//! - **Cluster Coordinator**: monitors heartbeats, replicates flow changes,
+//!   manages node membership.
+//! - **Primary Node**: runs processors marked "Primary Node Only".
+//!
+//! Election uses a lightweight Raft-inspired protocol over TCP.  The module is
+//! designed so that a full `openraft` backend can be swapped in once it reaches
+//! a stable release.
+//!
+//! ## Phase 1 scope
+//!
+//! - Static cluster membership via configuration
+//! - Heartbeat mechanism (5 s interval, 3 missed = disconnect)
+//! - Coordinator / Primary Node election
+//! - Flow configuration replication
+//! - Connection load-balancing strategy types
+
+pub mod config;
+pub mod coordinator;
+pub mod election;
+pub mod heartbeat;
+pub mod load_balance;
+pub mod node;
+pub mod protocol;
+pub mod replication;
+
+pub use config::ClusterConfig;
+pub use coordinator::ClusterCoordinator;
+pub use election::{ElectionRole, ElectionState};
+pub use heartbeat::HeartbeatManager;
+pub use load_balance::LoadBalanceStrategy;
+pub use node::{ClusterNodeId, NodeInfo, NodeState};
+pub use replication::FlowReplicator;

--- a/crates/runifi-core/src/cluster/node.rs
+++ b/crates/runifi-core/src/cluster/node.rs
@@ -1,0 +1,305 @@
+use std::fmt;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+/// Unique identifier for a node within the cluster.
+///
+/// Wraps a `String` for human-readable node names (e.g. "node-1") while
+/// providing cheap cloning via the inner `Arc<str>` inside `String`.
+pub type ClusterNodeId = String;
+
+/// Node lifecycle states, matching NiFi's cluster node model.
+///
+/// ```text
+///   CONNECTING ──► CONNECTED ──► DISCONNECTING ──► DISCONNECTED
+///       │                              ▲                │
+///       └──────────────────────────────┘                │
+///                                                       │
+///       └───────────────────────────────────────────────┘
+///              (reconnect after heartbeat recovery)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum NodeState {
+    /// Node is attempting to join the cluster.
+    Connecting,
+    /// Node is an active member of the cluster.
+    Connected,
+    /// Node is gracefully leaving the cluster.
+    Disconnecting,
+    /// Node is not part of the cluster.
+    Disconnected,
+}
+
+impl NodeState {
+    /// Returns `true` if the node is in a state where it can process data.
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Connected)
+    }
+
+    /// Returns `true` if the node is in a terminal state.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Disconnected)
+    }
+
+    /// Returns the valid next states from the current state.
+    pub fn valid_transitions(&self) -> &'static [NodeState] {
+        match self {
+            Self::Connecting => &[Self::Connected, Self::Disconnected],
+            Self::Connected => &[Self::Disconnecting, Self::Disconnected],
+            Self::Disconnecting => &[Self::Disconnected],
+            Self::Disconnected => &[Self::Connecting],
+        }
+    }
+
+    /// Check whether a transition to the given target state is valid.
+    pub fn can_transition_to(&self, target: NodeState) -> bool {
+        self.valid_transitions().contains(&target)
+    }
+}
+
+impl fmt::Display for NodeState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connecting => write!(f, "CONNECTING"),
+            Self::Connected => write!(f, "CONNECTED"),
+            Self::Disconnecting => write!(f, "DISCONNECTING"),
+            Self::Disconnected => write!(f, "DISCONNECTED"),
+        }
+    }
+}
+
+/// Elected cluster roles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ClusterRole {
+    /// Monitors heartbeats, replicates flow changes, manages membership.
+    Coordinator,
+    /// Runs processors marked "Primary Node Only".
+    PrimaryNode,
+}
+
+impl fmt::Display for ClusterRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Coordinator => write!(f, "COORDINATOR"),
+            Self::PrimaryNode => write!(f, "PRIMARY_NODE"),
+        }
+    }
+}
+
+/// Information about a node in the cluster, including its current state,
+/// roles, and last heartbeat timestamp.
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    /// Unique node identifier.
+    pub id: ClusterNodeId,
+    /// Network address for cluster communication.
+    pub address: String,
+    /// Current lifecycle state.
+    pub state: NodeState,
+    /// Elected roles held by this node (can be multiple).
+    pub roles: Vec<ClusterRole>,
+    /// Timestamp of the last successful heartbeat received from this node.
+    pub last_heartbeat: Option<Instant>,
+    /// Number of consecutive missed heartbeats.
+    pub missed_heartbeats: u32,
+    /// Flow configuration version this node has applied.
+    pub flow_version: u64,
+}
+
+impl NodeInfo {
+    /// Create a new `NodeInfo` in the `Connecting` state.
+    pub fn new(id: ClusterNodeId, address: String) -> Self {
+        Self {
+            id,
+            address,
+            state: NodeState::Connecting,
+            roles: Vec::new(),
+            last_heartbeat: None,
+            missed_heartbeats: 0,
+            flow_version: 0,
+        }
+    }
+
+    /// Attempt to transition to a new state. Returns `true` if the
+    /// transition was valid and applied.
+    pub fn transition_to(&mut self, target: NodeState) -> bool {
+        if self.state.can_transition_to(target) {
+            self.state = target;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Record a successful heartbeat.
+    pub fn record_heartbeat(&mut self, flow_version: u64) {
+        self.last_heartbeat = Some(Instant::now());
+        self.missed_heartbeats = 0;
+        self.flow_version = flow_version;
+    }
+
+    /// Record a missed heartbeat. Returns `true` if the miss threshold
+    /// has been exceeded (caller should disconnect the node).
+    pub fn record_missed_heartbeat(&mut self, threshold: u32) -> bool {
+        self.missed_heartbeats += 1;
+        self.missed_heartbeats >= threshold
+    }
+
+    /// Check whether this node holds the coordinator role.
+    pub fn is_coordinator(&self) -> bool {
+        self.roles.contains(&ClusterRole::Coordinator)
+    }
+
+    /// Check whether this node holds the primary node role.
+    pub fn is_primary(&self) -> bool {
+        self.roles.contains(&ClusterRole::PrimaryNode)
+    }
+
+    /// Add a role to this node (idempotent).
+    pub fn add_role(&mut self, role: ClusterRole) {
+        if !self.roles.contains(&role) {
+            self.roles.push(role);
+        }
+    }
+
+    /// Remove a role from this node.
+    pub fn remove_role(&mut self, role: ClusterRole) {
+        self.roles.retain(|r| *r != role);
+    }
+}
+
+/// Summary of the current cluster state, suitable for API responses.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClusterStatus {
+    /// Whether clustering is enabled.
+    pub enabled: bool,
+    /// This node's identifier.
+    pub node_id: ClusterNodeId,
+    /// This node's current state.
+    pub state: NodeState,
+    /// This node's elected roles.
+    pub roles: Vec<ClusterRole>,
+    /// All known nodes in the cluster.
+    pub nodes: Vec<NodeSummary>,
+    /// Current flow configuration version.
+    pub flow_version: u64,
+    /// Current election term.
+    pub election_term: u64,
+}
+
+/// Abbreviated node info for API responses.
+#[derive(Debug, Clone, Serialize)]
+pub struct NodeSummary {
+    pub id: ClusterNodeId,
+    pub address: String,
+    pub state: NodeState,
+    pub roles: Vec<ClusterRole>,
+    pub missed_heartbeats: u32,
+    pub flow_version: u64,
+}
+
+impl From<&NodeInfo> for NodeSummary {
+    fn from(info: &NodeInfo) -> Self {
+        Self {
+            id: info.id.clone(),
+            address: info.address.clone(),
+            state: info.state,
+            roles: info.roles.clone(),
+            missed_heartbeats: info.missed_heartbeats,
+            flow_version: info.flow_version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_state_transitions() {
+        assert!(NodeState::Connecting.can_transition_to(NodeState::Connected));
+        assert!(NodeState::Connecting.can_transition_to(NodeState::Disconnected));
+        assert!(!NodeState::Connecting.can_transition_to(NodeState::Disconnecting));
+
+        assert!(NodeState::Connected.can_transition_to(NodeState::Disconnecting));
+        assert!(NodeState::Connected.can_transition_to(NodeState::Disconnected));
+        assert!(!NodeState::Connected.can_transition_to(NodeState::Connecting));
+
+        assert!(NodeState::Disconnecting.can_transition_to(NodeState::Disconnected));
+        assert!(!NodeState::Disconnecting.can_transition_to(NodeState::Connected));
+
+        assert!(NodeState::Disconnected.can_transition_to(NodeState::Connecting));
+        assert!(!NodeState::Disconnected.can_transition_to(NodeState::Connected));
+    }
+
+    #[test]
+    fn node_info_lifecycle() {
+        let mut node = NodeInfo::new("node-1".into(), "10.0.0.1:9443".into());
+        assert_eq!(node.state, NodeState::Connecting);
+
+        assert!(node.transition_to(NodeState::Connected));
+        assert_eq!(node.state, NodeState::Connected);
+
+        assert!(!node.transition_to(NodeState::Connecting));
+        assert_eq!(node.state, NodeState::Connected);
+
+        assert!(node.transition_to(NodeState::Disconnecting));
+        assert!(node.transition_to(NodeState::Disconnected));
+    }
+
+    #[test]
+    fn node_heartbeat_tracking() {
+        let mut node = NodeInfo::new("node-1".into(), "10.0.0.1:9443".into());
+
+        node.record_heartbeat(1);
+        assert_eq!(node.missed_heartbeats, 0);
+        assert!(node.last_heartbeat.is_some());
+
+        assert!(!node.record_missed_heartbeat(3));
+        assert!(!node.record_missed_heartbeat(3));
+        assert!(node.record_missed_heartbeat(3));
+    }
+
+    #[test]
+    fn node_roles() {
+        let mut node = NodeInfo::new("node-1".into(), "10.0.0.1:9443".into());
+        assert!(!node.is_coordinator());
+        assert!(!node.is_primary());
+
+        node.add_role(ClusterRole::Coordinator);
+        assert!(node.is_coordinator());
+
+        node.add_role(ClusterRole::Coordinator); // idempotent
+        assert_eq!(node.roles.len(), 1);
+
+        node.add_role(ClusterRole::PrimaryNode);
+        assert!(node.is_primary());
+        assert_eq!(node.roles.len(), 2);
+
+        node.remove_role(ClusterRole::Coordinator);
+        assert!(!node.is_coordinator());
+        assert!(node.is_primary());
+    }
+
+    #[test]
+    fn node_state_display() {
+        assert_eq!(NodeState::Connecting.to_string(), "CONNECTING");
+        assert_eq!(NodeState::Connected.to_string(), "CONNECTED");
+        assert_eq!(NodeState::Disconnecting.to_string(), "DISCONNECTING");
+        assert_eq!(NodeState::Disconnected.to_string(), "DISCONNECTED");
+    }
+
+    #[test]
+    fn node_summary_from_info() {
+        let mut info = NodeInfo::new("node-1".into(), "10.0.0.1:9443".into());
+        info.flow_version = 5;
+        info.add_role(ClusterRole::Coordinator);
+        let summary = NodeSummary::from(&info);
+        assert_eq!(summary.id, "node-1");
+        assert_eq!(summary.flow_version, 5);
+        assert_eq!(summary.roles.len(), 1);
+    }
+}

--- a/crates/runifi-core/src/cluster/protocol.rs
+++ b/crates/runifi-core/src/cluster/protocol.rs
@@ -1,0 +1,306 @@
+//! Cluster inter-node communication protocol.
+//!
+//! All messages are length-prefixed JSON over TCP.  The wire format is:
+//!
+//! ```text
+//! ┌──────────┬────────────────────────┐
+//! │ 4 bytes  │  N bytes               │
+//! │ (u32 LE) │  (JSON payload)        │
+//! └──────────┴────────────────────────┘
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use super::election::ElectionRole;
+use super::node::{ClusterNodeId, ClusterRole, NodeState};
+
+/// Envelope for all cluster protocol messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterMessage {
+    /// The node that sent this message.
+    pub sender_id: ClusterNodeId,
+    /// Monotonic message sequence number (per sender).
+    pub seq: u64,
+    /// The payload.
+    pub payload: MessagePayload,
+}
+
+/// Protocol message types exchanged between cluster nodes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum MessagePayload {
+    // ── Heartbeat ────────────────────────────────────────────────────────
+    /// Periodic heartbeat from a node.
+    Heartbeat(HeartbeatData),
+
+    /// Acknowledgement of a heartbeat.
+    HeartbeatAck(HeartbeatAckData),
+
+    // ── Election ─────────────────────────────────────────────────────────
+    /// Request a vote in an election.
+    VoteRequest(VoteRequestData),
+
+    /// Response to a vote request.
+    VoteResponse(VoteResponseData),
+
+    /// Announcement that a node has won an election.
+    ElectionWon(ElectionWonData),
+
+    // ── Flow replication ─────────────────────────────────────────────────
+    /// Flow configuration update broadcast by the coordinator.
+    FlowUpdate(FlowUpdateData),
+
+    /// Acknowledgement that a flow update was applied.
+    FlowUpdateAck(FlowUpdateAckData),
+
+    /// Request the current flow configuration (sent by joining nodes).
+    FlowSyncRequest,
+
+    /// Response with the current flow configuration.
+    FlowSyncResponse(FlowSyncResponseData),
+
+    // ── Membership ───────────────────────────────────────────────────────
+    /// Node join request.
+    JoinRequest(JoinRequestData),
+
+    /// Node join response from coordinator.
+    JoinResponse(JoinResponseData),
+
+    /// Graceful disconnect announcement.
+    DisconnectNotice,
+}
+
+// ── Heartbeat types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatData {
+    /// Current state of the sending node.
+    pub state: NodeState,
+    /// Roles held by the sending node.
+    pub roles: Vec<ClusterRole>,
+    /// Flow version the sender has applied.
+    pub flow_version: u64,
+    /// Current election term.
+    pub election_term: u64,
+    /// Summary metrics for monitoring.
+    pub metrics: Option<NodeMetricsSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatAckData {
+    /// Whether the coordinator accepted the heartbeat.
+    pub accepted: bool,
+    /// Current coordinator node ID.
+    pub coordinator_id: Option<ClusterNodeId>,
+    /// Current primary node ID.
+    pub primary_id: Option<ClusterNodeId>,
+    /// Current election term.
+    pub election_term: u64,
+}
+
+/// Lightweight metrics included in heartbeats for cluster-wide monitoring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeMetricsSummary {
+    /// Total FlowFiles processed since startup.
+    pub total_flowfiles: u64,
+    /// Active processor count.
+    pub active_processors: u32,
+    /// System load (0.0..1.0 if available).
+    pub system_load: Option<f64>,
+}
+
+// ── Election types ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoteRequestData {
+    /// The election term for this vote.
+    pub term: u64,
+    /// The role being elected.
+    pub role: ElectionRole,
+    /// Candidate's node ID.
+    pub candidate_id: ClusterNodeId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoteResponseData {
+    /// The election term this vote is for.
+    pub term: u64,
+    /// Whether the voter grants the vote.
+    pub vote_granted: bool,
+    /// The role being elected.
+    pub role: ElectionRole,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElectionWonData {
+    /// The election term.
+    pub term: u64,
+    /// The role that was won.
+    pub role: ElectionRole,
+    /// The winning node ID.
+    pub winner_id: ClusterNodeId,
+}
+
+// ── Flow replication types ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowUpdateData {
+    /// Monotonically increasing flow version.
+    pub version: u64,
+    /// The complete flow configuration as TOML string.
+    pub flow_config: String,
+    /// Election term of the coordinator that issued this update.
+    pub coordinator_term: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowUpdateAckData {
+    /// The flow version that was applied.
+    pub version: u64,
+    /// Whether the update was successfully applied.
+    pub success: bool,
+    /// Error message if the update failed.
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowSyncResponseData {
+    /// Current flow version.
+    pub version: u64,
+    /// Complete flow configuration as TOML string.
+    pub flow_config: String,
+    /// Current coordinator ID.
+    pub coordinator_id: Option<ClusterNodeId>,
+    /// Current primary node ID.
+    pub primary_id: Option<ClusterNodeId>,
+    /// Current election term.
+    pub election_term: u64,
+}
+
+// ── Membership types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JoinRequestData {
+    /// Address the joining node listens on.
+    pub address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JoinResponseData {
+    /// Whether the join was accepted.
+    pub accepted: bool,
+    /// Reason for rejection (if not accepted).
+    pub reason: Option<String>,
+    /// Current flow version to sync.
+    pub flow_version: u64,
+    /// Current flow config.
+    pub flow_config: Option<String>,
+}
+
+// ── Wire format helpers ──────────────────────────────────────────────────────
+
+impl ClusterMessage {
+    /// Serialize to length-prefixed JSON bytes for wire transmission.
+    pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
+        let json = serde_json::to_vec(self)?;
+        let len = json.len() as u32;
+        let mut buf = Vec::with_capacity(4 + json.len());
+        buf.extend_from_slice(&len.to_le_bytes());
+        buf.extend_from_slice(&json);
+        Ok(buf)
+    }
+
+    /// Deserialize from a JSON byte slice (without the length prefix).
+    pub fn decode(data: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_heartbeat() {
+        let msg = ClusterMessage {
+            sender_id: "node-1".into(),
+            seq: 42,
+            payload: MessagePayload::Heartbeat(HeartbeatData {
+                state: NodeState::Connected,
+                roles: vec![ClusterRole::Coordinator],
+                flow_version: 5,
+                election_term: 3,
+                metrics: Some(NodeMetricsSummary {
+                    total_flowfiles: 1000,
+                    active_processors: 4,
+                    system_load: Some(0.75),
+                }),
+            }),
+        };
+
+        let encoded = msg.encode().unwrap();
+        assert!(encoded.len() > 4);
+
+        let len = u32::from_le_bytes([encoded[0], encoded[1], encoded[2], encoded[3]]) as usize;
+        assert_eq!(len, encoded.len() - 4);
+
+        let decoded = ClusterMessage::decode(&encoded[4..]).unwrap();
+        assert_eq!(decoded.sender_id, "node-1");
+        assert_eq!(decoded.seq, 42);
+
+        match decoded.payload {
+            MessagePayload::Heartbeat(data) => {
+                assert_eq!(data.state, NodeState::Connected);
+                assert_eq!(data.flow_version, 5);
+                assert_eq!(data.election_term, 3);
+            }
+            _ => panic!("expected Heartbeat payload"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_vote_request() {
+        let msg = ClusterMessage {
+            sender_id: "node-2".into(),
+            seq: 1,
+            payload: MessagePayload::VoteRequest(VoteRequestData {
+                term: 5,
+                role: ElectionRole::Coordinator,
+                candidate_id: "node-2".into(),
+            }),
+        };
+
+        let encoded = msg.encode().unwrap();
+        let decoded = ClusterMessage::decode(&encoded[4..]).unwrap();
+        match decoded.payload {
+            MessagePayload::VoteRequest(data) => {
+                assert_eq!(data.term, 5);
+                assert_eq!(data.role, ElectionRole::Coordinator);
+            }
+            _ => panic!("expected VoteRequest payload"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_flow_update() {
+        let msg = ClusterMessage {
+            sender_id: "node-1".into(),
+            seq: 10,
+            payload: MessagePayload::FlowUpdate(FlowUpdateData {
+                version: 42,
+                flow_config: "[flow]\nname = \"test\"".into(),
+                coordinator_term: 3,
+            }),
+        };
+
+        let encoded = msg.encode().unwrap();
+        let decoded = ClusterMessage::decode(&encoded[4..]).unwrap();
+        match decoded.payload {
+            MessagePayload::FlowUpdate(data) => {
+                assert_eq!(data.version, 42);
+                assert!(data.flow_config.contains("test"));
+            }
+            _ => panic!("expected FlowUpdate payload"),
+        }
+    }
+}

--- a/crates/runifi-core/src/cluster/replication.rs
+++ b/crates/runifi-core/src/cluster/replication.rs
@@ -1,0 +1,406 @@
+//! Flow configuration replication across cluster nodes.
+//!
+//! The coordinator is responsible for broadcasting flow configuration changes
+//! to all connected nodes. Each flow update carries a monotonically increasing
+//! version number. Nodes apply updates atomically — either the entire update
+//! succeeds or it is rejected.
+//!
+//! Joining nodes request the current flow configuration via `FlowSyncRequest`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::RwLock;
+
+use super::node::{ClusterNodeId, NodeInfo, NodeState};
+use super::protocol::{FlowUpdateAckData, FlowUpdateData};
+
+/// Tracks flow replication state across the cluster.
+///
+/// The coordinator uses this to broadcast flow changes and track which nodes
+/// have acknowledged each version.
+pub struct FlowReplicator {
+    /// Current flow configuration version (monotonically increasing).
+    current_version: AtomicU64,
+
+    /// Current flow configuration as TOML string.
+    current_config: RwLock<String>,
+
+    /// Shared node state map.
+    nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>,
+
+    /// Pending acknowledgements for in-flight updates.
+    /// Maps version -> set of node IDs that have acknowledged.
+    pending_acks: RwLock<HashMap<u64, ReplicationStatus>>,
+}
+
+/// Status of a flow replication round.
+#[derive(Debug, Clone)]
+pub struct ReplicationStatus {
+    /// The flow version being replicated.
+    pub version: u64,
+    /// Nodes that have acknowledged this version.
+    pub acknowledged: Vec<ClusterNodeId>,
+    /// Nodes that have not yet acknowledged.
+    pub pending: Vec<ClusterNodeId>,
+    /// Nodes that rejected the update.
+    pub rejected: Vec<(ClusterNodeId, String)>,
+}
+
+impl FlowReplicator {
+    /// Create a new flow replicator.
+    pub fn new(nodes: Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>>) -> Self {
+        Self {
+            current_version: AtomicU64::new(0),
+            current_config: RwLock::new(String::new()),
+            nodes,
+            pending_acks: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Get the current flow version.
+    pub fn current_version(&self) -> u64 {
+        self.current_version.load(Ordering::Relaxed)
+    }
+
+    /// Get the current flow configuration.
+    pub fn current_config(&self) -> String {
+        self.current_config.read().clone()
+    }
+
+    /// Set the initial flow configuration (used at startup).
+    pub fn set_initial_config(&self, config: String, version: u64) {
+        self.current_version.store(version, Ordering::Relaxed);
+        *self.current_config.write() = config;
+    }
+
+    /// Prepare a flow update for broadcast.
+    ///
+    /// Increments the version, stores the new config, and returns the update
+    /// data to be sent to all peers. Also initializes the pending ack tracking.
+    ///
+    /// Returns `None` if there are no connected peers to replicate to.
+    pub fn prepare_update(
+        &self,
+        new_config: String,
+        coordinator_term: u64,
+    ) -> Option<FlowUpdateData> {
+        let new_version = self.current_version.fetch_add(1, Ordering::Relaxed) + 1;
+        *self.current_config.write() = new_config.clone();
+
+        // Determine which nodes need to acknowledge.
+        let connected_peers: Vec<ClusterNodeId> = {
+            let nodes = self.nodes.read();
+            nodes
+                .iter()
+                .filter(|(_, n)| n.state == NodeState::Connected)
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+
+        if connected_peers.is_empty() {
+            // Single-node cluster or no peers connected.
+            return None;
+        }
+
+        let status = ReplicationStatus {
+            version: new_version,
+            acknowledged: Vec::new(),
+            pending: connected_peers,
+            rejected: Vec::new(),
+        };
+
+        self.pending_acks.write().insert(new_version, status);
+
+        Some(FlowUpdateData {
+            version: new_version,
+            flow_config: new_config,
+            coordinator_term,
+        })
+    }
+
+    /// Record an acknowledgement from a peer node.
+    ///
+    /// Returns `true` if all nodes have acknowledged this version.
+    pub fn record_ack(&self, ack: &FlowUpdateAckData, node_id: &ClusterNodeId) -> bool {
+        let mut pending = self.pending_acks.write();
+        if let Some(status) = pending.get_mut(&ack.version) {
+            status.pending.retain(|id| id != node_id);
+
+            if ack.success {
+                status.acknowledged.push(node_id.clone());
+            } else {
+                status
+                    .rejected
+                    .push((node_id.clone(), ack.error.clone().unwrap_or_default()));
+            }
+
+            let all_done = status.pending.is_empty();
+            if all_done {
+                tracing::info!(
+                    version = ack.version,
+                    acked = status.acknowledged.len(),
+                    rejected = status.rejected.len(),
+                    "Flow replication round complete"
+                );
+            }
+            all_done
+        } else {
+            // Unknown version — stale ack.
+            false
+        }
+    }
+
+    /// Apply a received flow update (on non-coordinator nodes).
+    ///
+    /// Returns `FlowUpdateAckData` indicating success or failure.
+    pub fn apply_update(&self, update: &FlowUpdateData) -> FlowUpdateAckData {
+        let current = self.current_version.load(Ordering::Relaxed);
+
+        if update.version <= current {
+            // Already have this version or newer.
+            return FlowUpdateAckData {
+                version: update.version,
+                success: true,
+                error: None,
+            };
+        }
+
+        // Apply the update atomically.
+        self.current_version
+            .store(update.version, Ordering::Relaxed);
+        *self.current_config.write() = update.flow_config.clone();
+
+        tracing::info!(
+            version = update.version,
+            coordinator_term = update.coordinator_term,
+            "Applied flow configuration update"
+        );
+
+        FlowUpdateAckData {
+            version: update.version,
+            success: true,
+            error: None,
+        }
+    }
+
+    /// Get the replication status for a specific version.
+    pub fn replication_status(&self, version: u64) -> Option<ReplicationStatus> {
+        self.pending_acks.read().get(&version).cloned()
+    }
+
+    /// Check whether all connected nodes have the current flow version.
+    pub fn is_fully_replicated(&self) -> bool {
+        let current = self.current_version.load(Ordering::Relaxed);
+        let nodes = self.nodes.read();
+        nodes
+            .values()
+            .filter(|n| n.state == NodeState::Connected)
+            .all(|n| n.flow_version >= current)
+    }
+
+    /// Clean up old pending ack entries (keep only the most recent N versions).
+    pub fn cleanup_old_acks(&self, keep_count: usize) {
+        let mut pending = self.pending_acks.write();
+        if pending.len() > keep_count {
+            let mut versions: Vec<u64> = pending.keys().cloned().collect();
+            versions.sort();
+            let remove_count = versions.len() - keep_count;
+            for version in versions.into_iter().take(remove_count) {
+                pending.remove(&version);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_nodes() -> Arc<RwLock<HashMap<ClusterNodeId, NodeInfo>>> {
+        let mut nodes = HashMap::new();
+
+        let mut n1 = NodeInfo::new("node-1".into(), "node-1:9443".into());
+        n1.state = NodeState::Connected;
+        nodes.insert("node-1".into(), n1);
+
+        let mut n2 = NodeInfo::new("node-2".into(), "node-2:9443".into());
+        n2.state = NodeState::Connected;
+        nodes.insert("node-2".into(), n2);
+
+        let mut n3 = NodeInfo::new("node-3".into(), "node-3:9443".into());
+        n3.state = NodeState::Connected;
+        nodes.insert("node-3".into(), n3);
+
+        Arc::new(RwLock::new(nodes))
+    }
+
+    #[test]
+    fn initial_state() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+        assert_eq!(replicator.current_version(), 0);
+        assert!(replicator.current_config().is_empty());
+    }
+
+    #[test]
+    fn set_initial_config() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        replicator.set_initial_config("[flow]\nname = \"test\"".into(), 1);
+        assert_eq!(replicator.current_version(), 1);
+        assert!(replicator.current_config().contains("test"));
+    }
+
+    #[test]
+    fn prepare_update_increments_version() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        let update = replicator.prepare_update("[flow]\nname = \"v1\"".into(), 1);
+        assert!(update.is_some());
+        let update = update.unwrap();
+        assert_eq!(update.version, 1);
+        assert_eq!(replicator.current_version(), 1);
+
+        let update2 = replicator.prepare_update("[flow]\nname = \"v2\"".into(), 1);
+        assert!(update2.is_some());
+        assert_eq!(update2.unwrap().version, 2);
+    }
+
+    #[test]
+    fn prepare_update_no_peers() {
+        let nodes = Arc::new(RwLock::new(HashMap::new()));
+        let replicator = FlowReplicator::new(nodes);
+
+        let update = replicator.prepare_update("[flow]".into(), 1);
+        assert!(update.is_none()); // No connected peers.
+    }
+
+    #[test]
+    fn ack_tracking() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        let _update = replicator.prepare_update("[flow]".into(), 1);
+
+        // First ack — not complete yet.
+        let ack = FlowUpdateAckData {
+            version: 1,
+            success: true,
+            error: None,
+        };
+        assert!(!replicator.record_ack(&ack, &"node-1".into()));
+
+        // Second ack — not complete yet.
+        assert!(!replicator.record_ack(&ack, &"node-2".into()));
+
+        // Third ack — all done.
+        assert!(replicator.record_ack(&ack, &"node-3".into()));
+    }
+
+    #[test]
+    fn ack_with_rejection() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        let _update = replicator.prepare_update("[flow]".into(), 1);
+
+        // Success ack.
+        let ack_ok = FlowUpdateAckData {
+            version: 1,
+            success: true,
+            error: None,
+        };
+        replicator.record_ack(&ack_ok, &"node-1".into());
+
+        // Rejection ack.
+        let ack_fail = FlowUpdateAckData {
+            version: 1,
+            success: false,
+            error: Some("parse error".into()),
+        };
+        replicator.record_ack(&ack_fail, &"node-2".into());
+
+        // Last ack completes the round.
+        assert!(replicator.record_ack(&ack_ok, &"node-3".into()));
+
+        let status = replicator.replication_status(1).unwrap();
+        assert_eq!(status.acknowledged.len(), 2);
+        assert_eq!(status.rejected.len(), 1);
+    }
+
+    #[test]
+    fn apply_update_stores_config() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        let update = FlowUpdateData {
+            version: 5,
+            flow_config: "[flow]\nname = \"remote\"".into(),
+            coordinator_term: 3,
+        };
+
+        let ack = replicator.apply_update(&update);
+        assert!(ack.success);
+        assert_eq!(ack.version, 5);
+        assert_eq!(replicator.current_version(), 5);
+        assert!(replicator.current_config().contains("remote"));
+    }
+
+    #[test]
+    fn apply_stale_update() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        replicator.set_initial_config("v10".into(), 10);
+
+        let update = FlowUpdateData {
+            version: 5, // Stale.
+            flow_config: "old".into(),
+            coordinator_term: 1,
+        };
+
+        let ack = replicator.apply_update(&update);
+        assert!(ack.success); // Accepted silently.
+        assert_eq!(replicator.current_version(), 10); // Not overwritten.
+    }
+
+    #[test]
+    fn cleanup_old_acks() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes);
+
+        for _ in 0..10 {
+            replicator.prepare_update("[flow]".into(), 1);
+        }
+
+        assert_eq!(replicator.pending_acks.read().len(), 10);
+
+        replicator.cleanup_old_acks(3);
+        assert_eq!(replicator.pending_acks.read().len(), 3);
+    }
+
+    #[test]
+    fn is_fully_replicated() {
+        let nodes = make_test_nodes();
+        let replicator = FlowReplicator::new(nodes.clone());
+
+        replicator.set_initial_config("[flow]".into(), 5);
+
+        // Not fully replicated yet (nodes still at version 0).
+        assert!(!replicator.is_fully_replicated());
+
+        // Update node versions.
+        {
+            let mut nodes_write = nodes.write();
+            for node in nodes_write.values_mut() {
+                node.flow_version = 5;
+            }
+        }
+
+        assert!(replicator.is_fully_replicated());
+    }
+}

--- a/crates/runifi-core/src/config/flow_config.rs
+++ b/crates/runifi-core/src/config/flow_config.rs
@@ -3,6 +3,9 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
+use crate::cluster::config::ClusterConfig;
+use crate::cluster::load_balance::LoadBalanceConfig;
+
 /// Top-level flow configuration, loaded from TOML.
 #[derive(Debug, Default, Deserialize)]
 pub struct FlowConfig {
@@ -16,6 +19,8 @@ pub struct FlowConfig {
     pub audit: AuditConfig,
     #[serde(default)]
     pub auth: AuthConfig,
+    #[serde(default)]
+    pub cluster: ClusterConfig,
 }
 
 /// Configuration for the web API server.
@@ -312,6 +317,9 @@ pub struct ConnectionConfig {
     /// Back-pressure config (optional).
     #[serde(default)]
     pub back_pressure: Option<BackPressureConfigToml>,
+    /// Load balancing config for cluster distribution (optional).
+    #[serde(default)]
+    pub load_balancing: Option<LoadBalanceConfig>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/runifi-core/src/error.rs
+++ b/crates/runifi-core/src/error.rs
@@ -69,6 +69,18 @@ pub enum RuniFiError {
 
     #[error("checkpoint error: {path}: {reason}")]
     CheckpointError { path: String, reason: String },
+
+    #[error("cluster error: {0}")]
+    Cluster(String),
+
+    #[error("cluster node '{node_id}' not found")]
+    ClusterNodeNotFound { node_id: String },
+
+    #[error("cluster election failed for role '{role}': {reason}")]
+    ClusterElectionFailed { role: String, reason: String },
+
+    #[error("cluster flow replication failed: version={version}, {reason}")]
+    ClusterReplicationFailed { version: u64, reason: String },
 }
 
 pub type Result<T> = std::result::Result<T, RuniFiError>;

--- a/crates/runifi-core/src/lib.rs
+++ b/crates/runifi-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod auth;
+pub mod cluster;
 pub mod config;
 pub mod connection;
 pub mod engine;


### PR DESCRIPTION
## Summary

Implements Phase 1 of multi-node clustering for RuniFi (#31), providing the foundational infrastructure for NiFi-style zero-leader clustering where every node performs identical work on different data.

### What's included

- **Node Discovery & Membership**: Static cluster membership via TOML configuration, node lifecycle state machine (CONNECTING -> CONNECTED -> DISCONNECTING -> DISCONNECTED)
- **Heartbeat Mechanism**: Configurable heartbeat interval (default 5s) with automatic disconnect after N missed heartbeats (default 3)
- **Role Election**: Raft-inspired leader election for Cluster Coordinator and Primary Node roles, with term-based voting, majority quorum, and step-down on higher terms
- **Flow Replication**: Version-tracked flow configuration replication with acknowledgement tracking and atomic updates across all cluster nodes
- **Connection Load Balancing**: Four strategies — DoNotLoadBalance (default), RoundRobin, PartitionByAttribute (hash-based deterministic routing), SingleNode
- **Wire Protocol**: Length-prefixed JSON over TCP for all inter-node communication (heartbeats, votes, flow updates, join/disconnect)
- **Configuration Integration**: `[cluster]` section in FlowConfig, `load_balancing` option on connection configs

### New files

All in `crates/runifi-core/src/cluster/`:
- `mod.rs` — module declarations and public re-exports
- `config.rs` — ClusterConfig with TOML deserialization and validation
- `node.rs` — NodeState, NodeInfo, ClusterRole, ClusterStatus types
- `protocol.rs` — ClusterMessage envelope, all message payload types, wire encoding
- `election.rs` — ElectionState with Raft-inspired term/vote/majority logic
- `heartbeat.rs` — HeartbeatManager with periodic check loop and event emission
- `replication.rs` — FlowReplicator with version tracking and ack management
- `load_balance.rs` — LoadBalanceStrategy enum and LoadBalancer runtime
- `coordinator.rs` — ClusterCoordinator orchestrating all subsystems with TCP networking

### Modified files

- `crates/runifi-core/src/lib.rs` — added `pub mod cluster`
- `crates/runifi-core/src/error.rs` — added cluster error variants
- `crates/runifi-core/src/config/flow_config.rs` — added `ClusterConfig` and `LoadBalanceConfig` to flow/connection configs

### Test coverage

58 tests covering all components:
- Config validation and TOML deserialization
- Node state transitions and role management
- Election flow (voting, majority, step-down, stale term rejection)
- Heartbeat tracking and timeout detection
- Flow replication (prepare, ack tracking, apply, stale rejection)
- Load balancing (all 4 strategies with edge cases)
- Protocol message serialization round-trips
- Coordinator lifecycle (creation, start/stop, message processing)

### Configuration example

```toml
[cluster]
enabled = true
node_id = "node-1"
bind_address = "0.0.0.0:9443"
nodes = ["node-1:9443", "node-2:9443", "node-3:9443"]
heartbeat_interval_ms = 5000
heartbeat_miss_threshold = 3

[[flow.connections]]
source = "generate"
destination = "process"
relationship = "success"
[flow.connections.load_balancing]
strategy = "round_robin"
compression = true
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 606 tests, 0 failures)
- [x] All 58 new cluster tests pass
- [x] No regressions in existing tests
- [ ] CI pipeline passes

Closes #31