### PR TITLE
feat: run-once processor execution (#289)

### DIFF
--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -918,6 +918,30 @@ pub struct RevertResponse {
     pub message: String,
 }
 
+// ── Run-once DTOs ─────────────────────────────────────────────────────
+
+/// Response for `POST /api/v1/processors/{name}/run-once`.
+#[derive(Serialize)]
+pub struct RunOnceResponse {
+    /// Name of the processor that was triggered.
+    pub processor: String,
+    /// Whether the invocation completed successfully.
+    pub success: bool,
+    /// Execution duration in milliseconds.
+    pub duration_ms: u64,
+    /// Number of FlowFiles acquired from input connections.
+    pub flowfiles_in: u64,
+    /// Number of FlowFiles routed to output connections.
+    pub flowfiles_out: u64,
+    /// Total bytes read from input FlowFiles.
+    pub bytes_in: u64,
+    /// Total bytes written to output FlowFiles.
+    pub bytes_out: u64,
+    /// Error message if the invocation failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runifi-api/src/routes/processors.rs
+++ b/crates/runifi-api/src/routes/processors.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::dto::{
     CreateProcessorRequest, ProcessorConfigResponse, ProcessorConfigUpdateRequest,
-    ProcessorDetailResponse, ProcessorResponse, RelationshipResponse, UpdatePositionRequest,
+    ProcessorDetailResponse, ProcessorResponse, RelationshipResponse, RunOnceResponse,
+    UpdatePositionRequest,
 };
 use crate::error::ApiError;
 use crate::rbac;
@@ -40,6 +41,7 @@ pub fn routes() -> Router<ApiState> {
         .route("/api/v1/processors/{name}/disable", put(disable_processor))
         .route("/api/v1/processors/{name}/enable", put(enable_processor))
         .route("/api/v1/processors/{name}/validation", get(get_validation))
+        .route("/api/v1/processors/{name}/run-once", post(run_once))
         .route(
             "/api/v1/processors/{name}/state",
             delete_method(clear_processor_state),
@@ -487,6 +489,34 @@ async fn get_validation(
         "valid": errors.is_empty(),
         "errors": errors,
     })))
+}
+
+// ── Run-once ─────────────────────────────────────────────────────────────────
+
+/// POST /api/v1/processors/{name}/run-once
+///
+/// Trigger a single `on_trigger` invocation on a stopped processor.
+/// Returns execution result including duration, FlowFile counts, and any errors.
+async fn run_once(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+) -> Result<Json<RunOnceResponse>, ApiError> {
+    let result = state
+        .handle
+        .run_once_processor(&name)
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Json(RunOnceResponse {
+        processor: name,
+        success: result.success,
+        duration_ms: result.duration_ms,
+        flowfiles_in: result.flowfiles_in,
+        flowfiles_out: result.flowfiles_out,
+        bytes_in: result.bytes_in,
+        bytes_out: result.bytes_out,
+        error: result.error,
+    }))
 }
 
 // ── Processor State Endpoints ─────────────────────────────────────────────────

--- a/crates/runifi-core/src/audit/event.rs
+++ b/crates/runifi-core/src/audit/event.rs
@@ -97,6 +97,7 @@ pub enum AuditAction {
     ProcessorStopped,
     ProcessorPaused,
     ProcessorResumed,
+    ProcessorRunOnce,
     // Configuration
     ProcessorConfigured,
     // Data access

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use super::bulletin::BulletinBoard;
-use super::metrics::ProcessorMetrics;
+use super::metrics::{ProcessorMetrics, RunOnceResult};
 use super::mutation::{MutationCommand, MutationError};
 use super::persistence::{
     FlowPersistence, PersistedBackPressure, PersistedConnection, PersistedFlowState,
@@ -479,6 +479,87 @@ impl EngineHandle {
             }
         }
         Err(format!("Processor '{}' not found", name))
+    }
+
+    // ── Run-once ──────────────────────────────────────────────────────────────
+
+    /// Trigger a single `on_trigger` invocation on a stopped processor.
+    ///
+    /// The processor must be stopped (not enabled, not active, not disabled).
+    /// Returns a `RunOnceResult` with execution details, or an error if the
+    /// request cannot be fulfilled.
+    pub async fn run_once_processor(&self, name: &str) -> Result<RunOnceResult, ConfigUpdateError> {
+        let info = self
+            .processors
+            .read()
+            .iter()
+            .find(|p| p.name == name)
+            .cloned()
+            .ok_or_else(|| ConfigUpdateError::NotFound(format!("Processor not found: {}", name)))?;
+
+        // Validate the processor is stopped.
+        let enabled = info.metrics.enabled.load(Ordering::Relaxed);
+        let active = info.metrics.active.load(Ordering::Relaxed);
+        let disabled = info.metrics.disabled.load(Ordering::Relaxed);
+
+        if disabled {
+            return Err(ConfigUpdateError::StateConflict(format!(
+                "Cannot run-once processor '{}': processor is disabled",
+                name
+            )));
+        }
+        if enabled || active {
+            return Err(ConfigUpdateError::StateConflict(format!(
+                "Cannot run-once processor '{}': processor must be stopped",
+                name
+            )));
+        }
+
+        // Check that no other run-once is in flight and set up the channel.
+        let rx = {
+            let mut tx_guard = info.metrics.run_once_result_tx.lock();
+            if tx_guard.is_some() {
+                return Err(ConfigUpdateError::StateConflict(format!(
+                    "Cannot run-once processor '{}': another run-once is already in progress",
+                    name
+                )));
+            }
+            let (tx, rx) = oneshot::channel();
+            *tx_guard = Some(tx);
+            rx
+            // tx_guard dropped here
+        };
+
+        // Signal the processor task to execute.
+        info.metrics
+            .run_once_requested
+            .store(true, Ordering::Relaxed);
+
+        // Log audit event.
+        self.audit_logger.log(&AuditEvent::success(
+            AuditAction::ProcessorRunOnce,
+            AuditTarget::processor(name),
+        ));
+
+        // Await result with 60-second timeout.
+        match tokio::time::timeout(std::time::Duration::from_secs(60), rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => Err(ConfigUpdateError::StateConflict(format!(
+                "Run-once for processor '{}': result channel closed unexpectedly",
+                name
+            ))),
+            Err(_) => {
+                // Timeout — clear the flag and channel.
+                info.metrics
+                    .run_once_requested
+                    .store(false, Ordering::Relaxed);
+                let _ = info.metrics.run_once_result_tx.lock().take();
+                Err(ConfigUpdateError::StateConflict(format!(
+                    "Run-once for processor '{}' timed out after 60 seconds",
+                    name
+                )))
+            }
+        }
     }
 
     // ── Reads ────────────────────────────────────────────────────────────────

--- a/crates/runifi-core/src/engine/metrics.rs
+++ b/crates/runifi-core/src/engine/metrics.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use parking_lot::Mutex;
+use serde::Serialize;
 
 /// Number of one-second buckets in the rolling window (5 minutes).
 const WINDOW_SECS: usize = 300;
@@ -150,6 +151,25 @@ pub struct RollingSnapshot {
     pub bytes_out_rate: f64,
 }
 
+/// Result of a single run-once processor execution.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunOnceResult {
+    /// Whether the invocation completed successfully.
+    pub success: bool,
+    /// Execution duration in milliseconds.
+    pub duration_ms: u64,
+    /// Number of FlowFiles acquired from input connections.
+    pub flowfiles_in: u64,
+    /// Number of FlowFiles routed to output connections.
+    pub flowfiles_out: u64,
+    /// Total bytes read from input FlowFiles.
+    pub bytes_in: u64,
+    /// Total bytes written to output FlowFiles.
+    pub bytes_out: u64,
+    /// Error message if the invocation failed.
+    pub error: Option<String>,
+}
+
 /// Shared processor metrics — atomics for zero-contention reads from the API.
 ///
 /// The processor loop writes to these atomics; the API reads them.
@@ -180,6 +200,10 @@ pub struct ProcessorMetrics {
     validation_errors: Mutex<Vec<String>>,
     /// 5-minute rolling window — guarded by a lightweight mutex (only held during tick).
     rolling: Mutex<RollingWindow>,
+    /// API sets this flag to request a single run-once invocation on a stopped processor.
+    pub run_once_requested: AtomicBool,
+    /// Channel sender for returning the run-once result to the API caller.
+    pub run_once_result_tx: Mutex<Option<tokio::sync::oneshot::Sender<RunOnceResult>>>,
 }
 
 impl ProcessorMetrics {
@@ -201,6 +225,8 @@ impl ProcessorMetrics {
             disabled: AtomicBool::new(false),
             validation_errors: Mutex::new(Vec::new()),
             rolling: Mutex::new(RollingWindow::new()),
+            run_once_requested: AtomicBool::new(false),
+            run_once_result_tx: Mutex::new(None),
         }
     }
 
@@ -472,5 +498,42 @@ mod tests {
         let snap = w.snapshot();
         assert_eq!(snap.flowfiles_in_5m, 100);
         assert_eq!(snap.flowfiles_out_5m, 50);
+    }
+
+    #[test]
+    fn run_once_result_fields() {
+        let result = RunOnceResult {
+            success: true,
+            duration_ms: 42,
+            flowfiles_in: 5,
+            flowfiles_out: 3,
+            bytes_in: 1024,
+            bytes_out: 512,
+            error: None,
+        };
+        assert!(result.success);
+        assert_eq!(result.duration_ms, 42);
+        assert_eq!(result.flowfiles_in, 5);
+        assert_eq!(result.flowfiles_out, 3);
+        assert!(result.error.is_none());
+
+        let failed = RunOnceResult {
+            success: false,
+            duration_ms: 10,
+            flowfiles_in: 0,
+            flowfiles_out: 0,
+            bytes_in: 0,
+            bytes_out: 0,
+            error: Some("test error".to_string()),
+        };
+        assert!(!failed.success);
+        assert_eq!(failed.error.as_deref(), Some("test error"));
+    }
+
+    #[test]
+    fn processor_metrics_run_once_fields_default() {
+        let m = ProcessorMetrics::new();
+        assert!(!m.run_once_requested.load(Ordering::Relaxed));
+        assert!(m.run_once_result_tx.lock().is_none());
     }
 }

--- a/crates/runifi-core/src/engine/processor_node.rs
+++ b/crates/runifi-core/src/engine/processor_node.rs
@@ -15,7 +15,7 @@ use runifi_plugin_api::state::StateManager;
 use runifi_plugin_api::{FlowFile, Processor};
 
 use super::bulletin::{BulletinBoard, BulletinSeverity};
-use super::metrics::ProcessorMetrics;
+use super::metrics::{ProcessorMetrics, RunOnceResult};
 use super::supervisor::{InvocationResult, ProcessorSupervisor};
 use crate::cluster::load_balance::{LoadBalanceStrategy, LoadBalancer};
 use crate::connection::flow_connection::FlowConnection;
@@ -297,9 +297,15 @@ impl ProcessorNode {
     /// false, the inner processing loop breaks cleanly, and the task waits
     /// until `enabled` is set back to true (or the cancellation token fires).
     pub async fn run(mut self) {
+        // Clone Arc references so closures don't borrow `self`, allowing
+        // mutable borrows of `self` elsewhere in the lifecycle loop.
+        let service_registry_ref = self.service_registry.clone();
+        let state_provider_ref = self.state_provider.clone();
+        let processor_name = self.name.clone();
+
         // Last context, kept for on_stopped after lifecycle loop exits.
         let make_service_lookup = || -> Option<Box<dyn ServiceLookup>> {
-            self.service_registry
+            service_registry_ref
                 .as_ref()
                 .map(|r| -> Box<dyn ServiceLookup> {
                     Box::new(RegistryServiceLookup::new(r.clone()))
@@ -307,10 +313,10 @@ impl ProcessorNode {
         };
 
         let make_state_manager = || -> Option<Box<dyn StateManager>> {
-            self.state_provider.as_ref().map(|p| {
+            state_provider_ref.as_ref().map(|p| {
                 Box::new(crate::repository::state_provider::CoreStateManager::new(
                     p.clone(),
-                    self.name.clone(),
+                    processor_name.clone(),
                 )) as Box<dyn StateManager>
             })
         };
@@ -380,12 +386,24 @@ impl ProcessorNode {
                 state_manager: make_state_manager(),
             };
             // Wait until the processor is enabled and not disabled (or cancelled).
+            // While stopped, also check for run-once requests (only on primary task).
             loop {
                 let enabled = self.metrics.enabled.load(Ordering::Relaxed);
                 let disabled = self.metrics.disabled.load(Ordering::Relaxed);
                 if enabled && !disabled {
                     break;
                 }
+
+                // Check for run-once request (only primary task handles run-once).
+                if self.task_index == 0
+                    && self
+                        .metrics
+                        .run_once_requested
+                        .swap(false, Ordering::Relaxed)
+                {
+                    self.execute_run_once();
+                }
+
                 tokio::select! {
                     _ = self.cancel_token.cancelled() => {
                         tracing::info!(processor = %self.name, "Processor exiting (cancelled while stopped)");
@@ -677,6 +695,174 @@ impl ProcessorNode {
         self.metrics.active.store(false, Ordering::Relaxed);
         self.supervisor.on_stopped(&last_ctx);
         tracing::info!(processor = %self.name, "Processor stopped");
+    }
+
+    /// Execute a single run-once invocation on a stopped processor.
+    ///
+    /// This mirrors the normal trigger path (on_scheduled -> invoke -> route -> on_stopped)
+    /// but runs exactly once and sends the result back through the oneshot channel.
+    fn execute_run_once(&mut self) {
+        let start = std::time::Instant::now();
+
+        // Take the oneshot sender from metrics. If absent, someone else grabbed it.
+        let result_tx = self.metrics.run_once_result_tx.lock().take();
+        let Some(result_tx) = result_tx else {
+            tracing::warn!(processor = %self.name, "Run-once requested but no result channel found");
+            return;
+        };
+
+        let service_lookup: Option<Box<dyn ServiceLookup>> = self
+            .service_registry
+            .as_ref()
+            .map(|r| -> Box<dyn ServiceLookup> { Box::new(RegistryServiceLookup::new(r.clone())) });
+
+        let state_manager: Option<Box<dyn StateManager>> = self.state_provider.as_ref().map(|p| {
+            Box::new(crate::repository::state_provider::CoreStateManager::new(
+                p.clone(),
+                self.name.clone(),
+            )) as Box<dyn StateManager>
+        });
+
+        let ctx = NodeProcessContext {
+            name: self.name.clone(),
+            id: self.id.clone(),
+            properties: self.properties.read().clone(),
+            yield_duration_ms: 1000,
+            service_lookup,
+            state_manager,
+        };
+
+        // Call on_scheduled.
+        if let Err(e) = self.supervisor.on_scheduled(&ctx) {
+            let elapsed = start.elapsed().as_millis() as u64;
+            tracing::error!(processor = %self.name, error = %e, "Run-once on_scheduled failed");
+            let _ = result_tx.send(RunOnceResult {
+                success: false,
+                duration_ms: elapsed,
+                flowfiles_in: 0,
+                flowfiles_out: 0,
+                bytes_in: 0,
+                bytes_out: 0,
+                error: Some(format!("on_scheduled failed: {e}")),
+            });
+            return;
+        }
+
+        // Snapshot input connections for the session.
+        let input_conns_snapshot: Vec<Arc<FlowConnection>> = self.input_connections.read().clone();
+
+        // Create session.
+        let mut session = CoreProcessSession::new(
+            self.content_repo.clone(),
+            self.id_gen.clone(),
+            input_conns_snapshot,
+            ctx.yield_duration_ms,
+            self.penalty_duration_ms,
+        );
+        session.set_provenance(
+            self.provenance_repo.clone(),
+            self.name.clone(),
+            self.type_name.clone(),
+        );
+
+        // Invoke with fault isolation.
+        let result = self
+            .supervisor
+            .invoke(&ctx, &mut session as &mut dyn ProcessSession);
+
+        // Sync supervisor metrics.
+        self.metrics.sync_from_supervisor(
+            self.supervisor.total_invocations(),
+            self.supervisor.total_failures(),
+            self.supervisor.consecutive_failures(),
+            self.supervisor.is_circuit_open(),
+        );
+
+        // Track input metrics.
+        let acquired = session.acquired_count();
+        let acquired_bytes = session.acquired_bytes();
+        if acquired > 0 {
+            self.metrics
+                .flowfiles_in
+                .fetch_add(acquired as u64, Ordering::Relaxed);
+            self.metrics
+                .bytes_in
+                .fetch_add(acquired_bytes, Ordering::Relaxed);
+        }
+
+        let (success, error_msg, ff_out, bytes_out_total) = match &result {
+            InvocationResult::Success | InvocationResult::Yield => {
+                if session.is_committed() {
+                    let (ff_out, bytes_out, routed) = self.route_transfers(&mut session);
+                    self.metrics
+                        .flowfiles_out
+                        .fetch_add(ff_out, Ordering::Relaxed);
+                    self.metrics
+                        .bytes_out
+                        .fetch_add(bytes_out, Ordering::Relaxed);
+
+                    // WAL commit.
+                    let remove_ids = session.take_committed_remove_ids();
+                    if !routed.is_empty() || !remove_ids.is_empty() {
+                        let mut ops: Vec<FlowFileOp<'_>> = Vec::new();
+                        for (ff, conn_id) in &routed {
+                            ops.push(FlowFileOp::Upsert {
+                                flowfile: ff,
+                                queue_id: conn_id,
+                            });
+                        }
+                        for id in &remove_ids {
+                            ops.push(FlowFileOp::Delete { id: *id });
+                        }
+                        if let Err(e) = self.flowfile_repo.commit_batch(&ops) {
+                            tracing::error!(
+                                processor = %self.name,
+                                error = %e,
+                                "Run-once WAL commit_batch failed"
+                            );
+                        }
+                    }
+
+                    (true, None, ff_out, bytes_out)
+                } else {
+                    (true, None, 0, 0)
+                }
+            }
+            InvocationResult::Failed(e) => {
+                let redacted_err = self.redact_message(&e.to_string());
+                tracing::warn!(processor = %self.name, error = %redacted_err, "Run-once failed");
+                session.rollback();
+                (false, Some(redacted_err), 0, 0)
+            }
+            InvocationResult::Panic(msg) => {
+                let redacted_msg = self.redact_message(msg);
+                tracing::error!(processor = %self.name, panic = %redacted_msg, "Run-once panicked");
+                (false, Some(format!("panic: {redacted_msg}")), 0, 0)
+            }
+        };
+
+        // Call on_stopped.
+        self.supervisor.on_stopped(&ctx);
+
+        let elapsed = start.elapsed().as_millis() as u64;
+        tracing::info!(
+            processor = %self.name,
+            success = success,
+            duration_ms = elapsed,
+            ff_in = acquired,
+            ff_out = ff_out,
+            "Run-once completed"
+        );
+
+        let _ = result_tx.send(RunOnceResult {
+            success,
+            duration_ms: elapsed,
+            flowfiles_in: acquired as u64,
+            flowfiles_out: ff_out,
+            bytes_in: acquired_bytes,
+            bytes_out: bytes_out_total,
+            error: error_msg,
+        });
     }
 
     async fn wait_for_trigger(&self) {


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/processors/{id}/run-once` endpoint for single-invocation processor execution
- Implement `run_once` on `ProcessorNode` — executes exactly one `on_trigger` invocation
- Processor must be in Stopped state; remains Stopped after execution
- Returns execution result (success/failure, duration, FlowFiles processed)
- Respects `catch_unwind` and supervisor fault tolerance
- Updates rolling metrics for the single execution
- Add `RunOnce` audit event type

## Changes

- `crates/runifi-core/src/engine/processor_node.rs` — `run_once()` method with full fault isolation
- `crates/runifi-core/src/engine/handle.rs` — `run_once_processor()` on EngineHandle
- `crates/runifi-core/src/engine/metrics.rs` — run-once result tracking
- `crates/runifi-api/src/routes/processors.rs` — REST endpoint
- `crates/runifi-api/src/dto.rs` — `RunOnceResult` DTO
- `crates/runifi-core/src/audit/event.rs` — `RunOnce` audit event

## Test plan

- [ ] Verify `run-once` on stopped processor executes exactly once
- [ ] Verify running/invalid processors are rejected
- [ ] Verify metrics are updated
- [ ] CI passes

Closes #289