### PR TITLE
fix: update cargo-deny config for main pipeline

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,10 @@
 version = 2
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+ignore = [
+    # rustls-pemfile is unmaintained but still used transitively; no security risk
+    "RUSTSEC-2025-0134",
+]
 
 [licenses]
 version = 2
@@ -18,6 +21,7 @@ allow = [
     "Unicode-3.0",
     "Zlib",
     "CC0-1.0",
+    "MIT-0",
     "OpenSSL",
     "CDLA-Permissive-2.0",
 ]


### PR DESCRIPTION
## Summary
- Ignore RUSTSEC-2025-0134 (`rustls-pemfile` unmaintained — no security risk, used transitively)
- Allow `MIT-0` license (permissive, used by new transitive deps)

Fixes the `cargo deny` step in the main CI pipeline so the dev→main release PR can pass.