### PR TITLE
feat: dynamic connection anchor points with smart edge routing (#222)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/ConnectionEdge.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ConnectionEdge.tsx
@@ -27,13 +27,17 @@ function ConnectionEdgeInner({
   data,
   // onQueueClick is passed via edge data or through a custom mechanism
 }: ConnectionEdgeInnerProps) {
+  // Use dynamic positions from edge data if available, else fall back to React Flow defaults
+  const effectiveSourcePos = data?.smartSourcePosition ?? sourcePosition;
+  const effectiveTargetPos = data?.smartTargetPosition ?? targetPosition;
+
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
-    sourcePosition,
+    sourcePosition: effectiveSourcePos,
     targetX,
     targetY,
-    targetPosition,
+    targetPosition: effectiveTargetPos,
   });
 
   const queuedCount = data?.queuedCount ?? 0;

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -35,6 +35,7 @@ import { QueueInspectorModal } from './QueueInspectorModal';
 import { ColorPickerDialog } from './ColorPickerDialog';
 import { computeLayout } from '../utils/layout';
 import { stateColor } from '../utils/format';
+import { getSmartHandlePositions, sourceHandleId, targetHandleId } from '../utils/edgeRouting';
 import type { FlowResponse, SseMetricsEvent, PluginDescriptor } from '../types/api';
 import type { ProcessorNodeData, ConnectionEdgeData, LabelNodeData } from '../types/flow';
 import type { ToastKind } from '../hooks/useToast';
@@ -107,7 +108,10 @@ function buildEdges(
   topology: FlowResponse,
   metrics: SseMetricsEvent | null,
   onQueueClick: (connectionId: string, label: string) => void,
+  nodes: AnyNode[],
 ): ConnEdge[] {
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
   return topology.connections.map((conn, idx) => {
     const live =
       metrics?.connections.find(
@@ -119,12 +123,28 @@ function buildEdges(
 
     const backPressured = live?.back_pressured ?? false;
 
+    const srcNode = nodeMap.get(conn.source);
+    const tgtNode = nodeMap.get(conn.destination);
+
+    let sHandle = `${conn.relationship}--right`;
+    let tHandle = 'target--left';
+    let smartSourcePos: import('@xyflow/react').Position | undefined;
+    let smartTargetPos: import('@xyflow/react').Position | undefined;
+
+    if (srcNode && tgtNode) {
+      const positions = getSmartHandlePositions(srcNode, tgtNode);
+      sHandle = sourceHandleId(conn.relationship, positions.sourcePosition);
+      tHandle = targetHandleId(positions.targetPosition);
+      smartSourcePos = positions.sourcePosition;
+      smartTargetPos = positions.targetPosition;
+    }
+
     return {
       id: `${conn.source}--${conn.relationship}--${conn.destination}--${idx}`,
       source: conn.source,
       target: conn.destination,
-      sourceHandle: conn.relationship,
-      targetHandle: 'target',
+      sourceHandle: sHandle,
+      targetHandle: tHandle,
       type: 'connectionEdge' as const,
       data: {
         relationship: conn.relationship,
@@ -134,6 +154,8 @@ function buildEdges(
         connectionId: live?.id ?? '',
         pending: false,
         onQueueClick,
+        smartSourcePosition: smartSourcePos,
+        smartTargetPosition: smartTargetPos,
       },
       style: { stroke: backPressured ? 'var(--danger)' : 'var(--border)' },
     };
@@ -214,13 +236,17 @@ function FlowCanvasInner({
     [topology],
   );
   const initialEdges = useMemo(
-    () => buildEdges(topology, null, handleQueueClick),
+    () => buildEdges(topology, null, handleQueueClick, initialNodes),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [topology],
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState<AnyNode>(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState<ConnEdge>(initialEdges);
+
+  // Keep a ref to the latest nodes for edge routing calculations
+  const nodesRef = useRef(nodes);
+  useEffect(() => { nodesRef.current = nodes; }, [nodes]);
 
   const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
@@ -275,8 +301,9 @@ function FlowCanvasInner({
       connectable: false,
     }));
 
-    setNodes([...procNodes, ...labelNodes]);
-    setEdges(buildEdges(topology, liveMetrics, handleQueueClick));
+    const allNodes = [...procNodes, ...labelNodes];
+    setNodes(allNodes);
+    setEdges(buildEdges(topology, liveMetrics, handleQueueClick, allNodes));
   }, [topology, liveMetrics, setNodes, setEdges, plugins, handleQueueClick]);
 
   useEffect(() => {
@@ -344,6 +371,8 @@ function FlowCanvasInner({
             connectionId: live.id,
             pending: false,
             onQueueClick: handleQueueClick,
+            smartSourcePosition: edge.data?.smartSourcePosition,
+            smartTargetPosition: edge.data?.smartTargetPosition,
           },
           style: {
             stroke: live.back_pressured ? 'var(--danger)' : 'var(--border)',
@@ -382,16 +411,86 @@ function FlowCanvasInner({
     positionTimers.current.set(nodeId, timer);
   }, []);
 
+  /** Recalculate smart edge routing for all edges touching the given node ids */
+  const recalcEdgeRouting = useCallback(
+    (movedNodeIds: Set<string>) => {
+      const currentNodes = nodesRef.current;
+      const nodeMap = new Map(currentNodes.map((n) => [n.id, n]));
+
+      setEdges((prevEdges) => {
+        const needsUpdate = prevEdges.some(
+          (e) => movedNodeIds.has(e.source) || movedNodeIds.has(e.target),
+        );
+        if (!needsUpdate) return prevEdges;
+
+        return prevEdges.map((edge) => {
+          if (!movedNodeIds.has(edge.source) && !movedNodeIds.has(edge.target)) {
+            return edge;
+          }
+
+          const srcNode = nodeMap.get(edge.source);
+          const tgtNode = nodeMap.get(edge.target);
+          if (!srcNode || !tgtNode) return edge;
+
+          const positions = getSmartHandlePositions(srcNode, tgtNode);
+          const rel = edge.data?.relationship ?? 'success';
+          const newSourceHandle = sourceHandleId(rel, positions.sourcePosition);
+          const newTargetHandle = targetHandleId(positions.targetPosition);
+
+          if (
+            edge.sourceHandle === newSourceHandle &&
+            edge.targetHandle === newTargetHandle
+          ) {
+            return edge;
+          }
+
+          return {
+            ...edge,
+            sourceHandle: newSourceHandle,
+            targetHandle: newTargetHandle,
+            data: {
+              ...edge.data!,
+              smartSourcePosition: positions.sourcePosition,
+              smartTargetPosition: positions.targetPosition,
+            },
+          };
+        });
+      });
+    },
+    [setEdges],
+  );
+
   const handleNodesChange: typeof onNodesChange = useCallback(
     (changes) => {
+      const positionFinalized = new Set<string>();
       for (const change of changes) {
         if (change.type === 'position' && change.position && !change.dragging) {
           persistPosition(change.id, change.position.x, change.position.y);
+          positionFinalized.add(change.id);
         }
       }
       onNodesChange(changes);
+
+      // Recalculate edge routing for any nodes that stopped dragging
+      if (positionFinalized.size > 0) {
+        recalcEdgeRouting(positionFinalized);
+      }
     },
-    [onNodesChange, persistPosition],
+    [onNodesChange, persistPosition, recalcEdgeRouting],
+  );
+
+  /** Recalculate during drag for real-time feedback */
+  const handleNodeDrag: NodeMouseHandler<AnyNode> = useCallback(
+    (_event, node) => {
+      // During drag, React Flow has already updated the node position
+      // before this callback fires. Update the ref so recalcEdgeRouting
+      // reads the latest positions.
+      nodesRef.current = nodesRef.current.map((n) =>
+        n.id === node.id ? { ...n, position: node.position } : n,
+      );
+      recalcEdgeRouting(new Set([node.id]));
+    },
+    [recalcEdgeRouting],
   );
 
   useEffect(() => {
@@ -603,13 +702,30 @@ function FlowCanvasInner({
       const { sourceId, targetId } = pendingConnectionContext;
       setPendingConnectionContext(null);
 
+      // Compute smart handle positions
+      const srcNode = nodes.find((n) => n.id === sourceId);
+      const tgtNode = nodes.find((n) => n.id === targetId);
+
+      let sHandle = `${relationship}--right`;
+      let tHandle = 'target--left';
+      let smartSrcPos: import('@xyflow/react').Position | undefined;
+      let smartTgtPos: import('@xyflow/react').Position | undefined;
+
+      if (srcNode && tgtNode) {
+        const positions = getSmartHandlePositions(srcNode, tgtNode);
+        sHandle = sourceHandleId(relationship, positions.sourcePosition);
+        tHandle = targetHandleId(positions.targetPosition);
+        smartSrcPos = positions.sourcePosition;
+        smartTgtPos = positions.targetPosition;
+      }
+
       const edgeId = `${sourceId}--${relationship}--${targetId}--${Date.now()}`;
       const newEdge: ConnEdge = {
         id: edgeId,
         source: sourceId,
         target: targetId,
-        sourceHandle: relationship,
-        targetHandle: 'target',
+        sourceHandle: sHandle,
+        targetHandle: tHandle,
         type: 'connectionEdge' as const,
         data: {
           relationship,
@@ -619,6 +735,8 @@ function FlowCanvasInner({
           connectionId: '',
           pending: true,
           onQueueClick: handleQueueClick,
+          smartSourcePosition: smartSrcPos,
+          smartTargetPosition: smartTgtPos,
         },
         style: { stroke: 'var(--border)' },
       };
@@ -652,7 +770,7 @@ function FlowCanvasInner({
           );
         });
     },
-    [pendingConnectionContext, setEdges, onToast, handleQueueClick],
+    [pendingConnectionContext, setEdges, onToast, handleQueueClick, nodes],
   );
 
   const initiateDelete = useCallback(
@@ -1032,6 +1150,7 @@ function FlowCanvasInner({
         onNodesChange={handleNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={handleConnect}
+        onNodeDrag={handleNodeDrag}
         onNodeContextMenu={handleNodeContextMenu}
         onEdgeContextMenu={handleEdgeContextMenu}
         onPaneContextMenu={handleCanvasContextMenu}

--- a/crates/runifi-api/dashboard-react/src/components/FunnelNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FunnelNode.tsx
@@ -10,6 +10,9 @@ import type { ProcessorNodeData } from '../types/flow';
  */
 export type FunnelNodeType = Node<ProcessorNodeData, 'funnelNode'>;
 
+/** All four sides for multi-directional handles */
+const ALL_POSITIONS = [Position.Top, Position.Right, Position.Bottom, Position.Left] as const;
+
 function FunnelNodeInner({ data }: NodeProps<FunnelNodeType>) {
   const { label, state, pending } = data;
 
@@ -21,12 +24,16 @@ function FunnelNodeInner({ data }: NodeProps<FunnelNodeType>) {
       role="article"
       aria-label={`Funnel ${label}${pending ? ' (pending)' : ''}`}
     >
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="target"
-        className="funnel-handle-target"
-      />
+      {/* Target handles on all 4 sides */}
+      {ALL_POSITIONS.map((pos) => (
+        <Handle
+          key={`target--${pos}`}
+          type="target"
+          position={pos}
+          id={`target--${pos}`}
+          className="funnel-handle-target edge-anchor-handle"
+        />
+      ))}
 
       {/* NiFi-style center connection handle */}
       <Handle
@@ -53,14 +60,16 @@ function FunnelNodeInner({ data }: NodeProps<FunnelNodeType>) {
 
       <span className="funnel-label" title={label}>{label}</span>
 
-      {/* Hidden per-relationship handle for edge anchoring */}
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="success"
-        className="edge-anchor-handle"
-        style={{ bottom: 0 }}
-      />
+      {/* Per-relationship source handles on all 4 sides */}
+      {ALL_POSITIONS.map((pos) => (
+        <Handle
+          key={`success--${pos}`}
+          type="source"
+          position={pos}
+          id={`success--${pos}`}
+          className="edge-anchor-handle"
+        />
+      ))}
     </div>
   );
 }

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorNode.tsx
@@ -29,6 +29,9 @@ function handleTopPercent(index: number, total: number): string {
   return `${step * (index + 1)}%`;
 }
 
+/** All four sides for multi-directional handles */
+const ALL_POSITIONS = [Position.Top, Position.Right, Position.Bottom, Position.Left] as const;
+
 function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
   const { label, typeName, state, metrics, bulletin, relationships, pending, customColor } = data;
   const borderColor: string = pending
@@ -47,12 +50,16 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
       role="article"
       aria-label={`Processor ${label}${pending ? ' (pending)' : ''}`}
     >
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="target"
-        style={{ top: '50%' }}
-      />
+      {/* Target handles on all 4 sides */}
+      {ALL_POSITIONS.map((pos) => (
+        <Handle
+          key={`target--${pos}`}
+          type="target"
+          position={pos}
+          id={`target--${pos}`}
+          className="edge-anchor-handle"
+        />
+      ))}
 
       {/* NiFi-style center connection handle — visible on hover */}
       <Handle
@@ -125,17 +132,22 @@ function ProcessorNodeInner({ data }: NodeProps<ProcessorNodeType>) {
         </div>
       )}
 
-      {/* Hidden per-relationship handles for edge anchoring */}
-      {rels.map((rel, idx) => (
-        <Handle
-          key={rel}
-          type="source"
-          position={Position.Right}
-          id={rel}
-          className="edge-anchor-handle"
-          style={{ top: handleTopPercent(idx, rels.length) }}
-        />
-      ))}
+      {/* Per-relationship source handles on all 4 sides */}
+      {rels.map((rel, idx) =>
+        ALL_POSITIONS.map((pos) => (
+          <Handle
+            key={`${rel}--${pos}`}
+            type="source"
+            position={pos}
+            id={`${rel}--${pos}`}
+            className="edge-anchor-handle"
+            style={pos === Position.Right || pos === Position.Left
+              ? { top: handleTopPercent(idx, rels.length) }
+              : undefined
+            }
+          />
+        ))
+      )}
     </div>
   );
 }

--- a/crates/runifi-api/dashboard-react/src/types/flow.ts
+++ b/crates/runifi-api/dashboard-react/src/types/flow.ts
@@ -1,6 +1,7 @@
 // React Flow node and edge data types
 // Note: @xyflow/react requires data types to satisfy Record<string, unknown>
 
+import type { Position } from '@xyflow/react';
 import type { MetricsResponse, BulletinResponse } from './api';
 
 export interface ProcessorNodeData extends Record<string, unknown> {
@@ -37,4 +38,7 @@ export interface ConnectionEdgeData extends Record<string, unknown> {
   pending: boolean;
   // Optional callback injected from FlowCanvas to open the queue inspector
   onQueueClick?: (connectionId: string, label: string) => void;
+  // Smart routing: dynamic handle positions based on node geometry
+  smartSourcePosition?: Position;
+  smartTargetPosition?: Position;
 }

--- a/crates/runifi-api/dashboard-react/src/utils/edgeRouting.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/edgeRouting.ts
@@ -1,0 +1,115 @@
+import { Position, type Node } from '@xyflow/react';
+
+/**
+ * Determines the optimal source and target handle positions for a connection
+ * based on the relative geometry of the two nodes. This produces NiFi-style
+ * smart edge routing where connections use the closest anchor points.
+ */
+
+// Approximate node dimensions for center calculation
+const DEFAULT_NODE_WIDTH = 220;
+const DEFAULT_NODE_HEIGHT = 120;
+const FUNNEL_NODE_SIZE = 80;
+
+interface NodeCenter {
+  x: number;
+  y: number;
+}
+
+function getNodeCenter(node: Node): NodeCenter {
+  const isFunnel = node.type === 'funnelNode';
+  const w = (node.measured?.width ?? node.width) ?? (isFunnel ? FUNNEL_NODE_SIZE : DEFAULT_NODE_WIDTH);
+  const h = (node.measured?.height ?? node.height) ?? (isFunnel ? FUNNEL_NODE_SIZE : DEFAULT_NODE_HEIGHT);
+  return {
+    x: node.position.x + w / 2,
+    y: node.position.y + h / 2,
+  };
+}
+
+export interface HandlePositions {
+  sourcePosition: Position;
+  targetPosition: Position;
+  sourceHandleSuffix: string;
+  targetHandleSuffix: string;
+}
+
+/**
+ * Given source and target nodes, compute the best handle positions.
+ *
+ * The algorithm picks the pair of sides that minimises the visual distance
+ * between source output and target input.  It considers the dominant axis
+ * (horizontal vs vertical offset) and the direction along that axis.
+ */
+export function getSmartHandlePositions(
+  sourceNode: Node,
+  targetNode: Node,
+): HandlePositions {
+  const src = getNodeCenter(sourceNode);
+  const tgt = getNodeCenter(targetNode);
+
+  const dx = tgt.x - src.x;
+  const dy = tgt.y - src.y;
+
+  let sourcePosition: Position;
+  let targetPosition: Position;
+
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    // Horizontal dominant
+    if (dx >= 0) {
+      // target is to the right → source right, target left
+      sourcePosition = Position.Right;
+      targetPosition = Position.Left;
+    } else {
+      // target is to the left → source left, target right
+      sourcePosition = Position.Left;
+      targetPosition = Position.Right;
+    }
+  } else {
+    // Vertical dominant
+    if (dy >= 0) {
+      // target is below → source bottom, target top
+      sourcePosition = Position.Bottom;
+      targetPosition = Position.Top;
+    } else {
+      // target is above → source top, target bottom
+      sourcePosition = Position.Top;
+      targetPosition = Position.Bottom;
+    }
+  }
+
+  return {
+    sourcePosition,
+    targetPosition,
+    sourceHandleSuffix: positionToSuffix(sourcePosition),
+    targetHandleSuffix: positionToSuffix(targetPosition),
+  };
+}
+
+function positionToSuffix(pos: Position): string {
+  switch (pos) {
+    case Position.Top:
+      return 'top';
+    case Position.Right:
+      return 'right';
+    case Position.Bottom:
+      return 'bottom';
+    case Position.Left:
+      return 'left';
+  }
+}
+
+/**
+ * Build the source handle id for a given relationship and position.
+ * Format: "{relationship}--{side}" e.g. "success--right", "success--bottom"
+ */
+export function sourceHandleId(relationship: string, pos: Position): string {
+  return `${relationship}--${positionToSuffix(pos)}`;
+}
+
+/**
+ * Build the target handle id for a given position.
+ * Format: "target--{side}" e.g. "target--left", "target--top"
+ */
+export function targetHandleId(pos: Position): string {
+  return `target--${positionToSuffix(pos)}`;
+}


### PR DESCRIPTION
## Summary
- Add NiFi-style smart edge routing that automatically selects optimal connection anchor points based on relative node positions
- Connections now dynamically choose the closest side (top/right/bottom/left) instead of being locked to fixed right→left routing
- Edge routing recalculates in real-time during node drag for smooth visual feedback

## Changes
- **`edgeRouting.ts`** (new): Geometry-based utility that computes optimal source/target handle positions by comparing node centers on the dominant axis (horizontal vs vertical)
- **`ProcessorNode.tsx`**: Add invisible handles on all 4 sides for both targets (`target--top/right/bottom/left`) and sources (per-relationship: `{rel}--top/right/bottom/left`)
- **`FunnelNode.tsx`**: Same multi-side handle treatment for funnel nodes
- **`ConnectionEdge.tsx`**: Read `smartSourcePosition`/`smartTargetPosition` from edge data to dynamically set `getBezierPath()` positions
- **`FlowCanvas.tsx`**: Wire smart routing into `buildEdges()`, `handleConfirmConnection()`, `onNodeDrag`, and position finalization. Preserve smart routing data through live metrics updates
- **`flow.ts`**: Add `smartSourcePosition`/`smartTargetPosition` optional fields to `ConnectionEdgeData`

## Test plan
- [ ] Add 2+ processors to canvas, connect them — edge should route right→left (horizontal layout)
- [ ] Move target processor above source — edge should re-route bottom→top
- [ ] Move target processor below source — edge should re-route top→bottom
- [ ] Move target to left of source — edge should re-route left→right
- [ ] Drag node continuously — edge routing updates in real-time
- [ ] Verify funnel nodes also get smart routing
- [ ] Verify queue badge, queue click, back-pressure styling still work
- [ ] Verify center-source drag handle still appears on hover

Closes #222