### PR TITLE
fix: persist processor positions across page refresh (#226)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -47,6 +47,7 @@ export interface ConnectionResponse {
 export interface FlowNodeResponse {
   name: string;
   type_name: string;
+  position?: { x: number; y: number };
 }
 
 export interface FlowEdgeResponse {

--- a/crates/runifi-api/dashboard-react/src/utils/layout.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/layout.ts
@@ -91,7 +91,7 @@ export function computeLayout(
   return processors.map((p): LayoutNode => ({
     id: p.name,
     type: p.type_name === 'Funnel' ? 'funnelNode' : 'processorNode',
-    position: positions.get(p.name) ?? { x: PADDING_X, y: PADDING_Y },
+    position: p.position ?? positions.get(p.name) ?? { x: PADDING_X, y: PADDING_Y },
     data: {
       label: p.name,
       typeName: p.type_name,


### PR DESCRIPTION
## Summary
- Add `position` field to `FlowNodeResponse` TypeScript interface to match the backend DTO
- Use saved positions from API in `computeLayout()`, falling back to auto-layout for new processors

## Root Cause
The backend already persists and returns processor positions via `GET /api/v1/flow` (as `position: Option<PositionResponse>`), and the frontend already saves positions on drag end via `PUT /api/v1/processors/{name}/position`. However, the `FlowNodeResponse` TypeScript type was missing the `position` field, so the API data was silently discarded. The `computeLayout()` function always computed fresh positions using topological sort.

## Changes
| File | Change |
|---|---|
| `dashboard-react/src/types/api.ts` | Add `position?: { x: number; y: number }` to `FlowNodeResponse` |
| `dashboard-react/src/utils/layout.ts` | Prefer `p.position` (from API) over auto-computed position |

## Test Plan
- [ ] Start server, add processors to canvas
- [ ] Drag processors to custom positions
- [ ] Refresh browser — processors should remain in their saved positions
- [ ] Add a new processor — should auto-layout since no saved position exists
- [ ] Verify existing flows with no saved positions still auto-layout correctly

Closes #226