### PR TITLE
feat: stateless execution engine for exactly-once process group semantics (#267)

### DIFF
--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -1329,6 +1329,7 @@ impl EngineHandle {
             default_back_pressure_count: None,
             default_back_pressure_bytes: None,
             default_flowfile_expiration_ms: None,
+            execution_mode: crate::engine::process_group::ExecutionMode::default(),
         };
 
         groups.push(group_info);

--- a/crates/runifi-core/src/engine/mod.rs
+++ b/crates/runifi-core/src/engine/mod.rs
@@ -9,5 +9,6 @@ pub mod process_group;
 pub mod processor_node;
 pub mod reporting_supervisor;
 pub mod reporting_task_manager;
+pub mod stateless_executor;
 pub mod supervisor;
 pub mod validation;

--- a/crates/runifi-core/src/engine/process_group.rs
+++ b/crates/runifi-core/src/engine/process_group.rs
@@ -3,6 +3,16 @@ use std::collections::HashMap;
 /// Unique identifier for a process group.
 pub type ProcessGroupId = String;
 
+/// Execution mode for a process group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExecutionMode {
+    /// Each processor commits independently (current behavior).
+    #[default]
+    Standard,
+    /// All processors share a single transaction — all-or-nothing semantics.
+    Stateless,
+}
+
 /// Information about a process group, visible to the API and engine handle.
 ///
 /// Process Groups are hierarchical containers that organize processors,
@@ -38,6 +48,8 @@ pub struct ProcessGroupInfo {
     pub default_back_pressure_bytes: Option<u64>,
     /// Default FlowFile expiration in milliseconds for connections in this group.
     pub default_flowfile_expiration_ms: Option<u64>,
+    /// Execution mode: Standard (per-processor commits) or Stateless (group transaction).
+    pub execution_mode: ExecutionMode,
 }
 
 /// Information about an input or output port on a process group.
@@ -85,6 +97,7 @@ impl ProcessGroupInfo {
             default_back_pressure_count: None,
             default_back_pressure_bytes: None,
             default_flowfile_expiration_ms: None,
+            execution_mode: ExecutionMode::default(),
         }
     }
 
@@ -189,5 +202,20 @@ mod tests {
         };
         assert_eq!(port.port_type, PortType::Input);
         assert_eq!(port.name, "raw-data");
+    }
+
+    #[test]
+    fn test_execution_mode_default_is_standard() {
+        assert_eq!(ExecutionMode::default(), ExecutionMode::Standard);
+    }
+
+    #[test]
+    fn test_execution_mode_on_process_group() {
+        let pg = ProcessGroupInfo::new("pg-1", "Test Group");
+        assert_eq!(pg.execution_mode, ExecutionMode::Standard);
+
+        let mut pg2 = ProcessGroupInfo::new("pg-2", "Stateless Group");
+        pg2.execution_mode = ExecutionMode::Stateless;
+        assert_eq!(pg2.execution_mode, ExecutionMode::Stateless);
     }
 }

--- a/crates/runifi-core/src/engine/stateless_executor.rs
+++ b/crates/runifi-core/src/engine/stateless_executor.rs
@@ -1,0 +1,489 @@
+use runifi_plugin_api::Processor;
+use runifi_plugin_api::context::ProcessContext;
+
+use crate::session::group_session::GroupSession;
+
+/// Configuration for stateless execution.
+#[derive(Default)]
+pub struct StatelessConfig {
+    /// Maximum retry attempts before routing to failure.
+    pub max_retries: u32,
+}
+
+/// Result of a stateless group execution.
+pub enum StatelessResult {
+    /// All processors in the group completed successfully.
+    Success,
+    /// A processor in the group failed after exhausting retries.
+    Failed {
+        processor_name: String,
+        error: String,
+    },
+}
+
+/// Executes all processors in a stateless process group as a single transaction.
+///
+/// On success, all sessions commit atomically. On any failure, everything
+/// rolls back and source FlowFiles return to input connections.
+pub struct StatelessExecutor {
+    config: StatelessConfig,
+}
+
+impl StatelessExecutor {
+    pub fn new(config: StatelessConfig) -> Self {
+        Self { config }
+    }
+
+    /// Execute a sequence of processors as a single transaction.
+    ///
+    /// Each processor's transfers are fed into the internal queue for the next
+    /// processor. On success, the group session is committed atomically.
+    /// On failure or panic, the group session is rolled back.
+    pub fn execute(
+        &self,
+        processors: &mut [(String, &mut dyn Processor, &dyn ProcessContext)],
+        session: &mut GroupSession,
+    ) -> StatelessResult {
+        for (name, processor, context) in processors.iter_mut() {
+            let mut attempts = 0;
+            loop {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    processor.on_trigger(*context, session)
+                }));
+
+                match result {
+                    Ok(Ok(())) => {
+                        // Move transfers to internal queue for next processor.
+                        let transfers = session.take_transfers();
+                        let flowfiles: Vec<_> = transfers.into_iter().map(|(ff, _)| ff).collect();
+                        session.feed_internal(flowfiles);
+                        break;
+                    }
+                    Ok(Err(e)) => {
+                        attempts += 1;
+                        if attempts > self.config.max_retries {
+                            tracing::error!(
+                                processor = %name,
+                                error = %e,
+                                attempts,
+                                "Stateless execution failed"
+                            );
+                            session.group_rollback();
+                            return StatelessResult::Failed {
+                                processor_name: name.clone(),
+                                error: e.to_string(),
+                            };
+                        }
+                        tracing::warn!(
+                            processor = %name,
+                            error = %e,
+                            attempt = attempts,
+                            max_retries = self.config.max_retries,
+                            "Retrying processor in stateless group"
+                        );
+                    }
+                    Err(panic_info) => {
+                        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                            s.to_string()
+                        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                            s.clone()
+                        } else {
+                            "unknown panic".to_string()
+                        };
+                        tracing::error!(
+                            processor = %name,
+                            error = %msg,
+                            "Processor panicked in stateless group"
+                        );
+                        session.group_rollback();
+                        return StatelessResult::Failed {
+                            processor_name: name.clone(),
+                            error: format!("panic: {msg}"),
+                        };
+                    }
+                }
+            }
+        }
+
+        // All processors succeeded — commit the group transaction.
+        session.group_commit();
+        StatelessResult::Success
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use runifi_plugin_api::context::ProcessContext;
+    use runifi_plugin_api::property::PropertyValue;
+    use runifi_plugin_api::relationship::Relationship;
+    use runifi_plugin_api::result::ProcessResult;
+    use runifi_plugin_api::session::ProcessSession;
+    use runifi_plugin_api::{FlowFile, REL_SUCCESS};
+
+    use crate::connection::back_pressure::BackPressureConfig;
+    use crate::connection::flow_connection::FlowConnection;
+    use crate::id::IdGenerator;
+    use crate::repository::content_memory::InMemoryContentRepository;
+
+    // ── Test helpers ────────────────────────────────────────────
+
+    struct TestContext {
+        name: String,
+    }
+
+    impl TestContext {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+            }
+        }
+    }
+
+    impl ProcessContext for TestContext {
+        fn get_property(&self, _name: &str) -> PropertyValue {
+            PropertyValue::Unset
+        }
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn id(&self) -> &str {
+            "test-id"
+        }
+        fn yield_duration_ms(&self) -> u64 {
+            1000
+        }
+    }
+
+    /// A processor that reads a FlowFile and transfers it to success.
+    struct PassThroughProcessor;
+
+    impl Processor for PassThroughProcessor {
+        fn on_trigger(
+            &mut self,
+            _context: &dyn ProcessContext,
+            session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            if let Some(ff) = session.get() {
+                session.transfer(ff, &REL_SUCCESS);
+            }
+            session.commit();
+            Ok(())
+        }
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS.clone()]
+        }
+    }
+
+    /// A processor that creates a FlowFile with content and transfers it.
+    struct GeneratorProcessor {
+        data: Bytes,
+    }
+
+    impl Processor for GeneratorProcessor {
+        fn on_trigger(
+            &mut self,
+            _context: &dyn ProcessContext,
+            session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            let ff = session.create();
+            let ff = session.write_content(ff, self.data.clone())?;
+            session.transfer(ff, &REL_SUCCESS);
+            session.commit();
+            Ok(())
+        }
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS.clone()]
+        }
+    }
+
+    /// A processor that always fails.
+    struct FailingProcessor;
+
+    impl Processor for FailingProcessor {
+        fn on_trigger(
+            &mut self,
+            _context: &dyn ProcessContext,
+            _session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            Err(runifi_plugin_api::PluginError::ProcessingFailed(
+                "intentional failure".to_string(),
+            ))
+        }
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS.clone()]
+        }
+    }
+
+    /// A processor that panics.
+    struct PanickingProcessor;
+
+    impl Processor for PanickingProcessor {
+        fn on_trigger(
+            &mut self,
+            _context: &dyn ProcessContext,
+            _session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            panic!("intentional panic");
+        }
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS.clone()]
+        }
+    }
+
+    /// A processor that fails N times then succeeds.
+    struct EventuallySucceedsProcessor {
+        failures_remaining: u32,
+    }
+
+    impl Processor for EventuallySucceedsProcessor {
+        fn on_trigger(
+            &mut self,
+            _context: &dyn ProcessContext,
+            session: &mut dyn ProcessSession,
+        ) -> ProcessResult {
+            if self.failures_remaining > 0 {
+                self.failures_remaining -= 1;
+                return Err(runifi_plugin_api::PluginError::ProcessingFailed(
+                    "transient failure".to_string(),
+                ));
+            }
+            if let Some(ff) = session.get() {
+                session.transfer(ff, &REL_SUCCESS);
+            }
+            session.commit();
+            Ok(())
+        }
+        fn relationships(&self) -> Vec<Relationship> {
+            vec![REL_SUCCESS.clone()]
+        }
+    }
+
+    fn make_flowfile(id: u64) -> FlowFile {
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    fn make_group_session(
+        input_connections: Vec<Arc<FlowConnection>>,
+    ) -> (GroupSession, Arc<InMemoryContentRepository>) {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        let session = GroupSession::new(content_repo.clone(), id_gen, input_connections);
+        (session, content_repo)
+    }
+
+    // ── Tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn successful_two_processor_chain() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let ctx1 = TestContext::new("proc-1");
+        let ctx2 = TestContext::new("proc-2");
+        let mut proc1 = PassThroughProcessor;
+        let mut proc2 = PassThroughProcessor;
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![
+            ("proc-1".to_string(), &mut proc1, &ctx1),
+            ("proc-2".to_string(), &mut proc2, &ctx2),
+        ];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Success));
+        assert!(session.is_committed());
+        // Input connection should be empty (FlowFile consumed).
+        assert_eq!(conn.count(), 0);
+    }
+
+    #[test]
+    fn failure_rolls_back_everything() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let ctx1 = TestContext::new("proc-1");
+        let ctx2 = TestContext::new("proc-2");
+        let mut proc1 = PassThroughProcessor;
+        let mut proc2 = FailingProcessor;
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![
+            ("proc-1".to_string(), &mut proc1, &ctx1),
+            ("proc-2".to_string(), &mut proc2, &ctx2),
+        ];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Failed { .. }));
+        assert!(!session.is_committed());
+        // FlowFile should be returned to input connection.
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn panic_rolls_back_everything() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let ctx1 = TestContext::new("proc-1");
+        let ctx2 = TestContext::new("proc-2");
+        let mut proc1 = PassThroughProcessor;
+        let mut proc2 = PanickingProcessor;
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![
+            ("proc-1".to_string(), &mut proc1, &ctx1),
+            ("proc-2".to_string(), &mut proc2, &ctx2),
+        ];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Failed { .. }));
+        if let StatelessResult::Failed { error, .. } = &result {
+            assert!(error.contains("panic"));
+        }
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn retry_succeeds_within_limit() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig { max_retries: 2 });
+
+        let ctx = TestContext::new("proc-1");
+        let mut proc1 = EventuallySucceedsProcessor {
+            failures_remaining: 2,
+        };
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> =
+            vec![("proc-1".to_string(), &mut proc1, &ctx)];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Success));
+        assert!(session.is_committed());
+    }
+
+    #[test]
+    fn retry_exhausted_rolls_back() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig { max_retries: 1 });
+
+        let ctx = TestContext::new("proc-1");
+        let mut proc1 = EventuallySucceedsProcessor {
+            failures_remaining: 3,
+        };
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> =
+            vec![("proc-1".to_string(), &mut proc1, &ctx)];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Failed { .. }));
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn content_created_by_first_processor_available_to_second() {
+        let (mut session, _repo) = make_group_session(vec![]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let ctx1 = TestContext::new("generator");
+        let ctx2 = TestContext::new("reader");
+        let mut generator = GeneratorProcessor {
+            data: Bytes::from_static(b"test data"),
+        };
+        let mut reader = PassThroughProcessor;
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![
+            ("generator".to_string(), &mut generator, &ctx1),
+            ("reader".to_string(), &mut reader, &ctx2),
+        ];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Success));
+    }
+
+    #[test]
+    fn failure_cleans_up_created_content() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let ctx1 = TestContext::new("generator");
+        let ctx2 = TestContext::new("failer");
+        let mut generator = GeneratorProcessor {
+            data: Bytes::from_static(b"will be rolled back"),
+        };
+        let mut failer = FailingProcessor;
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![
+            ("generator".to_string(), &mut generator, &ctx1),
+            ("failer".to_string(), &mut failer, &ctx2),
+        ];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Failed { .. }));
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn empty_processor_chain_succeeds() {
+        let (mut session, _repo) = make_group_session(vec![]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Success));
+        assert!(session.is_committed());
+    }
+
+    #[test]
+    fn first_processor_failure_rolls_back() {
+        let conn = Arc::new(FlowConnection::new("input", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(1)).unwrap();
+
+        let (mut session, _repo) = make_group_session(vec![conn.clone()]);
+        let executor = StatelessExecutor::new(StatelessConfig::default());
+
+        let ctx1 = TestContext::new("failer");
+        let ctx2 = TestContext::new("never-reached");
+        let mut failer = FailingProcessor;
+        let mut passthrough = PassThroughProcessor;
+
+        let mut processors: Vec<(String, &mut dyn Processor, &dyn ProcessContext)> = vec![
+            ("failer".to_string(), &mut failer, &ctx1),
+            ("never-reached".to_string(), &mut passthrough, &ctx2),
+        ];
+
+        let result = executor.execute(&mut processors, &mut session);
+        assert!(matches!(result, StatelessResult::Failed { .. }));
+        if let StatelessResult::Failed { processor_name, .. } = &result {
+            assert_eq!(processor_name, "failer");
+        }
+        assert_eq!(conn.count(), 1);
+    }
+}

--- a/crates/runifi-core/src/session/group_session.rs
+++ b/crates/runifi-core/src/session/group_session.rs
@@ -1,0 +1,600 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use runifi_plugin_api::FlowFile;
+use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+use runifi_plugin_api::session::ProcessSession;
+
+use crate::connection::flow_connection::FlowConnection;
+use crate::id::IdGenerator;
+use crate::repository::content_repo::ContentRepository;
+
+/// Pending transfer within a group session.
+struct GroupPendingTransfer {
+    flowfile: FlowFile,
+    relationship_name: &'static str,
+}
+
+/// Default penalty duration in milliseconds (30 seconds).
+const DEFAULT_PENALTY_DURATION_MS: u64 = 30_000;
+
+/// A transactional session spanning all processors in a stateless process group.
+///
+/// All operations are buffered until the entire group completes successfully.
+/// On any failure, everything rolls back and source FlowFiles return to input.
+///
+/// Key behavior:
+/// - `commit()` is a no-op — actual commit is deferred to `group_commit()`.
+/// - `rollback()` is a no-op — the executor handles group-level rollback.
+/// - `get()` pulls from the internal queue first (inter-processor transfers),
+///   then from input connections.
+pub struct GroupSession {
+    content_repo: Arc<dyn ContentRepository>,
+    id_gen: Arc<IdGenerator>,
+    input_connections: Vec<Arc<FlowConnection>>,
+
+    // Buffered state across all processors in the group
+    pending_transfers: Vec<GroupPendingTransfer>,
+    pending_removes: Vec<FlowFile>,
+    acquired_flowfiles: Vec<FlowFile>,
+    created_content_claims: Vec<u64>,
+    committed: bool,
+
+    /// FlowFiles transferred between processors within the group.
+    /// Available for the next processor via `get()`.
+    internal_queue: Vec<FlowFile>,
+}
+
+impl GroupSession {
+    pub fn new(
+        content_repo: Arc<dyn ContentRepository>,
+        id_gen: Arc<IdGenerator>,
+        input_connections: Vec<Arc<FlowConnection>>,
+    ) -> Self {
+        Self {
+            content_repo,
+            id_gen,
+            input_connections,
+            pending_transfers: Vec::new(),
+            pending_removes: Vec::new(),
+            acquired_flowfiles: Vec::new(),
+            created_content_claims: Vec::new(),
+            committed: false,
+            internal_queue: Vec::new(),
+        }
+    }
+
+    /// Feed FlowFiles into the internal queue for the next processor to consume.
+    pub fn feed_internal(&mut self, flowfiles: Vec<FlowFile>) {
+        self.internal_queue.extend(flowfiles);
+    }
+
+    /// Take pending transfers (FlowFile + relationship name).
+    pub fn take_transfers(&mut self) -> Vec<(FlowFile, &'static str)> {
+        self.pending_transfers
+            .drain(..)
+            .map(|t| (t.flowfile, t.relationship_name))
+            .collect()
+    }
+
+    /// Check if the session was committed.
+    pub fn is_committed(&self) -> bool {
+        self.committed
+    }
+
+    /// Commit the entire group transaction.
+    ///
+    /// Decrements ref counts for removed FlowFiles and marks the session as committed.
+    pub fn group_commit(&mut self) {
+        for ff in self.pending_removes.drain(..) {
+            if let Some(claim) = &ff.content_claim {
+                let _ = self.content_repo.decrement_ref(claim.resource_id);
+            }
+        }
+        self.committed = true;
+    }
+
+    /// Rollback the entire group transaction.
+    ///
+    /// Returns acquired FlowFiles to input connections and cleans up created content.
+    pub fn group_rollback(&mut self) {
+        // Return acquired FlowFiles to input connections.
+        for ff in self.acquired_flowfiles.drain(..) {
+            for conn in &self.input_connections {
+                if conn.try_send(ff.clone()).is_ok() {
+                    break;
+                }
+            }
+        }
+        // Clean up created content.
+        for resource_id in self.created_content_claims.drain(..) {
+            let _ = self.content_repo.decrement_ref(resource_id);
+        }
+        self.pending_transfers.clear();
+        self.pending_removes.clear();
+        self.internal_queue.clear();
+        self.committed = false;
+    }
+
+    /// Number of FlowFiles acquired from input connections.
+    pub fn acquired_count(&self) -> usize {
+        self.acquired_flowfiles.len()
+    }
+
+    /// Total bytes of FlowFiles acquired from input connections.
+    pub fn acquired_bytes(&self) -> u64 {
+        self.acquired_flowfiles.iter().map(|ff| ff.size).sum()
+    }
+}
+
+impl ProcessSession for GroupSession {
+    fn get(&mut self) -> Option<FlowFile> {
+        // Try internal queue first (inter-processor transfers within group).
+        if !self.internal_queue.is_empty() {
+            return Some(self.internal_queue.remove(0));
+        }
+
+        // Fall back to input connections using FIFO (oldest-first) logic.
+        if self.input_connections.is_empty() {
+            return None;
+        }
+
+        let now_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        let oldest_idx = self
+            .input_connections
+            .iter()
+            .enumerate()
+            .filter(|(_, conn)| conn.is_front_penalized(now_nanos) != Some(true))
+            .filter_map(|(i, conn)| conn.peek_oldest_timestamp().map(|ts| (i, ts)))
+            .min_by_key(|(_, ts)| *ts)
+            .map(|(i, _)| i);
+
+        if let Some(idx) = oldest_idx {
+            let conn = &self.input_connections[idx];
+            if let Some(ff) = conn.try_recv() {
+                if ff.is_penalized(now_nanos) {
+                    let _ = conn.try_send(ff);
+                    return None;
+                }
+                self.acquired_flowfiles.push(ff.clone());
+                return Some(ff);
+            }
+        }
+        None
+    }
+
+    fn get_batch(&mut self, max: usize) -> Vec<FlowFile> {
+        let mut batch = Vec::with_capacity(max);
+
+        // Drain internal queue first.
+        while batch.len() < max && !self.internal_queue.is_empty() {
+            batch.push(self.internal_queue.remove(0));
+        }
+
+        if batch.len() >= max || self.input_connections.is_empty() {
+            return batch;
+        }
+
+        let now_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+
+        // Then from input connections using FIFO ordering.
+        while batch.len() < max {
+            let oldest_idx = self
+                .input_connections
+                .iter()
+                .enumerate()
+                .filter(|(_, conn)| conn.is_front_penalized(now_nanos) != Some(true))
+                .filter_map(|(i, conn)| conn.peek_oldest_timestamp().map(|ts| (i, ts)))
+                .min_by_key(|(_, ts)| *ts)
+                .map(|(i, _)| i);
+
+            match oldest_idx {
+                Some(idx) => {
+                    let conn = &self.input_connections[idx];
+                    if let Some(ff) = conn.try_recv() {
+                        if ff.is_penalized(now_nanos) {
+                            let _ = conn.try_send(ff);
+                            continue;
+                        }
+                        self.acquired_flowfiles.push(ff.clone());
+                        batch.push(ff);
+                    } else {
+                        continue;
+                    }
+                }
+                None => break,
+            }
+        }
+
+        batch
+    }
+
+    fn read_content(&self, flowfile: &FlowFile) -> ProcessResult<Bytes> {
+        match &flowfile.content_claim {
+            Some(claim) => self
+                .content_repo
+                .read(claim)
+                .map_err(|_| PluginError::ContentNotFound(claim.resource_id)),
+            None => Ok(Bytes::new()),
+        }
+    }
+
+    fn write_content(&mut self, mut flowfile: FlowFile, data: Bytes) -> ProcessResult<FlowFile> {
+        let claim = self
+            .content_repo
+            .create(data.clone())
+            .map_err(|e| PluginError::ProcessingFailed(e.to_string()))?;
+        self.created_content_claims.push(claim.resource_id);
+        flowfile.size = data.len() as u64;
+        flowfile.content_claim = Some(claim);
+        Ok(flowfile)
+    }
+
+    fn create(&mut self) -> FlowFile {
+        let id = self.id_gen.next_id();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: now,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    fn clone_flowfile(&mut self, flowfile: &FlowFile) -> FlowFile {
+        let new_id = self.id_gen.next_id();
+        if let Some(claim) = &flowfile.content_claim {
+            let _ = self.content_repo.increment_ref(claim.resource_id);
+        }
+        FlowFile {
+            id: new_id,
+            attributes: flowfile.attributes.clone(),
+            content_claim: flowfile.content_claim.clone(),
+            size: flowfile.size,
+            created_at_nanos: flowfile.created_at_nanos,
+            lineage_start_id: flowfile.lineage_start_id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    fn transfer(&mut self, flowfile: FlowFile, relationship: &Relationship) {
+        self.pending_transfers.push(GroupPendingTransfer {
+            flowfile,
+            relationship_name: relationship.name,
+        });
+    }
+
+    fn remove(&mut self, flowfile: FlowFile) {
+        self.pending_removes.push(flowfile);
+    }
+
+    fn penalize(&mut self, mut flowfile: FlowFile) -> FlowFile {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let penalty_nanos = DEFAULT_PENALTY_DURATION_MS * 1_000_000;
+        flowfile.penalized_until_nanos = now + penalty_nanos;
+        flowfile
+    }
+
+    fn commit(&mut self) {
+        // No-op in group session — actual commit deferred to group_commit().
+    }
+
+    fn rollback(&mut self) {
+        // No-op for individual processor rollback in group session.
+        // The executor handles group-level rollback.
+    }
+}
+
+impl Drop for GroupSession {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.group_rollback();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::back_pressure::BackPressureConfig;
+    use crate::repository::content_memory::InMemoryContentRepository;
+
+    fn make_session(input_connections: Vec<Arc<FlowConnection>>) -> GroupSession {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        GroupSession::new(content_repo, id_gen, input_connections)
+    }
+
+    fn make_flowfile(id: u64) -> FlowFile {
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    fn make_flowfile_with_time(id: u64, created_at_nanos: u64) -> FlowFile {
+        FlowFile {
+            id,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos,
+            lineage_start_id: id,
+            penalized_until_nanos: 0,
+        }
+    }
+
+    #[test]
+    fn create_returns_unique_ids() {
+        let mut session = make_session(vec![]);
+        let ff1 = session.create();
+        let ff2 = session.create();
+        assert_ne!(ff1.id, ff2.id);
+        assert!(ff1.id > 0);
+        assert!(ff2.id > 0);
+    }
+
+    #[test]
+    fn write_and_read_content() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        let data = Bytes::from_static(b"hello world");
+        let ff = session.write_content(ff, data.clone()).unwrap();
+        assert_eq!(ff.size, 11);
+        assert!(ff.content_claim.is_some());
+
+        let read_back = session.read_content(&ff).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    fn read_content_empty_when_no_claim() {
+        let session = make_session(vec![]);
+        let ff = make_flowfile(1);
+        let content = session.read_content(&ff).unwrap();
+        assert!(content.is_empty());
+    }
+
+    #[test]
+    fn transfer_buffers_pending() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        session.transfer(ff, &runifi_plugin_api::REL_SUCCESS);
+
+        let transfers = session.take_transfers();
+        assert_eq!(transfers.len(), 1);
+        assert_eq!(transfers[0].1, "success");
+    }
+
+    #[test]
+    fn commit_is_noop() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        session.transfer(ff, &runifi_plugin_api::REL_SUCCESS);
+        session.commit();
+        // commit() is a no-op — session should NOT be marked committed.
+        assert!(!session.is_committed());
+    }
+
+    #[test]
+    fn group_commit_marks_committed() {
+        let mut session = make_session(vec![]);
+        session.group_commit();
+        assert!(session.is_committed());
+    }
+
+    #[test]
+    fn group_commit_decrements_refs_for_removed() {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        let mut session = GroupSession::new(content_repo.clone(), id_gen, vec![]);
+
+        let ff = session.create();
+        let data = Bytes::from_static(b"to be removed");
+        let ff = session.write_content(ff, data).unwrap();
+        let claim = ff.content_claim.clone().unwrap();
+
+        session.remove(ff);
+        // Before group_commit, content should still be accessible.
+        assert!(content_repo.read(&claim).is_ok());
+
+        session.group_commit();
+        // After group_commit, content should be freed.
+        assert!(content_repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn group_rollback_returns_flowfiles_to_input() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(42)).unwrap();
+        assert_eq!(conn.count(), 1);
+
+        let mut session = make_session(vec![conn.clone()]);
+        let ff = session.get().unwrap();
+        assert_eq!(ff.id, 42);
+        assert_eq!(conn.count(), 0);
+
+        session.group_rollback();
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn group_rollback_cleans_up_created_content() {
+        let content_repo = Arc::new(InMemoryContentRepository::new());
+        let id_gen = Arc::new(IdGenerator::new());
+        let mut session = GroupSession::new(content_repo.clone(), id_gen, vec![]);
+
+        let ff = session.create();
+        let data = Bytes::from_static(b"will be rolled back");
+        let ff = session.write_content(ff, data).unwrap();
+        let claim = ff.content_claim.clone().unwrap();
+
+        assert!(content_repo.read(&claim).is_ok());
+
+        session.group_rollback();
+        assert!(content_repo.read(&claim).is_err());
+    }
+
+    #[test]
+    fn drop_without_commit_triggers_rollback() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(99)).unwrap();
+
+        {
+            let mut session = make_session(vec![conn.clone()]);
+            let _ff = session.get().unwrap();
+            assert_eq!(conn.count(), 0);
+            // Drop without group_commit.
+        }
+
+        // FlowFile should be back in the connection via auto-rollback.
+        assert_eq!(conn.count(), 1);
+    }
+
+    #[test]
+    fn internal_queue_fed_and_consumed() {
+        let mut session = make_session(vec![]);
+
+        let ff1 = make_flowfile(1);
+        let ff2 = make_flowfile(2);
+        session.feed_internal(vec![ff1, ff2]);
+
+        let got1 = session.get().unwrap();
+        assert_eq!(got1.id, 1);
+        let got2 = session.get().unwrap();
+        assert_eq!(got2.id, 2);
+        assert!(session.get().is_none());
+    }
+
+    #[test]
+    fn internal_queue_consumed_before_input_connections() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile_with_time(10, 100)).unwrap();
+
+        let mut session = make_session(vec![conn]);
+        session.feed_internal(vec![make_flowfile(1)]);
+
+        // Internal queue item should come first.
+        let got = session.get().unwrap();
+        assert_eq!(got.id, 1);
+
+        // Then from input connection.
+        let got = session.get().unwrap();
+        assert_eq!(got.id, 10);
+    }
+
+    #[test]
+    fn get_batch_drains_internal_queue_first() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile_with_time(10, 100)).unwrap();
+        conn.try_send(make_flowfile_with_time(11, 200)).unwrap();
+
+        let mut session = make_session(vec![conn]);
+        session.feed_internal(vec![make_flowfile(1), make_flowfile(2)]);
+
+        let batch = session.get_batch(3);
+        assert_eq!(batch.len(), 3);
+        assert_eq!(batch[0].id, 1); // internal
+        assert_eq!(batch[1].id, 2); // internal
+        assert_eq!(batch[2].id, 10); // from connection
+    }
+
+    #[test]
+    fn clone_flowfile_shares_content() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        let data = Bytes::from_static(b"shared content");
+        let ff = session.write_content(ff, data.clone()).unwrap();
+
+        let cloned = session.clone_flowfile(&ff);
+        assert_ne!(cloned.id, ff.id);
+        assert_eq!(cloned.content_claim, ff.content_claim);
+        assert_eq!(cloned.size, ff.size);
+
+        let original_content = session.read_content(&ff).unwrap();
+        let cloned_content = session.read_content(&cloned).unwrap();
+        assert_eq!(original_content, cloned_content);
+    }
+
+    #[test]
+    fn penalize_sets_future_timestamp() {
+        let mut session = make_session(vec![]);
+        let ff = session.create();
+        assert_eq!(ff.penalized_until_nanos, 0);
+
+        let penalized = session.penalize(ff);
+        assert!(penalized.penalized_until_nanos > 0);
+    }
+
+    #[test]
+    fn acquired_count_tracks_gets_from_connections() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        for i in 0..3 {
+            conn.try_send(make_flowfile(i)).unwrap();
+        }
+
+        let mut session = make_session(vec![conn]);
+        session.get();
+        session.get();
+        assert_eq!(session.acquired_count(), 2);
+    }
+
+    #[test]
+    fn internal_queue_does_not_count_as_acquired() {
+        let mut session = make_session(vec![]);
+        session.feed_internal(vec![make_flowfile(1), make_flowfile(2)]);
+        session.get();
+        session.get();
+        // Internal queue items are not from input connections.
+        assert_eq!(session.acquired_count(), 0);
+    }
+
+    #[test]
+    fn group_rollback_clears_internal_queue() {
+        let mut session = make_session(vec![]);
+        session.feed_internal(vec![make_flowfile(1), make_flowfile(2)]);
+
+        session.group_rollback();
+
+        assert!(session.get().is_none());
+    }
+
+    #[test]
+    fn get_from_input_connection() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        conn.try_send(make_flowfile(42)).unwrap();
+
+        let mut session = make_session(vec![conn]);
+        let ff = session.get().unwrap();
+        assert_eq!(ff.id, 42);
+    }
+
+    #[test]
+    fn get_returns_none_when_empty() {
+        let conn = Arc::new(FlowConnection::new("test", BackPressureConfig::default()));
+        let mut session = make_session(vec![conn]);
+        assert!(session.get().is_none());
+    }
+}

--- a/crates/runifi-core/src/session/mod.rs
+++ b/crates/runifi-core/src/session/mod.rs
@@ -1,1 +1,2 @@
+pub mod group_session;
 pub mod process_session;

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -1229,6 +1229,7 @@ fn restore_process_groups(
             default_back_pressure_count: pg.default_back_pressure_count,
             default_back_pressure_bytes: pg.default_back_pressure_bytes,
             default_flowfile_expiration_ms: pg.default_flowfile_expiration_ms,
+            execution_mode: runifi_core::engine::process_group::ExecutionMode::default(),
         });
     }
 


### PR DESCRIPTION
## Summary

Implements a stateless execution engine for Process Groups, enabling exactly-once semantics where all processors in a group share a single transaction. If any processor fails, the entire group rolls back.

- Added `ExecutionMode` enum (`Standard` / `Stateless`) to `ProcessGroupInfo`
- Implemented `GroupSession` — a transactional session spanning all processors in a stateless group, with internal FlowFile queue for inter-processor transfers
- Implemented `StatelessExecutor` — runs processors sequentially with shared transaction, retry support, and panic isolation via `catch_unwind`

## Changes

- **`crates/runifi-core/src/engine/process_group.rs`**: Added `ExecutionMode` enum and `execution_mode` field to `ProcessGroupInfo`
- **`crates/runifi-core/src/session/group_session.rs`** (new): `GroupSession` implementing `ProcessSession` with deferred commit/rollback, internal queue for inter-processor FlowFile passing, FIFO input ordering
- **`crates/runifi-core/src/engine/stateless_executor.rs`** (new): `StatelessExecutor` with `execute()` method — runs processor chain as single transaction, retries on failure, panics roll back
- **`crates/runifi-core/src/engine/mod.rs`**: Registered `stateless_executor` module
- **`crates/runifi-core/src/session/mod.rs`**: Registered `group_session` module

## Test plan

- [x] GroupSession: create, read/write content, transfer, commit no-op, group_commit, group_rollback
- [x] GroupSession: internal queue priority over input connections, acquired_count tracking
- [x] GroupSession: Drop triggers rollback, content cleanup on rollback
- [x] StatelessExecutor: successful two-processor chain
- [x] StatelessExecutor: failure in second processor rolls back everything
- [x] StatelessExecutor: panic in processor rolls back everything
- [x] StatelessExecutor: retry succeeds within limit
- [x] StatelessExecutor: retry exhausted rolls back
- [x] StatelessExecutor: content sharing between processors in chain
- [x] StatelessExecutor: empty chain succeeds
- [x] StatelessExecutor: first processor failure rolls back
- [x] All existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` clean

Closes #267