### PR TITLE
feat: implement Process Groups for hierarchical flow organization (#30)

### DIFF
--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -115,6 +115,13 @@ pub struct FlowResponse {
     pub connections: Vec<FlowEdgeResponse>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<FlowLabelResponse>,
+    /// Number of process groups in the flow.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub process_group_count: usize,
+}
+
+fn is_zero(v: &usize) -> bool {
+    *v == 0
 }
 
 /// A label in the flow topology response.

--- a/crates/runifi-api/src/lib.rs
+++ b/crates/runifi-api/src/lib.rs
@@ -86,6 +86,7 @@ pub fn create_router_with_registry(
         .merge(routes::user_groups::routes())
         .merge(routes::labels::routes())
         .merge(routes::provenance::routes())
+        .merge(routes::process_groups::routes())
         .merge(dashboard::routes())
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/crates/runifi-api/src/routes/flow.rs
+++ b/crates/runifi-api/src/routes/flow.rs
@@ -57,10 +57,13 @@ async fn get_flow(State(state): State<ApiState>) -> Json<FlowResponse> {
         })
         .collect();
 
+    let process_group_count = handle.process_groups.read().len();
+
     Json(FlowResponse {
         name: handle.flow_name.clone(),
         processors,
         connections,
         labels,
+        process_group_count,
     })
 }

--- a/crates/runifi-api/src/routes/mod.rs
+++ b/crates/runifi-api/src/routes/mod.rs
@@ -5,6 +5,7 @@ pub mod events;
 pub mod flow;
 pub mod labels;
 pub mod plugins;
+pub mod process_groups;
 pub mod processors;
 pub mod provenance;
 pub mod services;

--- a/crates/runifi-api/src/routes/process_groups.rs
+++ b/crates/runifi-api/src/routes/process_groups.rs
@@ -1,0 +1,374 @@
+use std::collections::HashMap;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{delete as delete_method, get, post, put};
+use axum::{Json, Router, middleware};
+use serde::{Deserialize, Serialize};
+
+use crate::error::ApiError;
+use crate::rbac;
+use crate::state::ApiState;
+
+pub fn routes() -> Router<ApiState> {
+    // GET endpoints — ViewFlow (Viewer+)
+    let view_routes = Router::new()
+        .route("/api/v1/process-groups", get(list_process_groups))
+        .route("/api/v1/process-groups/{id}", get(get_process_group))
+        .layer(middleware::from_fn(rbac::require_view_flow));
+
+    // Mutation endpoints — ModifyFlow (Admin only)
+    let modify_routes = Router::new()
+        .route("/api/v1/process-groups", post(create_process_group))
+        .route("/api/v1/process-groups/{id}", put(update_process_group))
+        .route(
+            "/api/v1/process-groups/{id}",
+            delete_method(delete_process_group),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/processors/{processor_name}",
+            put(add_processor_to_group),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/processors/{processor_name}",
+            delete_method(remove_processor_from_group),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/connections/{connection_id}",
+            put(add_connection_to_group),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/connections/{connection_id}",
+            delete_method(remove_connection_from_group),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/input-ports",
+            post(add_input_port),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/output-ports",
+            post(add_output_port),
+        )
+        .route(
+            "/api/v1/process-groups/{id}/ports/{port_id}",
+            delete_method(remove_port),
+        )
+        .layer(middleware::from_fn(rbac::require_modify_flow));
+
+    view_routes.merge(modify_routes)
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+/// Request body for creating a process group.
+#[derive(Deserialize)]
+pub struct CreateProcessGroupRequest {
+    /// Human-readable name for the process group.
+    pub name: String,
+    /// Optional parent group ID for nesting.
+    #[serde(default)]
+    pub parent_group_id: Option<String>,
+    /// Input port names.
+    #[serde(default)]
+    pub input_ports: Vec<String>,
+    /// Output port names.
+    #[serde(default)]
+    pub output_ports: Vec<String>,
+    /// Group-scoped variables.
+    #[serde(default)]
+    pub variables: HashMap<String, String>,
+}
+
+/// Request body for updating a process group.
+#[derive(Deserialize)]
+pub struct UpdateProcessGroupRequest {
+    /// New name for the group (optional).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New variables for the group (replaces existing, optional).
+    #[serde(default)]
+    pub variables: Option<HashMap<String, String>>,
+}
+
+/// Request body for adding a port.
+#[derive(Deserialize)]
+pub struct AddPortRequest {
+    /// Name for the new port.
+    pub name: String,
+}
+
+/// Response for a process group.
+#[derive(Serialize)]
+pub struct ProcessGroupResponse {
+    pub id: String,
+    pub name: String,
+    pub input_ports: Vec<PortResponse>,
+    pub output_ports: Vec<PortResponse>,
+    pub processor_names: Vec<String>,
+    pub connection_ids: Vec<String>,
+    pub child_group_ids: Vec<String>,
+    pub parent_group_id: Option<String>,
+    pub variables: HashMap<String, String>,
+}
+
+/// Response for a port.
+#[derive(Serialize)]
+pub struct PortResponse {
+    pub id: String,
+    pub name: String,
+    pub port_type: String,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+async fn list_process_groups(State(state): State<ApiState>) -> Json<Vec<ProcessGroupResponse>> {
+    let groups = state.handle.list_process_groups();
+    let response: Vec<ProcessGroupResponse> = groups.into_iter().map(to_response).collect();
+    Json(response)
+}
+
+async fn get_process_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<ProcessGroupResponse>, ApiError> {
+    let group = state
+        .handle
+        .get_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Process group not found: {}", id)))?;
+    Ok(Json(to_response(group)))
+}
+
+async fn create_process_group(
+    State(state): State<ApiState>,
+    Json(body): Json<CreateProcessGroupRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_group_name(&body.name)?;
+
+    let group_id = state
+        .handle
+        .create_process_group(
+            body.name,
+            body.parent_group_id,
+            body.input_ports,
+            body.output_ports,
+            body.variables,
+        )
+        .map_err(ApiError::BadRequest)?;
+
+    let group = state
+        .handle
+        .get_process_group(&group_id)
+        .ok_or_else(|| ApiError::BadRequest("Failed to retrieve created group".to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(to_response(group))).into_response())
+}
+
+async fn update_process_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateProcessGroupRequest>,
+) -> Result<Json<ProcessGroupResponse>, ApiError> {
+    if let Some(ref name) = body.name {
+        validate_group_name(name)?;
+    }
+
+    state
+        .handle
+        .update_process_group(&id, body.name, body.variables)
+        .map_err(ApiError::BadRequest)?;
+
+    let group = state
+        .handle
+        .get_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Process group not found: {}", id)))?;
+
+    Ok(Json(to_response(group)))
+}
+
+async fn delete_process_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .remove_process_group(&id)
+        .map_err(ApiError::Conflict)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_processor_to_group(
+    State(state): State<ApiState>,
+    Path((id, processor_name)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .add_processor_to_group(&id, &processor_name)
+        .map_err(ApiError::BadRequest)?;
+
+    Ok(Json(serde_json::json!({
+        "status": "added",
+        "group_id": id,
+        "processor": processor_name,
+    })))
+}
+
+async fn remove_processor_from_group(
+    State(state): State<ApiState>,
+    Path((id, processor_name)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .remove_processor_from_group(&id, &processor_name)
+        .map_err(ApiError::BadRequest)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_connection_to_group(
+    State(state): State<ApiState>,
+    Path((id, connection_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .add_connection_to_group(&id, &connection_id)
+        .map_err(ApiError::BadRequest)?;
+
+    Ok(Json(serde_json::json!({
+        "status": "added",
+        "group_id": id,
+        "connection_id": connection_id,
+    })))
+}
+
+async fn remove_connection_from_group(
+    State(state): State<ApiState>,
+    Path((id, connection_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .remove_connection_from_group(&id, &connection_id)
+        .map_err(ApiError::BadRequest)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_input_port(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<AddPortRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let port_id = state
+        .handle
+        .add_input_port(&id, body.name.clone())
+        .map_err(ApiError::BadRequest)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({
+            "id": port_id,
+            "name": body.name,
+            "port_type": "input",
+            "group_id": id,
+        })),
+    )
+        .into_response())
+}
+
+async fn add_output_port(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<AddPortRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let port_id = state
+        .handle
+        .add_output_port(&id, body.name.clone())
+        .map_err(ApiError::BadRequest)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({
+            "id": port_id,
+            "name": body.name,
+            "port_type": "output",
+            "group_id": id,
+        })),
+    )
+        .into_response())
+}
+
+async fn remove_port(
+    State(state): State<ApiState>,
+    Path((id, port_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .remove_port(&id, &port_id)
+        .map_err(ApiError::BadRequest)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn validate_group_name(name: &str) -> Result<(), ApiError> {
+    if name.is_empty() {
+        return Err(ApiError::BadRequest(
+            "Process group name must not be empty".to_string(),
+        ));
+    }
+    if name.len() > 128 {
+        return Err(ApiError::BadRequest(
+            "Process group name must not exceed 128 characters".to_string(),
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ' ')
+    {
+        return Err(ApiError::BadRequest(
+            "Process group name may only contain letters, digits, underscores, hyphens, and spaces"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn to_response(
+    group: runifi_core::engine::process_group::ProcessGroupInfo,
+) -> ProcessGroupResponse {
+    ProcessGroupResponse {
+        id: group.id,
+        name: group.name,
+        input_ports: group
+            .input_ports
+            .into_iter()
+            .map(|p| PortResponse {
+                id: p.id,
+                name: p.name,
+                port_type: match p.port_type {
+                    runifi_core::engine::process_group::PortType::Input => "input".to_string(),
+                    runifi_core::engine::process_group::PortType::Output => "output".to_string(),
+                },
+            })
+            .collect(),
+        output_ports: group
+            .output_ports
+            .into_iter()
+            .map(|p| PortResponse {
+                id: p.id,
+                name: p.name,
+                port_type: match p.port_type {
+                    runifi_core::engine::process_group::PortType::Input => "input".to_string(),
+                    runifi_core::engine::process_group::PortType::Output => "output".to_string(),
+                },
+            })
+            .collect(),
+        processor_names: group.processor_names,
+        connection_ids: group.connection_ids,
+        child_group_ids: group.child_group_ids,
+        parent_group_id: group.parent_group_id,
+        variables: group.variables,
+    }
+}

--- a/crates/runifi-core/src/audit/event.rs
+++ b/crates/runifi-core/src/audit/event.rs
@@ -109,6 +109,10 @@ pub enum AuditAction {
     ServiceEnabled,
     ServiceDisabled,
     ServiceConfigured,
+    // Process groups
+    ProcessGroupCreated,
+    ProcessGroupUpdated,
+    ProcessGroupRemoved,
     // System
     EngineStarted,
     EngineShutdown,
@@ -142,6 +146,13 @@ impl AuditTarget {
         Self {
             resource_type: "service".to_string(),
             resource_id: name.into(),
+        }
+    }
+
+    pub fn process_group(id: impl Into<String>) -> Self {
+        Self {
+            resource_type: "process_group".to_string(),
+            resource_id: id.into(),
         }
     }
 

--- a/crates/runifi-core/src/config/flow_config.rs
+++ b/crates/runifi-core/src/config/flow_config.rs
@@ -220,6 +220,9 @@ pub struct FlowDefinition {
     pub connections: Vec<ConnectionConfig>,
     #[serde(default)]
     pub services: Vec<ServiceConfig>,
+    /// Process Groups for hierarchical flow organization.
+    #[serde(default)]
+    pub process_groups: Vec<ProcessGroupConfig>,
 }
 
 impl Default for FlowDefinition {
@@ -229,8 +232,65 @@ impl Default for FlowDefinition {
             processors: Vec::new(),
             connections: Vec::new(),
             services: Vec::new(),
+            process_groups: Vec::new(),
         }
     }
+}
+
+/// Configuration for a Process Group — a hierarchical container for
+/// processors, connections, ports, and child process groups.
+///
+/// ```toml
+/// [[flow.process_groups]]
+/// name = "data-enrichment"
+///
+/// [flow.process_groups.input_ports]
+/// ports = ["raw-data"]
+///
+/// [flow.process_groups.output_ports]
+/// ports = ["enriched-data"]
+///
+/// [[flow.process_groups.processors]]
+/// name = "lookup"
+/// type = "InvokeHTTP"
+///
+/// [[flow.process_groups.connections]]
+/// source = "raw-data"
+/// relationship = "success"
+/// destination = "lookup"
+///
+/// [flow.process_groups.variables]
+/// "api.url" = "https://example.com"
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct ProcessGroupConfig {
+    /// Unique name for this process group.
+    pub name: String,
+    /// Input ports that receive FlowFiles from the parent group.
+    #[serde(default)]
+    pub input_ports: Option<PortsConfig>,
+    /// Output ports that send FlowFiles to the parent group.
+    #[serde(default)]
+    pub output_ports: Option<PortsConfig>,
+    /// Processors within this process group.
+    #[serde(default)]
+    pub processors: Vec<ProcessorConfig>,
+    /// Connections within this process group.
+    #[serde(default)]
+    pub connections: Vec<ConnectionConfig>,
+    /// Nested child process groups.
+    #[serde(default)]
+    pub process_groups: Vec<ProcessGroupConfig>,
+    /// Group-scoped variables. Child groups inherit and can override.
+    #[serde(default)]
+    pub variables: HashMap<String, String>,
+}
+
+/// Port name list for Process Group input or output ports.
+#[derive(Debug, Deserialize)]
+pub struct PortsConfig {
+    /// List of port names.
+    pub ports: Vec<String>,
 }
 
 /// Configuration for a controller service instance in the flow.
@@ -674,5 +734,88 @@ mod tests {
         assert_eq!(config.flow.name, "my-flow");
         assert!(config.flow.processors.is_empty());
         assert!(config.flow.connections.is_empty());
+    }
+
+    #[test]
+    fn process_group_config_deserializes() {
+        let toml_str = r#"
+            [flow]
+            name = "grouped-flow"
+
+            [[flow.process_groups]]
+            name = "data-enrichment"
+
+            [flow.process_groups.input_ports]
+            ports = ["raw-data"]
+
+            [flow.process_groups.output_ports]
+            ports = ["enriched-data"]
+
+            [flow.process_groups.variables]
+            "api.url" = "https://example.com"
+
+            [[flow.process_groups.processors]]
+            name = "lookup"
+            type = "GenerateFlowFile"
+
+            [[flow.process_groups.connections]]
+            source = "raw-data"
+            relationship = "success"
+            destination = "lookup"
+        "#;
+
+        let config: FlowConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.flow.process_groups.len(), 1);
+
+        let pg = &config.flow.process_groups[0];
+        assert_eq!(pg.name, "data-enrichment");
+
+        let input_ports = pg.input_ports.as_ref().unwrap();
+        assert_eq!(input_ports.ports, vec!["raw-data"]);
+
+        let output_ports = pg.output_ports.as_ref().unwrap();
+        assert_eq!(output_ports.ports, vec!["enriched-data"]);
+
+        assert_eq!(pg.processors.len(), 1);
+        assert_eq!(pg.processors[0].name, "lookup");
+
+        assert_eq!(pg.connections.len(), 1);
+        assert_eq!(pg.connections[0].source, "raw-data");
+
+        assert_eq!(pg.variables.get("api.url").unwrap(), "https://example.com");
+    }
+
+    #[test]
+    fn default_config_has_empty_process_groups() {
+        let config = FlowConfig::default();
+        assert!(config.flow.process_groups.is_empty());
+    }
+
+    #[test]
+    fn nested_process_groups_deserialize() {
+        let toml_str = r#"
+            [flow]
+            name = "nested-flow"
+
+            [[flow.process_groups]]
+            name = "outer-group"
+
+            [[flow.process_groups.process_groups]]
+            name = "inner-group"
+
+            [flow.process_groups.process_groups.input_ports]
+            ports = ["in"]
+        "#;
+
+        let config: FlowConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.flow.process_groups.len(), 1);
+
+        let outer = &config.flow.process_groups[0];
+        assert_eq!(outer.name, "outer-group");
+        assert_eq!(outer.process_groups.len(), 1);
+
+        let inner = &outer.process_groups[0];
+        assert_eq!(inner.name, "inner-group");
+        assert_eq!(inner.input_ports.as_ref().unwrap().ports, vec!["in"]);
     }
 }

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -428,6 +428,9 @@ impl FlowEngine {
         // Shared label store.
         let labels = Arc::new(RwLock::new(Vec::new()));
 
+        // Shared process group store.
+        let process_groups = Arc::new(RwLock::new(Vec::new()));
+
         // Build the EngineHandle.
         let engine_handle = EngineHandle {
             flow_name: self.flow_name.clone(),
@@ -441,6 +444,7 @@ impl FlowEngine {
             audit_logger: self.audit_logger.clone(),
             service_registry: self.service_registry.clone(),
             labels: labels.clone(),
+            process_groups: process_groups.clone(),
             mutation_tx,
             persistence: self.persistence.clone(),
             provenance_repo: self.provenance_repo.clone(),
@@ -456,6 +460,7 @@ impl FlowEngine {
                 positions,
                 self.service_registry.clone(),
                 labels,
+                process_groups,
             );
             let persist_token = self.cancel_token.child_token();
             let persist_clone = persistence.clone();

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -13,6 +13,7 @@ use super::bulletin::BulletinBoard;
 use super::metrics::ProcessorMetrics;
 use super::mutation::{MutationCommand, MutationError};
 use super::persistence::FlowPersistence;
+use super::process_group::{PortInfo, PortType, ProcessGroupId, ProcessGroupInfo};
 use super::processor_node::{
     SharedInputConnections, SharedInputNotifiers, SharedOutputConnections,
 };
@@ -171,6 +172,14 @@ pub fn reset_label_id_counter(next_id: u64) {
     LABEL_ID_COUNTER.store(next_id, Ordering::Relaxed);
 }
 
+/// Auto-incrementing process group ID counter.
+static GROUP_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Reset the process group ID counter to a specific value (used when restoring persisted state).
+pub fn reset_group_id_counter(next_id: u64) {
+    GROUP_ID_COUNTER.store(next_id, Ordering::Relaxed);
+}
+
 /// A Clone-able, Send+Sync handle for API queries and mutations against a running engine.
 ///
 /// Created by `FlowEngine::start()`. The processor and connection lists use
@@ -198,6 +207,8 @@ pub struct EngineHandle {
     pub service_registry: SharedServiceRegistry,
     /// Canvas labels — text annotations, no data flow impact.
     pub labels: Arc<RwLock<Vec<LabelInfo>>>,
+    /// Process groups for hierarchical flow organization.
+    pub process_groups: Arc<RwLock<Vec<ProcessGroupInfo>>>,
     /// Sender half of the engine mutation command channel.
     pub(crate) mutation_tx: mpsc::Sender<MutationCommand>,
     /// Flow persistence layer (debounced background writer).
@@ -695,5 +706,400 @@ impl EngineHandle {
     /// List all labels.
     pub fn list_labels(&self) -> Vec<LabelInfo> {
         self.labels.read().clone()
+    }
+
+    // ── Process group management ──────────────────────────────────────────
+
+    /// Auto-incrementing process group ID counter.
+    fn next_group_id() -> ProcessGroupId {
+        let id = GROUP_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("pg-{}", id)
+    }
+
+    /// Create a new process group. Returns the generated group ID.
+    ///
+    /// If `parent_group_id` is `Some`, the group is nested inside the parent.
+    /// Input/output port names are converted to `PortInfo` entries.
+    pub fn create_process_group(
+        &self,
+        name: String,
+        parent_group_id: Option<ProcessGroupId>,
+        input_port_names: Vec<String>,
+        output_port_names: Vec<String>,
+        variables: HashMap<String, String>,
+    ) -> Result<ProcessGroupId, String> {
+        let mut groups = self.process_groups.write();
+
+        // Validate parent exists if specified.
+        if let Some(ref parent_id) = parent_group_id
+            && !groups.iter().any(|g| g.id == *parent_id)
+        {
+            return Err(format!("Parent process group not found: {}", parent_id));
+        }
+
+        // Check for duplicate name within the same parent scope.
+        let duplicate = groups
+            .iter()
+            .any(|g| g.name == name && g.parent_group_id == parent_group_id);
+        if duplicate {
+            return Err(format!(
+                "A process group named '{}' already exists in this scope",
+                name
+            ));
+        }
+
+        let group_id = Self::next_group_id();
+
+        let input_ports: Vec<PortInfo> = input_port_names
+            .into_iter()
+            .enumerate()
+            .map(|(i, port_name)| PortInfo {
+                id: format!("{}-in-{}", group_id, i),
+                name: port_name,
+                port_type: PortType::Input,
+                group_id: group_id.clone(),
+            })
+            .collect();
+
+        let output_ports: Vec<PortInfo> = output_port_names
+            .into_iter()
+            .enumerate()
+            .map(|(i, port_name)| PortInfo {
+                id: format!("{}-out-{}", group_id, i),
+                name: port_name,
+                port_type: PortType::Output,
+                group_id: group_id.clone(),
+            })
+            .collect();
+
+        let group_info = ProcessGroupInfo {
+            id: group_id.clone(),
+            name,
+            input_ports,
+            output_ports,
+            processor_names: Vec::new(),
+            connection_ids: Vec::new(),
+            child_group_ids: Vec::new(),
+            parent_group_id: parent_group_id.clone(),
+            variables,
+        };
+
+        groups.push(group_info);
+
+        // Register this group as a child of its parent.
+        if let Some(ref parent_id) = parent_group_id
+            && let Some(parent) = groups.iter_mut().find(|g| g.id == *parent_id)
+        {
+            parent.child_group_ids.push(group_id.clone());
+        }
+
+        drop(groups);
+
+        self.audit_logger.log(&AuditEvent::success(
+            AuditAction::ProcessGroupCreated,
+            AuditTarget::process_group(&group_id),
+        ));
+        self.notify_persist();
+
+        Ok(group_id)
+    }
+
+    /// Get a process group by ID.
+    pub fn get_process_group(&self, id: &str) -> Option<ProcessGroupInfo> {
+        self.process_groups
+            .read()
+            .iter()
+            .find(|g| g.id == id)
+            .cloned()
+    }
+
+    /// List all process groups.
+    pub fn list_process_groups(&self) -> Vec<ProcessGroupInfo> {
+        self.process_groups.read().clone()
+    }
+
+    /// List top-level process groups (those with no parent).
+    pub fn list_root_process_groups(&self) -> Vec<ProcessGroupInfo> {
+        self.process_groups
+            .read()
+            .iter()
+            .filter(|g| g.parent_group_id.is_none())
+            .cloned()
+            .collect()
+    }
+
+    /// Update a process group's name and/or variables.
+    pub fn update_process_group(
+        &self,
+        id: &str,
+        name: Option<String>,
+        variables: Option<HashMap<String, String>>,
+    ) -> Result<(), String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == id)
+            .ok_or_else(|| format!("Process group not found: {}", id))?;
+
+        if let Some(new_name) = name {
+            group.name = new_name;
+        }
+        if let Some(new_vars) = variables {
+            group.variables = new_vars;
+        }
+
+        drop(groups);
+        self.audit_logger.log(&AuditEvent::success(
+            AuditAction::ProcessGroupUpdated,
+            AuditTarget::process_group(id),
+        ));
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Remove a process group by ID.
+    ///
+    /// The group must be empty (no processors, connections, or child groups).
+    pub fn remove_process_group(&self, id: &str) -> Result<(), String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter()
+            .find(|g| g.id == id)
+            .ok_or_else(|| format!("Process group not found: {}", id))?;
+
+        if !group.processor_names.is_empty() {
+            return Err(format!(
+                "Process group '{}' still contains {} processor(s). Remove them first.",
+                id,
+                group.processor_names.len()
+            ));
+        }
+        if !group.connection_ids.is_empty() {
+            return Err(format!(
+                "Process group '{}' still contains {} connection(s). Remove them first.",
+                id,
+                group.connection_ids.len()
+            ));
+        }
+        if !group.child_group_ids.is_empty() {
+            return Err(format!(
+                "Process group '{}' still contains {} child group(s). Remove them first.",
+                id,
+                group.child_group_ids.len()
+            ));
+        }
+
+        let parent_id = group.parent_group_id.clone();
+        let group_id = group.id.clone();
+
+        // Remove from parent's child list.
+        if let Some(ref parent_id) = parent_id
+            && let Some(parent) = groups.iter_mut().find(|g| g.id == *parent_id)
+        {
+            parent.child_group_ids.retain(|cid| cid != &group_id);
+        }
+
+        groups.retain(|g| g.id != id);
+        drop(groups);
+
+        self.audit_logger.log(&AuditEvent::success(
+            AuditAction::ProcessGroupRemoved,
+            AuditTarget::process_group(id),
+        ));
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Add a processor to a process group by name.
+    pub fn add_processor_to_group(
+        &self,
+        group_id: &str,
+        processor_name: &str,
+    ) -> Result<(), String> {
+        // Verify the processor exists.
+        if self.get_processor_info(processor_name).is_none() {
+            return Err(format!("Processor not found: {}", processor_name));
+        }
+
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        if group.processor_names.contains(&processor_name.to_string()) {
+            return Err(format!(
+                "Processor '{}' is already in group '{}'",
+                processor_name, group_id
+            ));
+        }
+
+        group.processor_names.push(processor_name.to_string());
+        drop(groups);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Remove a processor from a process group.
+    pub fn remove_processor_from_group(
+        &self,
+        group_id: &str,
+        processor_name: &str,
+    ) -> Result<(), String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        let len_before = group.processor_names.len();
+        group.processor_names.retain(|n| n != processor_name);
+        if group.processor_names.len() == len_before {
+            return Err(format!(
+                "Processor '{}' is not in group '{}'",
+                processor_name, group_id
+            ));
+        }
+
+        drop(groups);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Add a connection to a process group by connection ID.
+    pub fn add_connection_to_group(
+        &self,
+        group_id: &str,
+        connection_id: &str,
+    ) -> Result<(), String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        if group.connection_ids.contains(&connection_id.to_string()) {
+            return Err(format!(
+                "Connection '{}' is already in group '{}'",
+                connection_id, group_id
+            ));
+        }
+
+        group.connection_ids.push(connection_id.to_string());
+        drop(groups);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Remove a connection from a process group.
+    pub fn remove_connection_from_group(
+        &self,
+        group_id: &str,
+        connection_id: &str,
+    ) -> Result<(), String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        let len_before = group.connection_ids.len();
+        group.connection_ids.retain(|c| c != connection_id);
+        if group.connection_ids.len() == len_before {
+            return Err(format!(
+                "Connection '{}' is not in group '{}'",
+                connection_id, group_id
+            ));
+        }
+
+        drop(groups);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Add an input port to a process group.
+    pub fn add_input_port(&self, group_id: &str, port_name: String) -> Result<String, String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        if group.input_ports.iter().any(|p| p.name == port_name) {
+            return Err(format!(
+                "Input port '{}' already exists in group '{}'",
+                port_name, group_id
+            ));
+        }
+
+        let port_id = format!("{}-in-{}", group_id, group.input_ports.len());
+        group.input_ports.push(PortInfo {
+            id: port_id.clone(),
+            name: port_name,
+            port_type: PortType::Input,
+            group_id: group_id.to_string(),
+        });
+
+        drop(groups);
+        self.notify_persist();
+        Ok(port_id)
+    }
+
+    /// Add an output port to a process group.
+    pub fn add_output_port(&self, group_id: &str, port_name: String) -> Result<String, String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        if group.output_ports.iter().any(|p| p.name == port_name) {
+            return Err(format!(
+                "Output port '{}' already exists in group '{}'",
+                port_name, group_id
+            ));
+        }
+
+        let port_id = format!("{}-out-{}", group_id, group.output_ports.len());
+        group.output_ports.push(PortInfo {
+            id: port_id.clone(),
+            name: port_name,
+            port_type: PortType::Output,
+            group_id: group_id.to_string(),
+        });
+
+        drop(groups);
+        self.notify_persist();
+        Ok(port_id)
+    }
+
+    /// Remove a port from a process group by port ID.
+    pub fn remove_port(&self, group_id: &str, port_id: &str) -> Result<(), String> {
+        let mut groups = self.process_groups.write();
+        let group = groups
+            .iter_mut()
+            .find(|g| g.id == group_id)
+            .ok_or_else(|| format!("Process group not found: {}", group_id))?;
+
+        let in_len = group.input_ports.len();
+        group.input_ports.retain(|p| p.id != port_id);
+        if group.input_ports.len() < in_len {
+            drop(groups);
+            self.notify_persist();
+            return Ok(());
+        }
+
+        let out_len = group.output_ports.len();
+        group.output_ports.retain(|p| p.id != port_id);
+        if group.output_ports.len() < out_len {
+            drop(groups);
+            self.notify_persist();
+            return Ok(());
+        }
+
+        Err(format!(
+            "Port '{}' not found in group '{}'",
+            port_id, group_id
+        ))
     }
 }

--- a/crates/runifi-core/src/engine/mod.rs
+++ b/crates/runifi-core/src/engine/mod.rs
@@ -5,5 +5,6 @@ pub mod metrics;
 pub mod mutation;
 pub mod mutation_handler;
 pub mod persistence;
+pub mod process_group;
 pub mod processor_node;
 pub mod supervisor;

--- a/crates/runifi-core/src/engine/persistence.rs
+++ b/crates/runifi-core/src/engine/persistence.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
 
 use super::handle::{ConnectionInfo, LabelInfo, Position, ProcessorInfo};
+use super::process_group::ProcessGroupInfo;
 
 /// File names for persisted flow state.
 const FLOW_STATE_FILE: &str = "flow.json";
@@ -42,6 +43,8 @@ pub struct PersistedFlowState {
     pub services: Vec<PersistedService>,
     #[serde(default)]
     pub labels: Vec<PersistedLabel>,
+    #[serde(default)]
+    pub process_groups: Vec<PersistedProcessGroup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,6 +122,36 @@ fn default_font_size() -> f64 {
     14.0
 }
 
+/// Persisted process group data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedProcessGroup {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub input_ports: Vec<PersistedPort>,
+    #[serde(default)]
+    pub output_ports: Vec<PersistedPort>,
+    #[serde(default)]
+    pub processor_names: Vec<String>,
+    #[serde(default)]
+    pub connection_ids: Vec<String>,
+    #[serde(default)]
+    pub child_group_ids: Vec<String>,
+    #[serde(default)]
+    pub parent_group_id: Option<String>,
+    #[serde(default)]
+    pub variables: HashMap<String, String>,
+}
+
+/// Persisted port data for a process group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedPort {
+    pub id: String,
+    pub name: String,
+    /// "input" or "output"
+    pub port_type: String,
+}
+
 // ── Snapshot source — breaks the Arc cycle ────────────────────────────────────
 
 /// The subset of engine state needed for persistence snapshotting.
@@ -133,6 +166,7 @@ pub(crate) struct SnapshotSource {
     pub positions: Arc<DashMap<String, Position>>,
     pub service_registry: crate::registry::service_registry::SharedServiceRegistry,
     pub labels: Arc<RwLock<Vec<LabelInfo>>>,
+    pub process_groups: Arc<RwLock<Vec<ProcessGroupInfo>>>,
 }
 
 // ── Snapshot from live engine state ───────────────────────────────────────────
@@ -209,6 +243,43 @@ impl PersistedFlowState {
             })
             .collect();
 
+        let process_groups: Vec<PersistedProcessGroup> = source
+            .process_groups
+            .read()
+            .iter()
+            .map(|g| {
+                let input_ports: Vec<PersistedPort> = g
+                    .input_ports
+                    .iter()
+                    .map(|p| PersistedPort {
+                        id: p.id.clone(),
+                        name: p.name.clone(),
+                        port_type: "input".to_string(),
+                    })
+                    .collect();
+                let output_ports: Vec<PersistedPort> = g
+                    .output_ports
+                    .iter()
+                    .map(|p| PersistedPort {
+                        id: p.id.clone(),
+                        name: p.name.clone(),
+                        port_type: "output".to_string(),
+                    })
+                    .collect();
+                PersistedProcessGroup {
+                    id: g.id.clone(),
+                    name: g.name.clone(),
+                    input_ports,
+                    output_ports,
+                    processor_names: g.processor_names.clone(),
+                    connection_ids: g.connection_ids.clone(),
+                    child_group_ids: g.child_group_ids.clone(),
+                    parent_group_id: g.parent_group_id.clone(),
+                    variables: g.variables.clone(),
+                }
+            })
+            .collect();
+
         Self {
             version: CURRENT_VERSION,
             flow_name: source.flow_name.clone(),
@@ -217,6 +288,7 @@ impl PersistedFlowState {
             positions,
             services,
             labels,
+            process_groups,
         }
     }
 }
@@ -361,6 +433,7 @@ impl FlowPersistence {
     ///
     /// This intentionally does **not** accept an `EngineHandle` to avoid
     /// creating a circular `Arc` reference.
+    #[allow(clippy::too_many_arguments)]
     pub fn set_source(
         &self,
         flow_name: String,
@@ -369,6 +442,7 @@ impl FlowPersistence {
         positions: Arc<DashMap<String, Position>>,
         service_registry: crate::registry::service_registry::SharedServiceRegistry,
         labels: Arc<RwLock<Vec<LabelInfo>>>,
+        process_groups: Arc<RwLock<Vec<ProcessGroupInfo>>>,
     ) {
         *self.inner.source.write() = Some(SnapshotSource {
             flow_name,
@@ -377,6 +451,7 @@ impl FlowPersistence {
             positions,
             service_registry,
             labels,
+            process_groups,
         });
     }
 
@@ -474,6 +549,7 @@ mod tests {
             positions: HashMap::new(),
             services: vec![],
             labels: vec![],
+            process_groups: vec![],
         }
     }
 
@@ -530,6 +606,7 @@ mod tests {
                 background_color: "#3b82f6".to_string(),
                 font_size: 14.0,
             }],
+            process_groups: vec![],
         };
 
         let json = serde_json::to_string_pretty(&state).unwrap();
@@ -580,6 +657,7 @@ mod tests {
             positions: HashMap::new(),
             services: vec![],
             labels: vec![],
+            process_groups: vec![],
         };
         atomic_write(&conf_dir, &state2).unwrap();
 
@@ -679,6 +757,7 @@ mod tests {
             positions: HashMap::new(),
             services: vec![],
             labels: vec![],
+            process_groups: vec![],
         };
 
         atomic_write(&conf_dir, &state).unwrap();
@@ -720,6 +799,7 @@ mod tests {
         let positions = Arc::new(DashMap::new());
         let service_registry = crate::registry::service_registry::SharedServiceRegistry::new();
         let labels = Arc::new(RwLock::new(Vec::new()));
+        let process_groups = Arc::new(RwLock::new(Vec::new()));
         persistence.set_source(
             "debounce-test".to_string(),
             processors,
@@ -727,6 +807,7 @@ mod tests {
             positions,
             service_registry,
             labels,
+            process_groups,
         );
 
         let cancel = tokio_util::sync::CancellationToken::new();

--- a/crates/runifi-core/src/engine/process_group.rs
+++ b/crates/runifi-core/src/engine/process_group.rs
@@ -1,0 +1,181 @@
+use std::collections::HashMap;
+
+/// Unique identifier for a process group.
+pub type ProcessGroupId = String;
+
+/// Information about a process group, visible to the API and engine handle.
+///
+/// Process Groups are hierarchical containers that organize processors,
+/// connections, input/output ports, and child process groups. They provide
+/// variable scoping (child groups inherit and can override parent variables)
+/// and serve as the boundary for flow versioning.
+#[derive(Debug, Clone)]
+pub struct ProcessGroupInfo {
+    /// Unique identifier for this process group.
+    pub id: ProcessGroupId,
+    /// Human-readable name.
+    pub name: String,
+    /// Input ports — receive FlowFiles from connections in the parent group.
+    pub input_ports: Vec<PortInfo>,
+    /// Output ports — send FlowFiles to connections in the parent group.
+    pub output_ports: Vec<PortInfo>,
+    /// Names of processors that belong to this group.
+    pub processor_names: Vec<String>,
+    /// IDs of connections that belong to this group.
+    pub connection_ids: Vec<String>,
+    /// IDs of child process groups.
+    pub child_group_ids: Vec<ProcessGroupId>,
+    /// ID of the parent process group, or `None` for top-level groups.
+    pub parent_group_id: Option<ProcessGroupId>,
+    /// Group-scoped variables. Child groups inherit parent variables
+    /// and can override them with their own values.
+    pub variables: HashMap<String, String>,
+}
+
+/// Information about an input or output port on a process group.
+///
+/// Ports are named connection endpoints that bridge the boundary between
+/// a process group and its parent. An input port receives FlowFiles from
+/// a connection in the parent group and makes them available to processors
+/// inside the group. An output port receives FlowFiles from processors
+/// inside the group and sends them to connections in the parent group.
+#[derive(Debug, Clone)]
+pub struct PortInfo {
+    /// Unique identifier for this port.
+    pub id: String,
+    /// Human-readable name for this port.
+    pub name: String,
+    /// The type of port (input or output).
+    pub port_type: PortType,
+    /// The process group this port belongs to.
+    pub group_id: ProcessGroupId,
+}
+
+/// The type of a port on a process group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortType {
+    /// Receives FlowFiles from the parent group.
+    Input,
+    /// Sends FlowFiles to the parent group.
+    Output,
+}
+
+impl ProcessGroupInfo {
+    /// Create a new process group with the given id and name.
+    pub fn new(id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            input_ports: Vec::new(),
+            output_ports: Vec::new(),
+            processor_names: Vec::new(),
+            connection_ids: Vec::new(),
+            child_group_ids: Vec::new(),
+            parent_group_id: None,
+            variables: HashMap::new(),
+        }
+    }
+
+    /// Resolve a variable by name, checking this group's variables first,
+    /// then walking up the parent chain. Returns `None` if not found.
+    pub fn resolve_variable<'a>(
+        &'a self,
+        name: &str,
+        all_groups: &'a [ProcessGroupInfo],
+    ) -> Option<&'a str> {
+        // Check own variables first.
+        if let Some(value) = self.variables.get(name) {
+            return Some(value.as_str());
+        }
+
+        // Walk up to parent.
+        if let Some(ref parent_id) = self.parent_group_id
+            && let Some(parent) = all_groups.iter().find(|g| g.id == *parent_id)
+        {
+            return parent.resolve_variable(name, all_groups);
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_process_group() {
+        let pg = ProcessGroupInfo::new("pg-1", "Test Group");
+        assert_eq!(pg.id, "pg-1");
+        assert_eq!(pg.name, "Test Group");
+        assert!(pg.input_ports.is_empty());
+        assert!(pg.output_ports.is_empty());
+        assert!(pg.processor_names.is_empty());
+        assert!(pg.connection_ids.is_empty());
+        assert!(pg.child_group_ids.is_empty());
+        assert!(pg.parent_group_id.is_none());
+        assert!(pg.variables.is_empty());
+    }
+
+    #[test]
+    fn test_variable_resolution_own_variable() {
+        let mut pg = ProcessGroupInfo::new("pg-1", "Group 1");
+        pg.variables.insert("key".to_string(), "value".to_string());
+
+        let groups = vec![pg.clone()];
+        assert_eq!(pg.resolve_variable("key", &groups), Some("value"));
+        assert_eq!(pg.resolve_variable("missing", &groups), None);
+    }
+
+    #[test]
+    fn test_variable_resolution_inherits_from_parent() {
+        let mut parent = ProcessGroupInfo::new("parent", "Parent");
+        parent
+            .variables
+            .insert("inherited".to_string(), "from-parent".to_string());
+        parent
+            .variables
+            .insert("overridden".to_string(), "parent-value".to_string());
+
+        let mut child = ProcessGroupInfo::new("child", "Child");
+        child.parent_group_id = Some("parent".to_string());
+        child
+            .variables
+            .insert("overridden".to_string(), "child-value".to_string());
+        child
+            .variables
+            .insert("own".to_string(), "child-only".to_string());
+
+        let groups = vec![parent, child.clone()];
+
+        // Child's own variable.
+        assert_eq!(child.resolve_variable("own", &groups), Some("child-only"));
+
+        // Inherited from parent.
+        assert_eq!(
+            child.resolve_variable("inherited", &groups),
+            Some("from-parent")
+        );
+
+        // Overridden by child.
+        assert_eq!(
+            child.resolve_variable("overridden", &groups),
+            Some("child-value")
+        );
+
+        // Not found anywhere.
+        assert_eq!(child.resolve_variable("missing", &groups), None);
+    }
+
+    #[test]
+    fn test_port_info() {
+        let port = PortInfo {
+            id: "port-1".to_string(),
+            name: "raw-data".to_string(),
+            port_type: PortType::Input,
+            group_id: "pg-1".to_string(),
+        };
+        assert_eq!(port.port_type, PortType::Input);
+        assert_eq!(port.name, "raw-data");
+    }
+}

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -18,7 +18,9 @@ use runifi_core::config::property_encryption::{
 use runifi_core::connection::back_pressure::BackPressureConfig;
 use runifi_core::engine::flow_engine::FlowEngine;
 use runifi_core::engine::handle::{PluginKind, PluginTypeInfo};
-use runifi_core::engine::persistence::{self, FlowPersistence, PersistedFlowState};
+use runifi_core::engine::persistence::{
+    self, FlowPersistence, PersistedFlowState, PersistedProcessGroup,
+};
 use runifi_core::engine::processor_node::SchedulingStrategy;
 use runifi_core::registry::plugin_registry::PluginRegistry;
 use runifi_core::repository::content_encrypted::EncryptedContentRepository;
@@ -385,13 +387,19 @@ async fn main() -> Result<()> {
                 runifi_core::engine::handle::reset_label_id_counter(max_label_id + 1);
             }
         }
+
+        // Restore process groups from persisted state.
+        restore_process_groups(handle, &state.process_groups);
     }
 
-    // On first startup (no runtime flow), trigger an initial persist so the
-    // seed config is saved as the runtime state.
+    // On first startup (no runtime flow), load process groups from seed config
+    // and trigger an initial persist so the seed config is saved as the runtime state.
     if runtime_flow.is_none()
         && let Some(handle) = engine.handle()
     {
+        if !config.flow.process_groups.is_empty() {
+            load_seed_process_groups(handle, &config.flow.process_groups, None);
+        }
         handle.notify_persist();
     }
 
@@ -855,6 +863,130 @@ fn load_from_seed_config(
     }
 
     Ok(())
+}
+
+/// Restore process groups from persisted state directly into the engine handle.
+///
+/// This bypasses the `create_process_group` API (which would generate new IDs
+/// and trigger audit events) and instead populates the handle's process_groups
+/// store directly — preserving original IDs from the persisted state.
+fn restore_process_groups(
+    handle: &runifi_core::engine::handle::EngineHandle,
+    persisted_groups: &[PersistedProcessGroup],
+) {
+    use runifi_core::engine::process_group::{PortInfo, PortType, ProcessGroupInfo};
+
+    if persisted_groups.is_empty() {
+        return;
+    }
+
+    let mut groups = handle.process_groups.write();
+    let mut max_group_id: u64 = 0;
+
+    for pg in persisted_groups {
+        // Extract numeric suffix from "pg-N" for counter reset.
+        if let Some(suffix) = pg.id.strip_prefix("pg-")
+            && let Ok(n) = suffix.parse::<u64>()
+        {
+            max_group_id = max_group_id.max(n);
+        }
+
+        let input_ports: Vec<PortInfo> = pg
+            .input_ports
+            .iter()
+            .map(|p| PortInfo {
+                id: p.id.clone(),
+                name: p.name.clone(),
+                port_type: PortType::Input,
+                group_id: pg.id.clone(),
+            })
+            .collect();
+
+        let output_ports: Vec<PortInfo> = pg
+            .output_ports
+            .iter()
+            .map(|p| PortInfo {
+                id: p.id.clone(),
+                name: p.name.clone(),
+                port_type: PortType::Output,
+                group_id: pg.id.clone(),
+            })
+            .collect();
+
+        groups.push(ProcessGroupInfo {
+            id: pg.id.clone(),
+            name: pg.name.clone(),
+            input_ports,
+            output_ports,
+            processor_names: pg.processor_names.clone(),
+            connection_ids: pg.connection_ids.clone(),
+            child_group_ids: pg.child_group_ids.clone(),
+            parent_group_id: pg.parent_group_id.clone(),
+            variables: pg.variables.clone(),
+        });
+    }
+
+    // Reset the group ID counter so new groups don't collide.
+    if max_group_id > 0 {
+        runifi_core::engine::handle::reset_group_id_counter(max_group_id + 1);
+    }
+
+    tracing::info!(
+        count = persisted_groups.len(),
+        "Restored process groups from persisted state"
+    );
+}
+
+/// Load process groups from the seed TOML configuration into the engine handle.
+///
+/// This is called when starting fresh (no persisted state) and creates the
+/// hierarchical process group structure defined in the config.
+fn load_seed_process_groups(
+    handle: &runifi_core::engine::handle::EngineHandle,
+    groups_config: &[runifi_core::config::flow_config::ProcessGroupConfig],
+    parent_id: Option<String>,
+) {
+    for pg_config in groups_config {
+        let input_ports = pg_config
+            .input_ports
+            .as_ref()
+            .map(|p| p.ports.clone())
+            .unwrap_or_default();
+
+        let output_ports = pg_config
+            .output_ports
+            .as_ref()
+            .map(|p| p.ports.clone())
+            .unwrap_or_default();
+
+        match handle.create_process_group(
+            pg_config.name.clone(),
+            parent_id.clone(),
+            input_ports,
+            output_ports,
+            pg_config.variables.clone(),
+        ) {
+            Ok(group_id) => {
+                tracing::info!(
+                    name = %pg_config.name,
+                    id = %group_id,
+                    "Created process group (from seed config)"
+                );
+
+                // Recursively create child process groups.
+                if !pg_config.process_groups.is_empty() {
+                    load_seed_process_groups(handle, &pg_config.process_groups, Some(group_id));
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    name = %pg_config.name,
+                    error = %e,
+                    "Failed to create process group from seed config"
+                );
+            }
+        }
+    }
 }
 
 async fn wait_for_shutdown() {


### PR DESCRIPTION
## Summary

Implements Process Groups as hierarchical containers for organizing processors, connections, and I/O ports within the flow engine. Closes #30.

### Core Engine
- `ProcessGroupInfo`, `PortInfo`, `PortType` types in new `engine/process_group.rs` module
- `ProcessGroupConfig` and `PortsConfig` for TOML configuration support (with recursive nesting)
- EngineHandle CRUD methods: create, get, list, update, remove groups
- Port management: add/remove input/output ports per group
- Processor and connection membership tracking
- Variable scoping with parent-chain resolution (child overrides parent)
- Module-level group ID counter with reset support for state restoration

### Persistence
- `PersistedProcessGroup` and `PersistedPort` types in flow state
- Snapshot serialization/deserialization for process groups and ports
- Restore process groups from persisted state on startup
- Load process groups from seed TOML config (recursive nesting)
- Group ID counter reset to prevent collisions after restore

### REST API
- `GET /api/v1/process-groups` — list all process groups
- `POST /api/v1/process-groups` — create a process group
- `GET /api/v1/process-groups/{id}` — get a specific group
- `PUT /api/v1/process-groups/{id}` — update name/variables
- `DELETE /api/v1/process-groups/{id}` — remove an empty group
- `PUT/DELETE /api/v1/process-groups/{id}/processors/{name}` — membership
- `PUT/DELETE /api/v1/process-groups/{id}/connections/{id}` — membership
- `POST /api/v1/process-groups/{id}/input-ports` — add input port
- `POST /api/v1/process-groups/{id}/output-ports` — add output port
- `DELETE /api/v1/process-groups/{id}/ports/{port_id}` — remove port
- `process_group_count` field in `GET /api/v1/flow` response
- RBAC: view routes require ViewFlow, mutation routes require ModifyFlow

### Audit
- `ProcessGroupCreated`, `ProcessGroupUpdated`, `ProcessGroupRemoved` audit actions
- `AuditTarget::process_group(id)` constructor

## Test plan
- [x] Unit tests for `ProcessGroupInfo::new()` and field defaults
- [x] Unit tests for variable resolution (own, inherited, overridden, missing)
- [x] Unit tests for `PortInfo` construction
- [x] TOML config deserialization tests (flat, nested, defaults)
- [x] Persistence round-trip tests (existing tests updated with `process_groups: vec![]`)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — all 608+ tests pass
- [x] `cargo fmt --all -- --check` passes