### PR TITLE
fix: prefix unused variable in mTLS provider test

### DIFF
--- a/crates/runifi-core/src/auth/mtls_provider.rs
+++ b/crates/runifi-core/src/auth/mtls_provider.rs
@@ -260,7 +260,7 @@ mod tests {
             identity_regex: Some(r"^([^@]+)".into()),
             ..test_config()
         };
-        let provider = MtlsAuthProvider::new(config);
+        let _provider = MtlsAuthProvider::new(config);
 
         // Since we don't have a real cert, test the regex logic directly:
         // The extract_identity() method relies on parsing a real DER cert first,


### PR DESCRIPTION
## Summary
- Prefix unused `provider` variable with `_` in mTLS provider test to fix `-D warnings` CI failure

One-character fix: `provider` → `_provider` at `mtls_provider.rs:263`.