### PR TITLE
feat: connection visualization with back-pressure indicators and config dialog

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/ConnectionConfigModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ConnectionConfigModal.tsx
@@ -1,0 +1,282 @@
+import { memo, useState, useEffect, useCallback, type FormEvent } from 'react';
+import type { ConnectionResponse } from '../types/api';
+import type { ToastKind } from '../hooks/useToast';
+import { formatBytes } from '../utils/format';
+
+type ActiveTab = 'details' | 'settings';
+
+interface ConnectionConfigModalProps {
+  connectionId: string;
+  onToast: (kind: ToastKind, message: string) => void;
+  onClose: () => void;
+}
+
+interface ConnectionConfig {
+  back_pressure_object_threshold: number;
+  back_pressure_bytes_threshold: number;
+}
+
+function parseSizeToBytes(input: string): number | null {
+  const trimmed = input.trim().toUpperCase();
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|TB)?$/);
+  if (!match) return null;
+  const value = parseFloat(match[1]);
+  const unit = match[2] ?? 'B';
+  const multipliers: Record<string, number> = {
+    B: 1,
+    KB: 1024,
+    MB: 1024 * 1024,
+    GB: 1024 * 1024 * 1024,
+    TB: 1024 * 1024 * 1024 * 1024,
+  };
+  return Math.round(value * (multipliers[unit] ?? 1));
+}
+
+function formatSizeForInput(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024 * 1024)).toFixed(0)} TB`;
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(0)} GB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${bytes} B`;
+}
+
+function ConnectionConfigModalInner({
+  connectionId,
+  onToast,
+  onClose,
+}: ConnectionConfigModalProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>('details');
+  const [config, setConfig] = useState<ConnectionResponse | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Form state
+  const [objectThreshold, setObjectThreshold] = useState('10000');
+  const [sizeThreshold, setSizeThreshold] = useState('1 GB');
+
+  // Load config on mount
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/v1/connections/${encodeURIComponent(connectionId)}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<ConnectionResponse>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setConfig(data);
+        setObjectThreshold(String(data.back_pressure_object_threshold));
+        setSizeThreshold(formatSizeForInput(data.back_pressure_bytes_threshold));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : String(err));
+      });
+    return () => { cancelled = true; };
+  }, [connectionId]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const handleSave = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      const objThreshold = parseInt(objectThreshold, 10);
+      if (isNaN(objThreshold) || objThreshold <= 0) {
+        onToast('error', 'Object threshold must be a positive number');
+        return;
+      }
+      const bytesThreshold = parseSizeToBytes(sizeThreshold);
+      if (bytesThreshold === null || bytesThreshold <= 0) {
+        onToast('error', 'Size threshold must be a valid size (e.g., "1 GB", "500 MB")');
+        return;
+      }
+
+      setSaving(true);
+      try {
+        const body: ConnectionConfig = {
+          back_pressure_object_threshold: objThreshold,
+          back_pressure_bytes_threshold: bytesThreshold,
+        };
+        const res = await fetch(
+          `/api/v1/connections/${encodeURIComponent(connectionId)}/config`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          },
+        );
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `HTTP ${res.status}`);
+        }
+        onToast('success', 'Connection configuration saved');
+        onClose();
+      } catch (err: unknown) {
+        onToast('error', err instanceof Error ? err.message : String(err));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [connectionId, objectThreshold, sizeThreshold, onToast, onClose],
+  );
+
+  const tabs: { key: ActiveTab; label: string }[] = [
+    { key: 'details', label: 'Details' },
+    { key: 'settings', label: 'Settings' },
+  ];
+
+  return (
+    <div className="modal-backdrop" onClick={onClose} role="presentation">
+      <div
+        className="config-panel"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Connection Configuration"
+      >
+        {/* Header */}
+        <div className="config-panel-header">
+          <h2 className="config-panel-title">
+            {config
+              ? `${config.source_name} \u2192 ${config.relationship} \u2192 ${config.dest_name}`
+              : 'Connection Configuration'}
+          </h2>
+          <button
+            className="config-panel-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            \u00d7
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="config-tabs" role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              className={`config-tab${activeTab === tab.key ? ' active' : ''}`}
+              onClick={() => setActiveTab(tab.key)}
+              role="tab"
+              aria-selected={activeTab === tab.key}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="config-tab-content">
+          {loadError && (
+            <div className="config-error">Failed to load: {loadError}</div>
+          )}
+
+          {!config && !loadError && (
+            <div className="config-loading">Loading...</div>
+          )}
+
+          {config && activeTab === 'details' && (
+            <div className="config-section">
+              <div className="config-field">
+                <label className="config-label">Connection ID</label>
+                <div className="config-value-display">{config.id}</div>
+              </div>
+              <div className="config-field">
+                <label className="config-label">Source</label>
+                <div className="config-value-display">{config.source_name}</div>
+              </div>
+              <div className="config-field">
+                <label className="config-label">Relationship</label>
+                <div className="config-value-display">{config.relationship}</div>
+              </div>
+              <div className="config-field">
+                <label className="config-label">Destination</label>
+                <div className="config-value-display">{config.dest_name}</div>
+              </div>
+              <div className="config-field">
+                <label className="config-label">Queue Size</label>
+                <div className="config-value-display">
+                  {config.queued_count.toLocaleString()} FlowFiles ({formatBytes(config.queued_bytes)})
+                </div>
+              </div>
+              <div className="config-field">
+                <label className="config-label">Fill Percentage</label>
+                <div className="config-value-display">
+                  {(config.fill_percentage * 100).toFixed(1)}%
+                </div>
+              </div>
+              <div className="config-field">
+                <label className="config-label">Back-Pressure Active</label>
+                <div className="config-value-display">
+                  {config.back_pressured ? 'Yes' : 'No'}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {config && activeTab === 'settings' && (
+            <form onSubmit={handleSave}>
+              <div className="config-section">
+                <div className="config-field">
+                  <label className="config-label" htmlFor="conn-bp-object">
+                    Back-Pressure Object Threshold
+                  </label>
+                  <p className="config-description">
+                    Maximum FlowFiles in queue before back-pressure is applied.
+                  </p>
+                  <input
+                    id="conn-bp-object"
+                    type="number"
+                    className="config-input"
+                    value={objectThreshold}
+                    onChange={(e) => setObjectThreshold(e.target.value)}
+                    min={1}
+                  />
+                </div>
+                <div className="config-field">
+                  <label className="config-label" htmlFor="conn-bp-size">
+                    Back-Pressure Data Size Threshold
+                  </label>
+                  <p className="config-description">
+                    Maximum data size before back-pressure (e.g., &quot;1 GB&quot;, &quot;500 MB&quot;).
+                  </p>
+                  <input
+                    id="conn-bp-size"
+                    type="text"
+                    className="config-input"
+                    value={sizeThreshold}
+                    onChange={(e) => setSizeThreshold(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="modal-actions">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={onClose}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={saving}
+                >
+                  {saving ? 'Saving...' : 'Apply'}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const ConnectionConfigModal = memo(ConnectionConfigModalInner);

--- a/crates/runifi-api/dashboard-react/src/components/ConnectionEdge.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ConnectionEdge.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -7,6 +7,7 @@ import {
   type EdgeProps,
 } from '@xyflow/react';
 import type { ConnectionEdgeData } from '../types/flow';
+import { backPressureEdgeColor, formatBytes } from '../utils/format';
 
 export type ConnectionEdgeType = Edge<ConnectionEdgeData, 'connectionEdge'>;
 
@@ -25,9 +26,7 @@ function ConnectionEdgeInner({
   source,
   target,
   data,
-  // onQueueClick is passed via edge data or through a custom mechanism
 }: ConnectionEdgeInnerProps) {
-  // Use dynamic positions from edge data if available, else fall back to React Flow defaults
   const effectiveSourcePos = data?.smartSourcePosition ?? sourcePosition;
   const effectiveTargetPos = data?.smartTargetPosition ?? targetPosition;
 
@@ -41,14 +40,20 @@ function ConnectionEdgeInner({
   });
 
   const queuedCount = data?.queuedCount ?? 0;
-  const backPressured = data?.backPressured ?? false;
+  const queuedBytes = data?.queuedBytes ?? 0;
+  const fillPercentage = data?.fillPercentage ?? 0;
+  const backPressureObjectThreshold = data?.backPressureObjectThreshold ?? 10000;
+  const backPressureBytesThreshold = data?.backPressureBytesThreshold ?? 1073741824;
   const relationship = data?.relationship ?? '';
   const connectionId = data?.connectionId ?? '';
   const onQueueClick = data?.onQueueClick as
     | ((connectionId: string, label: string) => void)
     | undefined;
 
-  const edgeColor = backPressured ? 'var(--danger)' : 'var(--border)';
+  const edgeColor = backPressureEdgeColor(fillPercentage);
+  const strokeWidth = fillPercentage > 0.85 ? 3 : 2;
+
+  const [hovered, setHovered] = useState(false);
 
   const handleQueueClick = useCallback(
     (e: React.MouseEvent) => {
@@ -61,27 +66,45 @@ function ConnectionEdgeInner({
     [onQueueClick, connectionId, source, relationship, target],
   );
 
+  // Badge text: show count + size when bytes > 0
+  const badgeText =
+    queuedBytes > 0
+      ? `${queuedCount.toLocaleString()} (${formatBytes(queuedBytes)})`
+      : `${queuedCount.toLocaleString()} queued`;
+
+  // Badge color class based on fill percentage
+  const badgeColorClass =
+    fillPercentage > 0.85 ? ' danger' : fillPercentage > 0.60 ? ' warning' : '';
+
   return (
     <>
+      {/* Animated flow direction dashes */}
+      <path
+        d={edgePath}
+        className="conn-edge-flow-line"
+        style={{ stroke: edgeColor }}
+        fill="none"
+      />
       <BaseEdge
         id={id}
         path={edgePath}
-        style={{ stroke: edgeColor, strokeWidth: 2 }}
+        style={{ stroke: edgeColor, strokeWidth }}
       />
       <EdgeLabelRenderer>
-        {/* position/transform must stay inline — required by React Flow's EdgeLabelRenderer */}
         <div
           style={{
             position: 'absolute',
             transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
           }}
-          className={`conn-edge-label nodrag nopan${backPressured ? ' back-pressured' : ''}`}
+          className={`conn-edge-label nodrag nopan${fillPercentage > 0.85 ? ' back-pressured' : ''}`}
           aria-label={`Connection ${relationship} — ${queuedCount} queued`}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
         >
           <span className="conn-edge-rel-badge">{relationship}</span>
           {queuedCount > 0 && (
             <span
-              className={`conn-edge-queue-badge${backPressured ? ' back-pressured' : ''}${connectionId ? ' clickable' : ''}`}
+              className={`conn-edge-queue-badge${badgeColorClass}${connectionId ? ' clickable' : ''}`}
               onClick={connectionId ? handleQueueClick : undefined}
               title={connectionId ? 'Click to inspect queue' : undefined}
               role={connectionId ? 'button' : undefined}
@@ -97,8 +120,45 @@ function ConnectionEdgeInner({
                   : undefined
               }
             >
-              {queuedCount.toLocaleString()} queued
+              {badgeText}
             </span>
+          )}
+          {/* Hover tooltip */}
+          {hovered && (
+            <div className="conn-edge-tooltip">
+              <div className="conn-edge-tooltip-row">
+                <span className="conn-edge-tooltip-label">Queue Size</span>
+                <span className="conn-edge-tooltip-value">
+                  {queuedCount.toLocaleString()} FlowFiles ({formatBytes(queuedBytes)})
+                </span>
+              </div>
+              <div className="conn-edge-tooltip-row">
+                <span className="conn-edge-tooltip-label">Object Threshold</span>
+                <span className="conn-edge-tooltip-value">
+                  {backPressureObjectThreshold.toLocaleString()}
+                </span>
+              </div>
+              <div className="conn-edge-tooltip-row">
+                <span className="conn-edge-tooltip-label">Size Threshold</span>
+                <span className="conn-edge-tooltip-value">
+                  {formatBytes(backPressureBytesThreshold)}
+                </span>
+              </div>
+              <div className="conn-edge-tooltip-row">
+                <span className="conn-edge-tooltip-label">Fill %</span>
+                <span className="conn-edge-tooltip-value">
+                  {(fillPercentage * 100).toFixed(1)}%
+                </span>
+              </div>
+              <div className="conn-edge-tooltip-row">
+                <span className="conn-edge-tooltip-label">Source</span>
+                <span className="conn-edge-tooltip-value">{source}</span>
+              </div>
+              <div className="conn-edge-tooltip-row">
+                <span className="conn-edge-tooltip-label">Destination</span>
+                <span className="conn-edge-tooltip-value">{target}</span>
+              </div>
+            </div>
           )}
         </div>
       </EdgeLabelRenderer>

--- a/crates/runifi-api/dashboard-react/src/components/ContextMenu.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ContextMenu.tsx
@@ -14,6 +14,7 @@ interface ContextMenuProps {
   menu: ContextMenuState;
   onDelete: () => void;
   onConfigure?: () => void;
+  onConfigureConnection?: () => void;
   onStart?: () => void;
   onStop?: () => void;
   onPause?: () => void;
@@ -32,6 +33,7 @@ function ContextMenuInner({
   menu,
   onDelete,
   onConfigure,
+  onConfigureConnection,
   onStart,
   onStop,
   onPause,
@@ -172,6 +174,15 @@ function ContextMenuInner({
         role="menu"
         aria-label="Connection context menu"
       >
+        {onConfigureConnection && (
+          <button
+            className="context-menu-item"
+            onClick={() => { onConfigureConnection(); onClose(); }}
+            role="menuitem"
+          >
+            Configure
+          </button>
+        )}
         {onViewQueue && (
           <button
             className="context-menu-item"

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -32,9 +32,10 @@ import { ConfirmDialog } from './ConfirmDialog';
 import { ContextMenu, type ContextMenuState } from './ContextMenu';
 import { ProcessorConfigModal } from './ProcessorConfigModal';
 import { QueueInspectorModal } from './QueueInspectorModal';
+import { ConnectionConfigModal } from './ConnectionConfigModal';
 import { ColorPickerDialog } from './ColorPickerDialog';
 import { computeLayout } from '../utils/layout';
-import { stateColor } from '../utils/format';
+import { stateColor, backPressureEdgeColor } from '../utils/format';
 import { getSmartHandlePositions, sourceHandleId, targetHandleId } from '../utils/edgeRouting';
 import type { FlowResponse, SseMetricsEvent, PluginDescriptor } from '../types/api';
 import type { ProcessorNodeData, ConnectionEdgeData, LabelNodeData } from '../types/flow';
@@ -121,7 +122,7 @@ function buildEdges(
           c.relationship === conn.relationship,
       ) ?? null;
 
-    const backPressured = live?.back_pressured ?? false;
+    const fillPercentage = live?.fill_percentage ?? 0;
 
     const srcNode = nodeMap.get(conn.source);
     const tgtNode = nodeMap.get(conn.destination);
@@ -150,14 +151,17 @@ function buildEdges(
         relationship: conn.relationship,
         queuedCount: live?.queued_count ?? 0,
         queuedBytes: live?.queued_bytes ?? 0,
-        backPressured,
+        backPressured: live?.back_pressured ?? false,
+        fillPercentage,
+        backPressureObjectThreshold: live?.back_pressure_object_threshold ?? 10000,
+        backPressureBytesThreshold: live?.back_pressure_bytes_threshold ?? 1073741824,
         connectionId: live?.id ?? '',
         pending: false,
         onQueueClick,
         smartSourcePosition: smartSourcePos,
         smartTargetPosition: smartTargetPos,
       },
-      style: { stroke: backPressured ? 'var(--danger)' : 'var(--border)' },
+      style: { stroke: backPressureEdgeColor(fillPercentage) },
     };
   });
 }
@@ -258,6 +262,7 @@ function FlowCanvasInner({
     existingRels: string[];
   } | null>(null);
   const [configTarget, setConfigTarget] = useState<{ name: string; state: string } | null>(null);
+  const [connConfigTarget, setConnConfigTarget] = useState<{ connectionId: string } | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<ColorPickerTarget | null>(null);
 
   const topologyKey = useRef(topology.name);
@@ -356,7 +361,7 @@ function FlowCanvasInner({
 
         if (
           edge.data?.queuedCount === live.queued_count &&
-          edge.data?.backPressured === live.back_pressured
+          edge.data?.fillPercentage === live.fill_percentage
         ) {
           return edge;
         }
@@ -368,14 +373,18 @@ function FlowCanvasInner({
             queuedCount: live.queued_count,
             queuedBytes: live.queued_bytes,
             backPressured: live.back_pressured,
+            fillPercentage: live.fill_percentage,
+            backPressureObjectThreshold: live.back_pressure_object_threshold,
+            backPressureBytesThreshold: live.back_pressure_bytes_threshold,
             connectionId: live.id,
             pending: false,
             onQueueClick: handleQueueClick,
+            onConfigureConnection: edge.data?.onConfigureConnection,
             smartSourcePosition: edge.data?.smartSourcePosition,
             smartTargetPosition: edge.data?.smartTargetPosition,
           },
           style: {
-            stroke: live.back_pressured ? 'var(--danger)' : 'var(--border)',
+            stroke: backPressureEdgeColor(live.fill_percentage),
           },
         };
       }),
@@ -1088,6 +1097,15 @@ function FlowCanvasInner({
     }
   }, [contextMenu, edges]);
 
+  const handleContextConfigureConnection = useCallback(() => {
+    if (!contextMenu?.edgeId) return;
+    const edge = edges.find((e) => e.id === contextMenu.edgeId);
+    setContextMenu(null);
+    if (edge && edge.data?.connectionId) {
+      setConnConfigTarget({ connectionId: edge.data.connectionId });
+    }
+  }, [contextMenu, edges]);
+
   const handleColorSelect = useCallback(
     (color: string) => {
       if (!colorPickerTarget) return;
@@ -1119,6 +1137,15 @@ function FlowCanvasInner({
       if (node.type === 'labelNode') return;
       const procData = node.data as ProcessorNodeData;
       setConfigTarget({ name: node.id, state: procData.state });
+    },
+    [],
+  );
+
+  const handleEdgeDoubleClick: EdgeMouseHandler<ConnEdge> = useCallback(
+    (_event, edge) => {
+      if (edge.data?.connectionId) {
+        setConnConfigTarget({ connectionId: edge.data.connectionId });
+      }
     },
     [],
   );
@@ -1155,6 +1182,7 @@ function FlowCanvasInner({
         onEdgeContextMenu={handleEdgeContextMenu}
         onPaneContextMenu={handleCanvasContextMenu}
         onNodeDoubleClick={handleNodeDoubleClick}
+        onEdgeDoubleClick={handleEdgeDoubleClick}
         onPaneClick={() => setContextMenu(null)}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
@@ -1274,6 +1302,7 @@ function FlowCanvasInner({
                 : undefined
             }
             onChangeColor={isProcessorCtx ? handleContextChangeColor : undefined}
+            onConfigureConnection={contextMenu.edgeId ? handleContextConfigureConnection : undefined}
             onViewQueue={contextMenu.edgeId ? handleContextViewQueue : undefined}
             onSelectAll={contextMenu.isCanvas ? handleSelectAll : undefined}
             onStartSelected={handleStartSelected}
@@ -1299,6 +1328,14 @@ function FlowCanvasInner({
           connectionLabel={queueInspectTarget.label}
           onToast={onToast}
           onClose={() => setQueueInspectTarget(null)}
+        />
+      )}
+
+      {connConfigTarget && (
+        <ConnectionConfigModal
+          connectionId={connConfigTarget.connectionId}
+          onToast={onToast}
+          onClose={() => setConnConfigTarget(null)}
         />
       )}
 

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -1160,6 +1160,20 @@ body {
   text-align: center;
 }
 
+.config-error {
+  font-size: 0.8rem;
+  color: var(--danger);
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.config-value-display {
+  font-size: 0.82rem;
+  color: var(--text);
+  padding: 0.3rem 0;
+  font-variant-numeric: tabular-nums;
+}
+
 .config-tabs {
   display: flex;
   gap: 0;
@@ -1699,11 +1713,68 @@ body {
   color: var(--danger);
 }
 
+.conn-edge-queue-badge.warning {
+  background: rgba(255, 170, 0, 0.15);
+  border-color: #ffaa00;
+  color: #ffaa00;
+}
+
+.conn-edge-queue-badge.danger {
+  background: rgba(221, 0, 0, 0.15);
+  border-color: #dd0000;
+  color: #dd0000;
+}
+
 .conn-edge-queue-badge.clickable {
   cursor: pointer;
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 2px;
+}
+
+/* ── Connection edge tooltip ────────────────────────────────── */
+
+.conn-edge-tooltip {
+  background: rgba(15, 17, 23, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 11px;
+  color: var(--text);
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 100;
+  min-width: 200px;
+  margin-top: 4px;
+}
+
+.conn-edge-tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 2px 0;
+}
+
+.conn-edge-tooltip-label {
+  color: var(--text-dim);
+}
+
+.conn-edge-tooltip-value {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Animated flow direction on edges ───────────────────────── */
+
+@keyframes flowAnimation {
+  from { stroke-dashoffset: 24; }
+  to { stroke-dashoffset: 0; }
+}
+
+.conn-edge-flow-line {
+  stroke-dasharray: 8 16;
+  animation: flowAnimation 1s linear infinite;
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 /* ── Color picker dialog ────────────────────────────────────── */

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -42,6 +42,9 @@ export interface ConnectionResponse {
   queued_count: number;
   queued_bytes: number;
   back_pressured: boolean;
+  back_pressure_object_threshold: number;
+  back_pressure_bytes_threshold: number;
+  fill_percentage: number;
 }
 
 export interface FlowNodeResponse {

--- a/crates/runifi-api/dashboard-react/src/types/flow.ts
+++ b/crates/runifi-api/dashboard-react/src/types/flow.ts
@@ -33,11 +33,16 @@ export interface ConnectionEdgeData extends Record<string, unknown> {
   queuedCount: number;
   queuedBytes: number;
   backPressured: boolean;
+  fillPercentage: number;
+  backPressureObjectThreshold: number;
+  backPressureBytesThreshold: number;
   connectionId: string;
   // True when created optimistically before the backend confirms
   pending: boolean;
   // Optional callback injected from FlowCanvas to open the queue inspector
   onQueueClick?: (connectionId: string, label: string) => void;
+  // Optional callback for opening the connection config dialog
+  onConfigureConnection?: (connectionId: string) => void;
   // Smart routing: dynamic handle positions based on node geometry
   smartSourcePosition?: Position;
   smartTargetPosition?: Position;

--- a/crates/runifi-api/dashboard-react/src/utils/format.ts
+++ b/crates/runifi-api/dashboard-react/src/utils/format.ts
@@ -42,6 +42,13 @@ export function backPressureColor(pct: number): string {
   return 'var(--accent)';
 }
 
+/** NiFi-style edge stroke color based on queue fill percentage. */
+export function backPressureEdgeColor(fillPct: number): string {
+  if (fillPct > 0.85) return '#dd0000';
+  if (fillPct > 0.60) return '#ffaa00';
+  return '#666666';
+}
+
 export function formatAge(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const secs = Math.floor(ms / 1000);

--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -99,6 +99,9 @@ pub struct ConnectionResponse {
     pub queued_count: usize,
     pub queued_bytes: u64,
     pub back_pressured: bool,
+    pub back_pressure_object_threshold: usize,
+    pub back_pressure_bytes_threshold: u64,
+    pub fill_percentage: f64,
     /// Load balance strategy in effect for this connection.
     /// Omitted from JSON when `None` (no load balancing).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,6 +112,21 @@ pub struct ConnectionResponse {
     /// Whether compression is enabled for cross-node transfer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub load_balance_compression: Option<bool>,
+}
+
+/// Compute fill percentage as `max(count/max_count, bytes/max_bytes)` clamped to `[0.0, 1.0]`.
+pub fn compute_fill_percentage(count: usize, max_count: usize, bytes: u64, max_bytes: u64) -> f64 {
+    let count_pct = if max_count > 0 {
+        count as f64 / max_count as f64
+    } else {
+        0.0
+    };
+    let bytes_pct = if max_bytes > 0 {
+        bytes as f64 / max_bytes as f64
+    } else {
+        0.0
+    };
+    count_pct.max(bytes_pct).clamp(0.0, 1.0)
 }
 
 // ── Canvas position ────────────────────────────────────────────────────
@@ -446,6 +464,9 @@ pub struct ConnectionDetailResponse {
     pub queued_count: usize,
     pub queued_bytes: u64,
     pub back_pressured: bool,
+    pub back_pressure_object_threshold: usize,
+    pub back_pressure_bytes_threshold: u64,
+    pub fill_percentage: f64,
     /// Load balance strategy in effect for this connection.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub load_balance_strategy: Option<String>,
@@ -455,6 +476,13 @@ pub struct ConnectionDetailResponse {
     /// Whether compression is enabled for cross-node transfer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub load_balance_compression: Option<bool>,
+}
+
+/// Request body for `PUT /api/v1/connections/{id}/config`.
+#[derive(Deserialize)]
+pub struct UpdateConnectionConfigRequest {
+    pub back_pressure_object_threshold: Option<usize>,
+    pub back_pressure_bytes_threshold: Option<u64>,
 }
 
 // ── Controller service DTOs ────────────────────────────────────────────
@@ -718,4 +746,45 @@ pub struct RevertResponse {
     pub reverted_to: String,
     pub comment: String,
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_percentage_empty_queue() {
+        assert_eq!(compute_fill_percentage(0, 10_000, 0, 1_073_741_824), 0.0);
+    }
+
+    #[test]
+    fn fill_percentage_by_count() {
+        let pct = compute_fill_percentage(5_000, 10_000, 0, 1_073_741_824);
+        assert!((pct - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn fill_percentage_by_bytes() {
+        let pct = compute_fill_percentage(0, 10_000, 536_870_912, 1_073_741_824);
+        assert!((pct - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn fill_percentage_takes_max() {
+        // count at 80%, bytes at 50% — should return 80%
+        let pct = compute_fill_percentage(8_000, 10_000, 536_870_912, 1_073_741_824);
+        assert!((pct - 0.8).abs() < 0.001);
+    }
+
+    #[test]
+    fn fill_percentage_clamped_to_1() {
+        // Over threshold
+        let pct = compute_fill_percentage(20_000, 10_000, 0, 1_073_741_824);
+        assert_eq!(pct, 1.0);
+    }
+
+    #[test]
+    fn fill_percentage_zero_thresholds() {
+        assert_eq!(compute_fill_percentage(100, 0, 100, 0), 0.0);
+    }
 }

--- a/crates/runifi-api/src/routes/connections.rs
+++ b/crates/runifi-api/src/routes/connections.rs
@@ -15,6 +15,7 @@ use runifi_core::engine::handle::ConnectionInfo;
 use crate::dto::{
     ConnectionDetailResponse, ConnectionResponse, CreateConnectionRequest,
     FlowFileAttributeResponse, QueueListingResponse, QueuedFlowFileResponse,
+    UpdateConnectionConfigRequest, compute_fill_percentage,
 };
 use crate::error::ApiError;
 use crate::rbac;
@@ -47,6 +48,7 @@ pub fn routes() -> Router<ApiState> {
     // GET endpoints — ViewFlow (Viewer+)
     let view_routes = Router::new()
         .route("/api/v1/connections", get(list_connections))
+        .route("/api/v1/connections/{id}", get(get_connection))
         .route("/api/v1/connections/{id}/queue", get(list_queue))
         .route(
             "/api/v1/connections/{id}/queue/{flowfile_id}",
@@ -69,6 +71,10 @@ pub fn routes() -> Router<ApiState> {
             axum::routing::post(create_connection),
         )
         .route("/api/v1/connections/{id}", delete_method(delete_connection))
+        .route(
+            "/api/v1/connections/{id}/config",
+            axum::routing::put(update_connection_config),
+        )
         .layer(middleware::from_fn(rbac::require_modify_flow));
 
     // Queue management — OperateProcessors (Operator+)
@@ -92,23 +98,76 @@ async fn list_connections(State(state): State<ApiState>) -> Json<Vec<ConnectionR
         .connections
         .read()
         .iter()
-        .map(|info| {
-            let (lb_strategy, lb_partition_attr, lb_compression) = load_balance_fields(info);
-            ConnectionResponse {
-                id: info.id.clone(),
-                source_name: info.source_name.clone(),
-                relationship: info.relationship.clone(),
-                dest_name: info.dest_name.clone(),
-                queued_count: info.connection.queue_count(),
-                queued_bytes: info.connection.queue_size_bytes(),
-                back_pressured: info.connection.is_back_pressured(),
-                load_balance_strategy: lb_strategy,
-                load_balance_partition_attribute: lb_partition_attr,
-                load_balance_compression: lb_compression,
-            }
-        })
+        .map(build_connection_response)
         .collect();
     Json(connections)
+}
+
+fn build_connection_response(info: &ConnectionInfo) -> ConnectionResponse {
+    let (lb_strategy, lb_partition_attr, lb_compression) = load_balance_fields(info);
+    let bp_config = info.connection.back_pressure_config();
+    let queued_count = info.connection.queue_count();
+    let queued_bytes = info.connection.queue_size_bytes();
+    ConnectionResponse {
+        id: info.id.clone(),
+        source_name: info.source_name.clone(),
+        relationship: info.relationship.clone(),
+        dest_name: info.dest_name.clone(),
+        queued_count,
+        queued_bytes,
+        back_pressured: info.connection.is_back_pressured(),
+        back_pressure_object_threshold: bp_config.max_count,
+        back_pressure_bytes_threshold: bp_config.max_bytes,
+        fill_percentage: compute_fill_percentage(
+            queued_count,
+            bp_config.max_count,
+            queued_bytes,
+            bp_config.max_bytes,
+        ),
+        load_balance_strategy: lb_strategy,
+        load_balance_partition_attribute: lb_partition_attr,
+        load_balance_compression: lb_compression,
+    }
+}
+
+/// Get a single connection by ID.
+async fn get_connection(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<ConnectionResponse>, ApiError> {
+    let conns = state.handle.connections.read();
+    let info = conns
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or(ApiError::ConnectionNotFound(id))?;
+    Ok(Json(build_connection_response(info)))
+}
+
+/// Update back-pressure configuration for an existing connection.
+async fn update_connection_config(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateConnectionConfigRequest>,
+) -> Result<Json<ConnectionResponse>, ApiError> {
+    let conns = state.handle.connections.read();
+    let info = conns
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or(ApiError::ConnectionNotFound(id.clone()))?;
+
+    let current = info.connection.back_pressure_config();
+    let new_max_count = body
+        .back_pressure_object_threshold
+        .unwrap_or(current.max_count);
+    let new_max_bytes = body
+        .back_pressure_bytes_threshold
+        .unwrap_or(current.max_bytes);
+
+    info.connection
+        .update_back_pressure(new_max_count, new_max_bytes);
+
+    let response = build_connection_response(info);
+    Ok(Json(response))
 }
 
 /// Create a new connection between two processors at runtime.
@@ -159,14 +218,25 @@ async fn create_connection(
         let conns = state.handle.connections.read();
         conns.iter().find(|c| c.id == conn_id).map(|info| {
             let (lb_strategy, lb_partition_attr, lb_compression) = load_balance_fields(info);
+            let bp_config = info.connection.back_pressure_config();
+            let queued_count = info.connection.queue_count();
+            let queued_bytes = info.connection.queue_size_bytes();
             ConnectionDetailResponse {
                 id: info.id.clone(),
                 source_name: info.source_name.clone(),
                 relationship: info.relationship.clone(),
                 dest_name: info.dest_name.clone(),
-                queued_count: info.connection.queue_count(),
-                queued_bytes: info.connection.queue_size_bytes(),
+                queued_count,
+                queued_bytes,
                 back_pressured: info.connection.is_back_pressured(),
+                back_pressure_object_threshold: bp_config.max_count,
+                back_pressure_bytes_threshold: bp_config.max_bytes,
+                fill_percentage: compute_fill_percentage(
+                    queued_count,
+                    bp_config.max_count,
+                    queued_bytes,
+                    bp_config.max_bytes,
+                ),
                 load_balance_strategy: lb_strategy,
                 load_balance_partition_attribute: lb_partition_attr,
                 load_balance_compression: lb_compression,

--- a/crates/runifi-api/src/routes/events.rs
+++ b/crates/runifi-api/src/routes/events.rs
@@ -12,7 +12,10 @@ use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::IntervalStream;
 
-use crate::dto::{BulletinResponse, ConnectionResponse, ProcessorResponse, SseMetricsEvent};
+use crate::dto::{
+    BulletinResponse, ConnectionResponse, ProcessorResponse, SseMetricsEvent,
+    compute_fill_percentage,
+};
 use crate::rbac;
 use crate::state::ApiState;
 
@@ -55,6 +58,16 @@ async fn sse_events(
             .read()
             .iter()
             .map(|info| {
+                let bp_config = info.connection.back_pressure_config();
+                let queued_count = info.connection.queue_count();
+                let queued_bytes = info.connection.queue_size_bytes();
+                let fill_percentage = compute_fill_percentage(
+                    queued_count,
+                    bp_config.max_count,
+                    queued_bytes,
+                    bp_config.max_bytes,
+                );
+
                 // Extract load balance display fields.
                 let (lb_strategy, lb_partition_attr, lb_compression) = {
                     match info.connection.load_balance_config() {
@@ -69,9 +82,12 @@ async fn sse_events(
                                         source_name: info.source_name.clone(),
                                         relationship: info.relationship.clone(),
                                         dest_name: info.dest_name.clone(),
-                                        queued_count: info.connection.queue_count(),
-                                        queued_bytes: info.connection.queue_size_bytes(),
+                                        queued_count,
+                                        queued_bytes,
                                         back_pressured: info.connection.is_back_pressured(),
+                                        back_pressure_object_threshold: bp_config.max_count,
+                                        back_pressure_bytes_threshold: bp_config.max_bytes,
+                                        fill_percentage,
                                         load_balance_strategy: Some(
                                             "partition_by_attribute".to_string(),
                                         ),
@@ -94,9 +110,12 @@ async fn sse_events(
                     source_name: info.source_name.clone(),
                     relationship: info.relationship.clone(),
                     dest_name: info.dest_name.clone(),
-                    queued_count: info.connection.queue_count(),
-                    queued_bytes: info.connection.queue_size_bytes(),
+                    queued_count,
+                    queued_bytes,
                     back_pressured: info.connection.is_back_pressured(),
+                    back_pressure_object_threshold: bp_config.max_count,
+                    back_pressure_bytes_threshold: bp_config.max_bytes,
+                    fill_percentage,
                     load_balance_strategy: lb_strategy,
                     load_balance_partition_attribute: lb_partition_attr,
                     load_balance_compression: lb_compression,

--- a/crates/runifi-core/src/connection/back_pressure.rs
+++ b/crates/runifi-core/src/connection/back_pressure.rs
@@ -9,7 +9,7 @@ pub struct BackPressureConfig {
 
 impl BackPressureConfig {
     pub const DEFAULT_MAX_COUNT: usize = 10_000;
-    pub const DEFAULT_MAX_BYTES: u64 = 100 * 1024 * 1024; // 100 MB
+    pub const DEFAULT_MAX_BYTES: u64 = 1_073_741_824; // 1 GB (matches NiFi default)
 
     pub const fn new(max_count: usize, max_bytes: u64) -> Self {
         Self {

--- a/crates/runifi-core/src/connection/flow_connection.rs
+++ b/crates/runifi-core/src/connection/flow_connection.rs
@@ -67,7 +67,10 @@ pub struct FlowConnection {
     pub id: String,
     sender: Sender<FlowFile>,
     receiver: Receiver<FlowFile>,
-    config: BackPressureConfig,
+    /// Runtime-updatable back-pressure object threshold.
+    bp_max_count: AtomicUsize,
+    /// Runtime-updatable back-pressure bytes threshold.
+    bp_max_bytes: AtomicU64,
     count: AtomicUsize,
     bytes: AtomicU64,
     notify: Arc<Notify>,
@@ -90,7 +93,8 @@ impl FlowConnection {
             id: id.into(),
             sender,
             receiver,
-            config,
+            bp_max_count: AtomicUsize::new(config.max_count),
+            bp_max_bytes: AtomicU64::new(config.max_bytes),
             count: AtomicUsize::new(0),
             bytes: AtomicU64::new(0),
             notify: Arc::new(Notify::new()),
@@ -113,7 +117,8 @@ impl FlowConnection {
             id: id.into(),
             sender,
             receiver,
-            config,
+            bp_max_count: AtomicUsize::new(config.max_count),
+            bp_max_bytes: AtomicU64::new(config.max_bytes),
             count: AtomicUsize::new(0),
             bytes: AtomicU64::new(0),
             notify: Arc::new(Notify::new()),
@@ -135,7 +140,8 @@ impl FlowConnection {
             id: id.into(),
             sender,
             receiver,
-            config,
+            bp_max_count: AtomicUsize::new(config.max_count),
+            bp_max_bytes: AtomicU64::new(config.max_bytes),
             count: AtomicUsize::new(0),
             bytes: AtomicU64::new(0),
             notify: Arc::new(Notify::new()),
@@ -304,8 +310,8 @@ impl FlowConnection {
 
     /// Check if back-pressure is active (queue exceeds thresholds).
     pub fn is_back_pressured(&self) -> bool {
-        self.count.load(Ordering::Relaxed) >= self.config.max_count
-            || self.bytes.load(Ordering::Relaxed) >= self.config.max_bytes
+        self.count.load(Ordering::Relaxed) >= self.bp_max_count.load(Ordering::Relaxed)
+            || self.bytes.load(Ordering::Relaxed) >= self.bp_max_bytes.load(Ordering::Relaxed)
     }
 
     /// Current number of FlowFiles in the queue.
@@ -319,8 +325,18 @@ impl FlowConnection {
     }
 
     /// Get the back-pressure configuration for this connection.
+    /// Returns the current runtime thresholds (which may differ from the initial config).
     pub fn back_pressure_config(&self) -> BackPressureConfig {
-        self.config
+        BackPressureConfig::new(
+            self.bp_max_count.load(Ordering::Relaxed),
+            self.bp_max_bytes.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Update back-pressure thresholds at runtime without rebuilding the channel.
+    pub fn update_back_pressure(&self, max_count: usize, max_bytes: u64) {
+        self.bp_max_count.store(max_count, Ordering::Relaxed);
+        self.bp_max_bytes.store(max_bytes, Ordering::Relaxed);
     }
 
     /// Get a handle to the notify for async wakeup.
@@ -965,5 +981,31 @@ mod tests {
         assert_eq!(conn.back_pressure_config().max_count, 2);
         assert_eq!(conn.back_pressure_config().max_bytes, 100);
         assert_eq!(conn.expiration(), Some(Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn update_back_pressure_thresholds() {
+        let config = BackPressureConfig::new(100, 1000);
+        let conn = FlowConnection::new("test", config);
+
+        // Send enough to not trigger BP at 100 threshold
+        for i in 0..50 {
+            conn.try_send(test_flowfile(i, 10)).unwrap();
+        }
+        assert!(!conn.is_back_pressured());
+
+        // Lower threshold so current count exceeds it
+        conn.update_back_pressure(30, 1000);
+        assert!(conn.is_back_pressured());
+        assert_eq!(conn.back_pressure_config().max_count, 30);
+
+        // Raise threshold back
+        conn.update_back_pressure(100, 1000);
+        assert!(!conn.is_back_pressured());
+    }
+
+    #[test]
+    fn default_max_bytes_is_1gb() {
+        assert_eq!(BackPressureConfig::DEFAULT_MAX_BYTES, 1_073_741_824);
     }
 }

--- a/crates/runifi-core/src/connection/query.rs
+++ b/crates/runifi-core/src/connection/query.rs
@@ -48,6 +48,9 @@ pub trait ConnectionQuery: Send + Sync {
         None
     }
 
+    /// Update back-pressure thresholds at runtime. Default is no-op.
+    fn update_back_pressure(&self, _max_count: usize, _max_bytes: u64) {}
+
     /// Access the underlying FlowConnection (for persistence of expiration/priority).
     /// Returns `None` if the implementation does not use a FlowConnection.
     fn flow_connection(&self) -> Option<&FlowConnection> {
@@ -139,6 +142,10 @@ impl ConnectionQuery for FlowConnectionQuery {
 
     fn load_balance_config(&self) -> Option<&LoadBalanceConfig> {
         self.connection.load_balance_config()
+    }
+
+    fn update_back_pressure(&self, max_count: usize, max_bytes: u64) {
+        self.connection.update_back_pressure(max_count, max_bytes);
     }
 
     fn flow_connection(&self) -> Option<&FlowConnection> {


### PR DESCRIPTION
## Summary
- Add NiFi-style 3-color back-pressure edge visualization (gray 0-60%, orange 61-85%, red 86-100%)
- Add queue depth badge showing count and bytes on connection edges
- Add hover tooltip with queue statistics, thresholds, and fill percentage
- Add connection configuration modal with Details/Settings tabs for runtime threshold changes
- Add `GET /api/v1/connections/{id}` and `PUT /api/v1/connections/{id}/config` API endpoints
- Extend SSE metrics with `fill_percentage`, `back_pressure_object_threshold`, `back_pressure_bytes_threshold`
- Add runtime-updatable back-pressure thresholds via atomic fields (no channel rebuild)
- Change default max bytes from 100 MB to 1 GB to match NiFi defaults

## Changes
- **13 files modified, 1 new file** across `runifi-core`, `runifi-api`, and dashboard
- **8 new tests** for fill percentage computation and back-pressure threshold updates
- All 817 tests pass, clippy clean

## Test Plan
- [x] `cargo test --workspace` — 817 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Fill percentage computation unit tests (6 cases: zero, mid, full, over-limit, edge, zero-thresholds)
- [x] Back-pressure threshold update test
- [x] Default max bytes = 1 GB assertion test

Closes #231