### PR TITLE
feat: implement load-balanced connections (#236)

### DIFF
--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -95,6 +95,16 @@ pub struct ConnectionResponse {
     pub queued_count: usize,
     pub queued_bytes: u64,
     pub back_pressured: bool,
+    /// Load balance strategy in effect for this connection.
+    /// Omitted from JSON when `None` (no load balancing).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_balance_strategy: Option<String>,
+    /// Partition attribute for `partition_by_attribute` strategy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_balance_partition_attribute: Option<String>,
+    /// Whether compression is enabled for cross-node transfer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_balance_compression: Option<bool>,
 }
 
 // ── Canvas position ────────────────────────────────────────────────────
@@ -410,6 +420,16 @@ pub struct CreateConnectionRequest {
     pub max_queue_size: Option<usize>,
     /// Maximum bytes in queue before back-pressure (default: 100 MB).
     pub max_queue_bytes: Option<u64>,
+    /// Load balance strategy: "do_not_load_balance" (default), "round_robin",
+    /// "partition_by_attribute", or "single_node".
+    #[serde(default)]
+    pub load_balance_strategy: Option<String>,
+    /// Attribute name for `partition_by_attribute` strategy.
+    #[serde(default)]
+    pub load_balance_partition_attribute: Option<String>,
+    /// Whether to compress FlowFile content during inter-node transfer.
+    #[serde(default)]
+    pub load_balance_compression: Option<bool>,
 }
 
 /// Response for a created or retrieved connection.
@@ -422,6 +442,15 @@ pub struct ConnectionDetailResponse {
     pub queued_count: usize,
     pub queued_bytes: u64,
     pub back_pressured: bool,
+    /// Load balance strategy in effect for this connection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_balance_strategy: Option<String>,
+    /// Partition attribute for `partition_by_attribute` strategy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_balance_partition_attribute: Option<String>,
+    /// Whether compression is enabled for cross-node transfer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_balance_compression: Option<bool>,
 }
 
 // ── Controller service DTOs ────────────────────────────────────────────

--- a/crates/runifi-api/src/routes/connections.rs
+++ b/crates/runifi-api/src/routes/connections.rs
@@ -8,7 +8,9 @@ use axum::{Json, Router, middleware};
 use serde::Deserialize;
 
 use runifi_core::audit::{AuditAction, AuditEvent, AuditTarget};
+use runifi_core::cluster::load_balance::{LoadBalanceConfig, LoadBalanceStrategy};
 use runifi_core::connection::back_pressure::BackPressureConfig;
+use runifi_core::engine::handle::ConnectionInfo;
 
 use crate::dto::{
     ConnectionDetailResponse, ConnectionResponse, CreateConnectionRequest,
@@ -17,6 +19,29 @@ use crate::dto::{
 use crate::error::ApiError;
 use crate::rbac;
 use crate::state::ApiState;
+
+/// Extract load balance display fields from a connection info.
+fn load_balance_fields(info: &ConnectionInfo) -> (Option<String>, Option<String>, Option<bool>) {
+    match info.connection.load_balance_config() {
+        Some(config) => {
+            let strategy_str = match &config.strategy {
+                LoadBalanceStrategy::DoNotLoadBalance => None,
+                LoadBalanceStrategy::RoundRobin => Some("round_robin".to_string()),
+                LoadBalanceStrategy::PartitionByAttribute { attribute } => {
+                    return (
+                        Some("partition_by_attribute".to_string()),
+                        Some(attribute.clone()),
+                        Some(config.compression),
+                    );
+                }
+                LoadBalanceStrategy::SingleNode { .. } => Some("single_node".to_string()),
+            };
+            let compression = if config.compression { Some(true) } else { None };
+            (strategy_str, None, compression)
+        }
+        None => (None, None, None),
+    }
+}
 
 pub fn routes() -> Router<ApiState> {
     // GET endpoints — ViewFlow (Viewer+)
@@ -67,14 +92,20 @@ async fn list_connections(State(state): State<ApiState>) -> Json<Vec<ConnectionR
         .connections
         .read()
         .iter()
-        .map(|info| ConnectionResponse {
-            id: info.id.clone(),
-            source_name: info.source_name.clone(),
-            relationship: info.relationship.clone(),
-            dest_name: info.dest_name.clone(),
-            queued_count: info.connection.queue_count(),
-            queued_bytes: info.connection.queue_size_bytes(),
-            back_pressured: info.connection.is_back_pressured(),
+        .map(|info| {
+            let (lb_strategy, lb_partition_attr, lb_compression) = load_balance_fields(info);
+            ConnectionResponse {
+                id: info.id.clone(),
+                source_name: info.source_name.clone(),
+                relationship: info.relationship.clone(),
+                dest_name: info.dest_name.clone(),
+                queued_count: info.connection.queue_count(),
+                queued_bytes: info.connection.queue_size_bytes(),
+                back_pressured: info.connection.is_back_pressured(),
+                load_balance_strategy: lb_strategy,
+                load_balance_partition_attribute: lb_partition_attr,
+                load_balance_compression: lb_compression,
+            }
         })
         .collect();
     Json(connections)
@@ -92,6 +123,25 @@ async fn create_connection(
             .unwrap_or(BackPressureConfig::DEFAULT_MAX_BYTES),
     );
 
+    // Parse optional load balance configuration from the request.
+    let lb_config = body.load_balance_strategy.as_deref().and_then(|strategy| {
+        let lb_strategy = match strategy {
+            "round_robin" => LoadBalanceStrategy::RoundRobin,
+            "partition_by_attribute" => LoadBalanceStrategy::PartitionByAttribute {
+                attribute: body
+                    .load_balance_partition_attribute
+                    .clone()
+                    .unwrap_or_default(),
+            },
+            "single_node" => LoadBalanceStrategy::SingleNode { target_node: None },
+            _ => return None, // "do_not_load_balance" or unknown — no config needed
+        };
+        Some(LoadBalanceConfig {
+            strategy: lb_strategy,
+            compression: body.load_balance_compression.unwrap_or(false),
+        })
+    });
+
     let conn_id = state
         .handle
         .add_connection(
@@ -99,6 +149,7 @@ async fn create_connection(
             body.relationship.clone(),
             body.destination.clone(),
             bp_config,
+            lb_config,
         )
         .await
         .map_err(ApiError::from)?;
@@ -106,10 +157,9 @@ async fn create_connection(
     // Build response from the newly registered connection info.
     let conn_detail = {
         let conns = state.handle.connections.read();
-        conns
-            .iter()
-            .find(|c| c.id == conn_id)
-            .map(|info| ConnectionDetailResponse {
+        conns.iter().find(|c| c.id == conn_id).map(|info| {
+            let (lb_strategy, lb_partition_attr, lb_compression) = load_balance_fields(info);
+            ConnectionDetailResponse {
                 id: info.id.clone(),
                 source_name: info.source_name.clone(),
                 relationship: info.relationship.clone(),
@@ -117,7 +167,11 @@ async fn create_connection(
                 queued_count: info.connection.queue_count(),
                 queued_bytes: info.connection.queue_size_bytes(),
                 back_pressured: info.connection.is_back_pressured(),
-            })
+                load_balance_strategy: lb_strategy,
+                load_balance_partition_attribute: lb_partition_attr,
+                load_balance_compression: lb_compression,
+            }
+        })
     };
 
     match conn_detail {

--- a/crates/runifi-api/src/routes/events.rs
+++ b/crates/runifi-api/src/routes/events.rs
@@ -54,14 +54,53 @@ async fn sse_events(
             .connections
             .read()
             .iter()
-            .map(|info| ConnectionResponse {
-                id: info.id.clone(),
-                source_name: info.source_name.clone(),
-                relationship: info.relationship.clone(),
-                dest_name: info.dest_name.clone(),
-                queued_count: info.connection.queue_count(),
-                queued_bytes: info.connection.queue_size_bytes(),
-                back_pressured: info.connection.is_back_pressured(),
+            .map(|info| {
+                // Extract load balance display fields.
+                let (lb_strategy, lb_partition_attr, lb_compression) = {
+                    match info.connection.load_balance_config() {
+                        Some(config) => {
+                            use runifi_core::cluster::load_balance::LoadBalanceStrategy;
+                            let strategy_str = match &config.strategy {
+                                LoadBalanceStrategy::DoNotLoadBalance => None,
+                                LoadBalanceStrategy::RoundRobin => Some("round_robin".to_string()),
+                                LoadBalanceStrategy::PartitionByAttribute { attribute } => {
+                                    return ConnectionResponse {
+                                        id: info.id.clone(),
+                                        source_name: info.source_name.clone(),
+                                        relationship: info.relationship.clone(),
+                                        dest_name: info.dest_name.clone(),
+                                        queued_count: info.connection.queue_count(),
+                                        queued_bytes: info.connection.queue_size_bytes(),
+                                        back_pressured: info.connection.is_back_pressured(),
+                                        load_balance_strategy: Some(
+                                            "partition_by_attribute".to_string(),
+                                        ),
+                                        load_balance_partition_attribute: Some(attribute.clone()),
+                                        load_balance_compression: Some(config.compression),
+                                    };
+                                }
+                                LoadBalanceStrategy::SingleNode { .. } => {
+                                    Some("single_node".to_string())
+                                }
+                            };
+                            let compression = if config.compression { Some(true) } else { None };
+                            (strategy_str, None, compression)
+                        }
+                        None => (None, None, None),
+                    }
+                };
+                ConnectionResponse {
+                    id: info.id.clone(),
+                    source_name: info.source_name.clone(),
+                    relationship: info.relationship.clone(),
+                    dest_name: info.dest_name.clone(),
+                    queued_count: info.connection.queue_count(),
+                    queued_bytes: info.connection.queue_size_bytes(),
+                    back_pressured: info.connection.is_back_pressured(),
+                    load_balance_strategy: lb_strategy,
+                    load_balance_partition_attribute: lb_partition_attr,
+                    load_balance_compression: lb_compression,
+                }
             })
             .collect();
 

--- a/crates/runifi-core/src/connection/flow_connection.rs
+++ b/crates/runifi-core/src/connection/flow_connection.rs
@@ -10,6 +10,7 @@ use tokio::sync::Notify;
 use tracing::warn;
 
 use super::back_pressure::BackPressureConfig;
+use crate::cluster::load_balance::LoadBalanceConfig;
 
 /// Lightweight snapshot of a FlowFile for queue inspection.
 ///
@@ -74,6 +75,10 @@ pub struct FlowConnection {
     expiration: Option<Duration>,
     /// Queue priority strategy.
     priority: QueuePriority,
+    /// Load balance configuration for distributing FlowFiles across
+    /// multiple connections on the same relationship. `None` means
+    /// no load balancing (default behavior).
+    load_balance: Option<LoadBalanceConfig>,
 }
 
 impl FlowConnection {
@@ -90,6 +95,7 @@ impl FlowConnection {
             shadow: Mutex::new(VecDeque::new()),
             expiration: None,
             priority: QueuePriority::Fifo,
+            load_balance: None,
         }
     }
 
@@ -112,6 +118,29 @@ impl FlowConnection {
             shadow: Mutex::new(VecDeque::new()),
             expiration,
             priority,
+            load_balance: None,
+        }
+    }
+
+    /// Create a new connection with load balance configuration.
+    pub fn with_load_balance(
+        id: impl Into<String>,
+        config: BackPressureConfig,
+        load_balance: LoadBalanceConfig,
+    ) -> Self {
+        let (sender, receiver) = channel::bounded(config.max_count);
+        Self {
+            id: id.into(),
+            sender,
+            receiver,
+            config,
+            count: AtomicUsize::new(0),
+            bytes: AtomicU64::new(0),
+            notify: Arc::new(Notify::new()),
+            shadow: Mutex::new(VecDeque::new()),
+            expiration: None,
+            priority: QueuePriority::Fifo,
+            load_balance: Some(load_balance),
         }
     }
 
@@ -305,6 +334,11 @@ impl FlowConnection {
     /// Get the queue priority strategy.
     pub fn queue_priority(&self) -> &QueuePriority {
         &self.priority
+    }
+
+    /// Get the load balance configuration, if any.
+    pub fn load_balance_config(&self) -> Option<&LoadBalanceConfig> {
+        self.load_balance.as_ref()
     }
 
     // ── Expiration ────────────────────────────────────────────────

--- a/crates/runifi-core/src/connection/query.rs
+++ b/crates/runifi-core/src/connection/query.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::back_pressure::BackPressureConfig;
 use super::flow_connection::{FlowConnection, FlowFileSnapshot};
+use crate::cluster::load_balance::LoadBalanceConfig;
 
 /// Trait for querying metadata and state of a connection between processors.
 ///
@@ -41,6 +42,11 @@ pub trait ConnectionQuery: Send + Sync {
     fn remove_flowfile(&self, flowfile_id: u64) -> bool;
     /// Clear all FlowFiles from the queue. Returns the number removed.
     fn clear_queue(&self) -> usize;
+
+    /// Return the load balance configuration for this connection, if any.
+    fn load_balance_config(&self) -> Option<&LoadBalanceConfig> {
+        None
+    }
 
     /// Access the underlying FlowConnection (for persistence of expiration/priority).
     /// Returns `None` if the implementation does not use a FlowConnection.
@@ -129,6 +135,10 @@ impl ConnectionQuery for FlowConnectionQuery {
 
     fn clear_queue(&self) -> usize {
         self.connection.clear_queue()
+    }
+
+    fn load_balance_config(&self) -> Option<&LoadBalanceConfig> {
+        self.connection.load_balance_config()
     }
 
     fn flow_connection(&self) -> Option<&FlowConnection> {

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -90,6 +90,7 @@ struct ConnBuilder {
     config: BackPressureConfig,
     expiration: Option<Duration>,
     priority: QueuePriority,
+    load_balance: Option<crate::cluster::load_balance::LoadBalanceConfig>,
 }
 
 impl FlowEngine {
@@ -211,6 +212,34 @@ impl FlowEngine {
             config,
             expiration,
             priority,
+            load_balance: None,
+        });
+        id
+    }
+
+    /// Connect two processors with load balance configuration.
+    #[allow(clippy::too_many_arguments)]
+    pub fn connect_with_load_balance(
+        &mut self,
+        source_id: NodeId,
+        relationship: &'static str,
+        dest_id: NodeId,
+        config: BackPressureConfig,
+        expiration: Option<Duration>,
+        priority: QueuePriority,
+        load_balance: Option<crate::cluster::load_balance::LoadBalanceConfig>,
+    ) -> ConnId {
+        let id = self.next_conn_id;
+        self.next_conn_id += 1;
+        self.connections.push(ConnBuilder {
+            _id: id,
+            source_node: source_id,
+            relationship,
+            dest_node: dest_id,
+            config,
+            expiration,
+            priority,
+            load_balance,
         });
         id
     }
@@ -240,12 +269,20 @@ impl FlowEngine {
         let mut flow_connections: Vec<(usize, &'static str, usize, Arc<FlowConnection>)> =
             Vec::new();
         for (idx, conn) in self.connections.iter().enumerate() {
-            let fc = Arc::new(FlowConnection::with_options(
-                format!("conn-{}", idx),
-                conn.config,
-                conn.expiration,
-                conn.priority.clone(),
-            ));
+            let fc = if let Some(ref lb_config) = conn.load_balance {
+                Arc::new(FlowConnection::with_load_balance(
+                    format!("conn-{}", idx),
+                    conn.config,
+                    lb_config.clone(),
+                ))
+            } else {
+                Arc::new(FlowConnection::with_options(
+                    format!("conn-{}", idx),
+                    conn.config,
+                    conn.expiration,
+                    conn.priority.clone(),
+                ))
+            };
             flow_connections.push((conn.source_node, conn.relationship, conn.dest_node, fc));
         }
 
@@ -812,12 +849,12 @@ async fn run_mutation_handler(
                     }
 
                     MutationCommand::AddConnection {
-                        source_name, relationship, dest_name, config, reply,
+                        source_name, relationship, dest_name, config, load_balance, reply,
                     } => {
                         handler.runtime_conn_id += 1;
                         let conn_id = format!("runtime-conn-{}", handler.runtime_conn_id);
                         let result = handler.handle_add_connection(
-                            conn_id, &source_name, &relationship, &dest_name, config,
+                            conn_id, &source_name, &relationship, &dest_name, config, load_balance,
                         );
                         let _ = reply.send(result);
                     }

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -517,6 +517,7 @@ impl EngineHandle {
         relationship: String,
         dest_name: String,
         config: BackPressureConfig,
+        load_balance: Option<crate::cluster::load_balance::LoadBalanceConfig>,
     ) -> Result<String, MutationError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.mutation_tx
@@ -525,6 +526,7 @@ impl EngineHandle {
                 relationship,
                 dest_name,
                 config,
+                load_balance,
                 reply: reply_tx,
             })
             .await
@@ -801,6 +803,7 @@ impl EngineHandle {
                     expiration,
                     priority,
                     priority_attribute,
+                    load_balancing: c.connection.load_balance_config().cloned(),
                 }
             })
             .collect();

--- a/crates/runifi-core/src/engine/mutation.rs
+++ b/crates/runifi-core/src/engine/mutation.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use tokio::sync::oneshot;
 
+use crate::cluster::load_balance::LoadBalanceConfig;
 use crate::connection::back_pressure::BackPressureConfig;
 
 /// A runtime mutation command sent to the engine via the command channel.
@@ -34,6 +35,7 @@ pub enum MutationCommand {
         relationship: String,
         dest_name: String,
         config: BackPressureConfig,
+        load_balance: Option<LoadBalanceConfig>,
         reply: oneshot::Sender<Result<String, MutationError>>,
     },
 

--- a/crates/runifi-core/src/engine/mutation_handler.rs
+++ b/crates/runifi-core/src/engine/mutation_handler.rs
@@ -13,6 +13,7 @@ use super::metrics::ProcessorMetrics;
 use super::mutation::MutationError;
 use super::processor_node::{ProcessorNode, SchedulingStrategy};
 use crate::audit::{AuditAction, AuditEvent, AuditLogger, AuditTarget};
+use crate::cluster::load_balance::LoadBalanceConfig;
 use crate::connection::back_pressure::BackPressureConfig;
 use crate::connection::flow_connection::FlowConnection;
 use crate::connection::query::FlowConnectionQuery;
@@ -231,6 +232,7 @@ impl DefaultMutationHandler {
         relationship: &str,
         dest_name: &str,
         config: BackPressureConfig,
+        load_balance: Option<LoadBalanceConfig>,
     ) -> std::result::Result<String, MutationError> {
         let (src_output_h, src_rel, dst_input_h, dst_notifiers_h) = {
             let procs = self.live_procs.read();
@@ -285,7 +287,15 @@ impl DefaultMutationHandler {
             }
         }
 
-        let fc = Arc::new(FlowConnection::new(conn_id.clone(), config));
+        let fc = if let Some(lb_config) = load_balance {
+            Arc::new(FlowConnection::with_load_balance(
+                conn_id.clone(),
+                config,
+                lb_config,
+            ))
+        } else {
+            Arc::new(FlowConnection::new(conn_id.clone(), config))
+        };
 
         let notifier = fc.notifier();
         dst_input_h.write().push(Arc::clone(&fc));

--- a/crates/runifi-core/src/engine/persistence.rs
+++ b/crates/runifi-core/src/engine/persistence.rs
@@ -85,6 +85,9 @@ pub struct PersistedConnection {
     /// Attribute name for PriorityAttribute priority mode.
     #[serde(default)]
     pub priority_attribute: Option<String>,
+    /// Load balance configuration for cluster distribution.
+    #[serde(default)]
+    pub load_balancing: Option<crate::cluster::load_balance::LoadBalanceConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -232,6 +235,7 @@ impl PersistedFlowState {
                     } else {
                         (None, None, None)
                     };
+                let load_balancing = c.connection.load_balance_config().cloned();
                 PersistedConnection {
                     source: c.source_name.clone(),
                     relationship: c.relationship.clone(),
@@ -243,6 +247,7 @@ impl PersistedFlowState {
                     expiration,
                     priority,
                     priority_attribute,
+                    load_balancing,
                 }
             })
             .collect();
@@ -649,6 +654,7 @@ mod tests {
                 expiration: None,
                 priority: None,
                 priority_attribute: None,
+                load_balancing: None,
             }],
             positions: HashMap::from([(
                 "gen".to_string(),

--- a/crates/runifi-core/src/engine/processor_node.rs
+++ b/crates/runifi-core/src/engine/processor_node.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::Ordering;
 
 use parking_lot::RwLock;
@@ -16,6 +17,7 @@ use runifi_plugin_api::{FlowFile, Processor};
 use super::bulletin::{BulletinBoard, BulletinSeverity};
 use super::metrics::ProcessorMetrics;
 use super::supervisor::{InvocationResult, ProcessorSupervisor};
+use crate::cluster::load_balance::{LoadBalanceStrategy, LoadBalancer};
 use crate::connection::flow_connection::FlowConnection;
 use crate::id::IdGenerator;
 use crate::registry::service_registry::{RegistryServiceLookup, SharedServiceRegistry};
@@ -123,6 +125,9 @@ pub struct ProcessorNode {
     provenance_repo: SharedProvenanceRepository,
     /// Local state provider for processor state persistence.
     state_provider: Option<SharedLocalStateProvider>,
+    /// Lazily initialized load balancer for distributing FlowFiles across
+    /// multiple output connections on the same relationship.
+    load_balancer: OnceLock<LoadBalancer>,
 }
 
 impl ProcessorNode {
@@ -159,6 +164,7 @@ impl ProcessorNode {
             service_registry: None,
             provenance_repo: Arc::new(crate::repository::provenance_repo::NullProvenanceRepository),
             state_provider: None,
+            load_balancer: OnceLock::new(),
         }
     }
 
@@ -579,6 +585,13 @@ impl ProcessorNode {
     ///
     /// The third element contains `(FlowFile, connection_id)` for each
     /// successfully routed FlowFile, used by the WAL.
+    ///
+    /// When multiple connections exist for the same relationship, uses the
+    /// load balance strategy (configured per-connection) to select the target:
+    /// - `DoNotLoadBalance`: sends to the first matching connection (default)
+    /// - `RoundRobin`: distributes evenly across all connections for the relationship
+    /// - `PartitionByAttribute`: routes based on a hash of the specified attribute
+    /// - `SingleNode`: sends all FlowFiles to the first connection
     fn route_transfers(
         &self,
         session: &mut CoreProcessSession,
@@ -591,34 +604,15 @@ impl ProcessorNode {
             self.output_connections.read().clone();
         for (flowfile, rel_name) in session.take_transfers() {
             let size = flowfile.size;
-            let mut routed = false;
-            for (rel, conn) in &output_connections {
-                if rel.name == rel_name {
-                    let conn_id = conn.id.clone();
-                    if let Err(_ff) = conn.try_send(flowfile.clone()) {
-                        tracing::warn!(
-                            processor = %self.name,
-                            relationship = rel_name,
-                            "Failed to route FlowFile — connection full"
-                        );
-                        self.bulletin_board.add(
-                            &self.name,
-                            BulletinSeverity::Warn,
-                            format!(
-                                "Failed to route FlowFile on relationship '{}' — connection full",
-                                rel_name
-                            ),
-                        );
-                    } else {
-                        ff_out += 1;
-                        bytes_out += size;
-                        routed_list.push((flowfile, conn_id));
-                    }
-                    routed = true;
-                    break;
-                }
-            }
-            if !routed {
+
+            // Collect all connections for this relationship.
+            let matching_conns: Vec<&Arc<FlowConnection>> = output_connections
+                .iter()
+                .filter(|(rel, _)| rel.name == rel_name)
+                .map(|(_, conn)| conn)
+                .collect();
+
+            if matching_conns.is_empty() {
                 // Check if the relationship is auto-terminated.
                 let is_auto_term = output_connections
                     .iter()
@@ -630,8 +624,101 @@ impl ProcessorNode {
                         "No connection for relationship (auto-terminated or unconnected)"
                     );
                 }
+                continue;
+            }
+
+            // Select target connection using load balance strategy.
+            let target_idx = if matching_conns.len() == 1 {
+                0
+            } else {
+                self.select_load_balanced_connection(&matching_conns, &flowfile)
+            };
+
+            let conn = matching_conns[target_idx];
+            let conn_id = conn.id.clone();
+            if let Err(_ff) = conn.try_send(flowfile.clone()) {
+                tracing::warn!(
+                    processor = %self.name,
+                    relationship = rel_name,
+                    connection_id = %conn_id,
+                    "Failed to route FlowFile -- connection full"
+                );
+                self.bulletin_board.add(
+                    &self.name,
+                    BulletinSeverity::Warn,
+                    format!(
+                        "Failed to route FlowFile on relationship '{}' -- connection full",
+                        rel_name
+                    ),
+                );
+            } else {
+                ff_out += 1;
+                bytes_out += size;
+                routed_list.push((flowfile, conn_id));
             }
         }
         (ff_out, bytes_out, routed_list)
+    }
+
+    /// Select a target connection index using the load balance strategy
+    /// configured on the connections.
+    ///
+    /// If any connection has a load balance config, its strategy is used.
+    /// Otherwise, defaults to the first connection (DoNotLoadBalance behavior).
+    fn select_load_balanced_connection(
+        &self,
+        connections: &[&Arc<FlowConnection>],
+        flowfile: &FlowFile,
+    ) -> usize {
+        // Find the first connection with a load balance config to determine strategy.
+        let lb_config = connections
+            .iter()
+            .find_map(|conn| conn.load_balance_config());
+
+        let Some(config) = lb_config else {
+            return 0; // No load balancing configured — use first connection.
+        };
+
+        match &config.strategy {
+            LoadBalanceStrategy::DoNotLoadBalance => 0,
+
+            LoadBalanceStrategy::RoundRobin => {
+                // Use the shared load balancer for round-robin distribution.
+                let lb = self
+                    .load_balancer
+                    .get_or_init(|| LoadBalancer::new(LoadBalanceStrategy::RoundRobin));
+                let nodes: Vec<String> = connections.iter().map(|c| c.id.clone()).collect();
+                let local = nodes[0].clone();
+                if let Some(target_id) = lb.select_node(&local, &nodes, None) {
+                    nodes.iter().position(|n| *n == target_id).unwrap_or(0)
+                } else {
+                    0
+                }
+            }
+
+            LoadBalanceStrategy::PartitionByAttribute { attribute } => {
+                // Hash the attribute value to select a consistent target.
+                let attr_value = flowfile
+                    .attributes
+                    .iter()
+                    .find(|(k, _)| k.as_ref() == attribute.as_str())
+                    .map(|(_, v)| v.as_ref() as &str);
+
+                let lb = self.load_balancer.get_or_init(|| {
+                    LoadBalancer::new(LoadBalanceStrategy::PartitionByAttribute {
+                        attribute: attribute.clone(),
+                    })
+                });
+                let nodes: Vec<String> = connections.iter().map(|c| c.id.clone()).collect();
+                let local = nodes[0].clone();
+                if let Some(target_id) = lb.select_node(&local, &nodes, attr_value) {
+                    nodes.iter().position(|n| *n == target_id).unwrap_or(0)
+                } else {
+                    0
+                }
+            }
+
+            LoadBalanceStrategy::SingleNode { .. } => 0,
+        }
     }
 }

--- a/crates/runifi-core/src/versioning/diff.rs
+++ b/crates/runifi-core/src/versioning/diff.rs
@@ -257,6 +257,7 @@ mod tests {
                     expiration: None,
                     priority: None,
                     priority_attribute: None,
+                    load_balancing: None,
                 })
                 .collect(),
             positions: HashMap::new(),

--- a/crates/runifi-core/src/versioning/version_store.rs
+++ b/crates/runifi-core/src/versioning/version_store.rs
@@ -351,6 +351,7 @@ mod tests {
                 expiration: None,
                 priority: None,
                 priority_attribute: None,
+                load_balancing: None,
             }],
             positions: HashMap::new(),
             services: vec![],

--- a/crates/runifi-core/tests/engine_mutations.rs
+++ b/crates/runifi-core/tests/engine_mutations.rs
@@ -266,6 +266,7 @@ async fn hot_add_connection_appears_in_handle() {
             "success".to_string(),
             "dst".to_string(),
             BackPressureConfig::default(),
+            None,
         )
         .await
         .expect("add_connection failed");
@@ -312,6 +313,7 @@ async fn hot_add_connection_invalid_relationship_returns_error() {
             "nonexistent-rel".to_string(),
             "dst".to_string(),
             BackPressureConfig::default(),
+            None,
         )
         .await;
 
@@ -344,6 +346,7 @@ async fn hot_add_connection_missing_destination_returns_error() {
             "success".to_string(),
             "missing-dst".to_string(),
             BackPressureConfig::default(),
+            None,
         )
         .await;
 
@@ -387,6 +390,7 @@ async fn duplicate_connection_returns_error() {
             "success".to_string(),
             "dst".to_string(),
             bp,
+            None,
         )
         .await
         .expect("first add");
@@ -397,6 +401,7 @@ async fn duplicate_connection_returns_error() {
             "success".to_string(),
             "dst".to_string(),
             bp,
+            None,
         )
         .await;
     assert!(result.is_err());
@@ -438,6 +443,7 @@ async fn hot_remove_connection_succeeds() {
             "success".to_string(),
             "dst".to_string(),
             BackPressureConfig::default(),
+            None,
         )
         .await
         .expect("add connection");
@@ -482,6 +488,7 @@ async fn hot_remove_processor_blocked_by_connection() {
             "success".to_string(),
             "dst".to_string(),
             BackPressureConfig::default(),
+            None,
         )
         .await
         .expect("add conn");

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -785,8 +785,14 @@ fn load_from_persisted_state(
         );
 
         let rel_name: &'static str = Box::leak(conn_state.relationship.clone().into_boxed_str());
-        engine.connect_with_options(
-            source_id, rel_name, dest_id, bp_config, expiration, priority,
+        engine.connect_with_load_balance(
+            source_id,
+            rel_name,
+            dest_id,
+            bp_config,
+            expiration,
+            priority,
+            conn_state.load_balancing.clone(),
         );
 
         tracing::info!(
@@ -938,8 +944,14 @@ fn load_from_seed_config(
         );
 
         let rel_name: &'static str = Box::leak(conn_config.relationship.clone().into_boxed_str());
-        engine.connect_with_options(
-            source_id, rel_name, dest_id, bp_config, expiration, priority,
+        engine.connect_with_load_balance(
+            source_id,
+            rel_name,
+            dest_id,
+            bp_config,
+            expiration,
+            priority,
+            conn_config.load_balancing.clone(),
         );
 
         tracing::info!(


### PR DESCRIPTION
## Summary

Implements NiFi-style load-balanced connections with three distribution strategies for routing FlowFiles across multiple connections sharing the same source relationship.

### Load Balance Strategies

- **RoundRobin**: Distributes FlowFiles evenly across connections using an atomic counter
- **PartitionByAttribute**: Routes FlowFiles with the same attribute value to the same connection (hash-based)
- **SingleNode**: Routes all FlowFiles to a specific target node (cluster-aware)
- **DoNotLoadBalance** (default): Standard behavior, routes to the first matching connection

### Changes

- **FlowConnection**: Added optional `LoadBalanceConfig` with `with_load_balance()` constructor and `load_balance_config()` accessor
- **ProcessorNode**: Rewrote `route_transfers()` to collect all matching connections per relationship and select via `LoadBalancer` (OnceLock-initialized)
- **ConnectionQuery trait**: Added `load_balance_config()` for API consumers
- **FlowEngine**: Added `connect_with_load_balance()` builder method
- **MutationCommand/Handler**: Thread `LoadBalanceConfig` through runtime hot-add path
- **EngineHandle**: Extended `add_connection()` to accept and persist load balance config
- **REST API**: Parse `load_balance_strategy`, `load_balance_partition_attribute`, `load_balance_compression` from `CreateConnectionRequest`; include in responses and SSE events
- **Persistence**: Serialize/deserialize `load_balancing` on `PersistedConnection`
- **Server**: Thread load balance config from both TOML seed config and persisted state restoration

### Configuration (TOML)

```toml
[[flow.connections]]
source = "generate"
relationship = "success"
destination = "process"

[flow.connections.load_balancing]
strategy = "RoundRobin"
compression = false
```

### API (JSON)

```json
{
  "source": "generate",
  "relationship": "success",
  "destination": "process",
  "load_balance_strategy": "round_robin",
  "load_balance_partition_attribute": null,
  "load_balance_compression": false
}
```

## Test plan

- [x] All 789 existing tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] Existing load balance unit tests in `cluster/load_balance.rs` cover RoundRobin, PartitionByAttribute, SingleNode strategies
- [x] Engine mutation tests updated for new `add_connection` signature

Closes #236