### PR TITLE
fix: downgrade React to 18.3.1 and fix FlowCanvas merge issues

### DIFF
--- a/crates/runifi-api/dashboard-react/package-lock.json
+++ b/crates/runifi-api/dashboard-react/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@xyflow/react": "^12.6.4",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@types/react": "^19.1.0",
-        "@types/react-dom": "^19.1.0",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.4.1",
         "typescript": "^5.8.3",
         "vite": "^6.3.5"
@@ -415,20 +415,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.2.14",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.2.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -736,7 +748,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -759,6 +770,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -840,20 +863,28 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-refresh": {
@@ -908,8 +939,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/crates/runifi-api/dashboard-react/package.json
+++ b/crates/runifi-api/dashboard-react/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "@xyflow/react": "^12.6.4",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@types/react": "^19.1.0",
-    "@types/react-dom": "^19.1.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.4.1",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"

--- a/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/FlowCanvas.tsx
@@ -365,6 +365,7 @@ function FlowCanvasInner({
   } | null>(null);
   const [configTarget, setConfigTarget] = useState<{ name: string; state: string } | null>(null);
   const [connConfigTarget, setConnConfigTarget] = useState<{ connectionId: string } | null>(null);
+  const [groupConfigTarget, setGroupConfigTarget] = useState<string | null>(null);
   const [colorPickerTarget, setColorPickerTarget] = useState<ColorPickerTarget | null>(null);
   const batchColorNodeIdsRef = useRef<string[] | null>(null);
 
@@ -459,7 +460,7 @@ function FlowCanvasInner({
             bulletin,
             pending: false,
           },
-        };
+        } as AnyNode;
       }),
     );
 
@@ -708,7 +709,7 @@ function FlowCanvasInner({
                           labelId: created.id,
                           pending: false,
                         },
-                      } as AnyNode
+                      } as AnyNode)
                     : n,
                 ),
               );
@@ -862,6 +863,9 @@ function FlowCanvasInner({
           queuedCount: 0,
           queuedBytes: 0,
           backPressured: false,
+          fillPercentage: 0,
+          backPressureObjectThreshold: 10000,
+          backPressureBytesThreshold: 1073741824,
           connectionId: '',
           pending: true,
           onQueueClick: handleQueueClick,
@@ -1273,6 +1277,9 @@ function FlowCanvasInner({
                   queuedCount: 0,
                   queuedBytes: 0,
                   backPressured: false,
+                  fillPercentage: 0,
+                  backPressureObjectThreshold: 10000,
+                  backPressureBytesThreshold: 1073741824,
                   connectionId: data.id,
                   pending: false,
                   onQueueClick: handleQueueClick,
@@ -1578,8 +1585,7 @@ function FlowCanvasInner({
     [colorPickerTarget, setNodes],
   );
 
-  // State for process group config modal
-  const [groupConfigTarget, setGroupConfigTarget] = useState<string | null>(null);
+  // State for process group config modal (moved up — used by isModalOpen)
 
   const handleNodeDoubleClick: NodeMouseHandler<AnyNode> = useCallback(
     (_event, node) => {


### PR DESCRIPTION
## Summary

- Downgrade React from 19.x to 18.3.1 to fix runtime crash (Error #185: "Objects are not valid as a React child") caused by React 19 incompatibility with `@xyflow/react` v12.10.1
- Fix four FlowCanvas.tsx issues introduced by merging multiple PRs (#229, #231, #233, #234) that modified the same file

## Root Cause

`@xyflow/react` v12.10.1 is developed and tested against React 18 (`devDependencies: "react": "^18.2.0"`). React 19 changed internal element validation and rendering behavior, causing xyflow's internal rendering pipeline to throw "Objects are not valid as a React child" during `setState` reconciliation.

## Changes

### React downgrade
- `react` / `react-dom`: `^19.1.0` → `^18.3.1`
- `@types/react`: `^19.1.0` → `^18.3.12`
- `@types/react-dom`: `^19.1.0` → `^18.3.1`

### FlowCanvas.tsx merge fixes
- Add missing `as AnyNode` cast in `setNodes` callback (from #229/#231 interaction)
- Add missing closing paren in ternary with `as AnyNode` cast (from #234 label creation)
- Add three missing `ConnectionEdgeData` properties (`fillPercentage`, `backPressureObjectThreshold`, `backPressureBytesThreshold`) required by #231's interface changes
- Move `groupConfigTarget` state declaration before its first use in `isModalOpen` (from #233/#229 interaction)

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [x] `vite build` produces production bundle successfully
- [x] Server starts and serves dashboard at localhost:8080
- [x] API endpoints respond correctly (`/api/v1/flow`, `/api/v1/plugins`, `/api/v1/events`)
- [x] Dashboard loads without React Error #185
- [x] Canvas renders with nodes, edges, and live SSE metrics