### PR TITLE
fix: add validation check and bulletin entries for run-once (#289)

### DIFF
--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -508,6 +508,17 @@ impl EngineHandle {
                 name
             )));
         }
+
+        // Reject if processor has validation errors.
+        let validation_errors = info.metrics.validation_errors();
+        if !validation_errors.is_empty() {
+            return Err(ConfigUpdateError::ValidationError(format!(
+                "Cannot run-once processor '{}': validation errors: {}",
+                name,
+                validation_errors.join("; ")
+            )));
+        }
+
         if enabled || active {
             return Err(ConfigUpdateError::StateConflict(format!(
                 "Cannot run-once processor '{}': processor must be stopped",

--- a/crates/runifi-core/src/engine/processor_node.rs
+++ b/crates/runifi-core/src/engine/processor_node.rs
@@ -831,12 +831,30 @@ impl ProcessorNode {
             InvocationResult::Failed(e) => {
                 let redacted_err = self.redact_message(&e.to_string());
                 tracing::warn!(processor = %self.name, error = %redacted_err, "Run-once failed");
+                self.bulletin_board.add(
+                    &self.name,
+                    BulletinSeverity::Warn,
+                    format!(
+                        "Run-once failed (consecutive: {}): {}",
+                        self.supervisor.consecutive_failures(),
+                        redacted_err
+                    ),
+                );
                 session.rollback();
                 (false, Some(redacted_err), 0, 0)
             }
             InvocationResult::Panic(msg) => {
                 let redacted_msg = self.redact_message(msg);
                 tracing::error!(processor = %self.name, panic = %redacted_msg, "Run-once panicked");
+                self.bulletin_board.add(
+                    &self.name,
+                    BulletinSeverity::Error,
+                    format!(
+                        "Run-once panicked (consecutive: {}): {}",
+                        self.supervisor.consecutive_failures(),
+                        redacted_msg
+                    ),
+                );
                 (false, Some(format!("panic: {redacted_msg}")), 0, 0)
             }
         };


### PR DESCRIPTION
## Summary

Follow-up improvements to the run-once processor execution feature (#289, merged in PR #298):

- Add processor validation error check before allowing run-once execution (rejects processors with missing required properties or invalid values)
- Add bulletin board entries for failed and panicked run-once invocations (makes failures visible in the dashboard bulletin panel)

## Changes

- **`runifi-core/engine/handle.rs`**: Add `validation_errors()` check in `run_once_processor()` between disabled and enabled checks, returning `ConfigUpdateError::ValidationError`
- **`runifi-core/engine/processor_node.rs`**: Add `bulletin_board.add()` calls in `execute_run_once()` for `Failed` (Warn) and `Panic` (Error) match arms

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [ ] CI pipeline passes

Closes #289