### PR TITLE
feat: cluster-scoped state and primary node only scheduling (#268)

### DIFF
--- a/crates/runifi-core/src/cluster/coordinator.rs
+++ b/crates/runifi-core/src/cluster/coordinator.rs
@@ -960,6 +960,11 @@ fn process_message(
             None
         }
 
+        MessagePayload::StateUpdate(_) | MessagePayload::StateSync(_) => {
+            // State replication messages — handled by the state replication layer (Phase 3).
+            None
+        }
+
         MessagePayload::FlowSyncResponse(_)
         | MessagePayload::JoinResponse(_)
         | MessagePayload::HeartbeatAck(_)

--- a/crates/runifi-core/src/cluster/mod.rs
+++ b/crates/runifi-core/src/cluster/mod.rs
@@ -39,6 +39,7 @@ pub mod node;
 pub mod protocol;
 pub mod quorum;
 pub mod replication;
+pub mod state;
 
 pub use config::ClusterConfig;
 pub use coordinator::ClusterCoordinator;
@@ -49,6 +50,7 @@ pub use load_balance::LoadBalanceStrategy;
 pub use node::{ClusterNodeId, ClusterRole, NodeInfo, NodeState, NodeSummary};
 pub use quorum::QuorumState;
 pub use replication::FlowReplicator;
+pub use state::{ClusterStateProvider, SharedClusterStateProvider};
 
 /// Extract a node ID from an address string like "node-1:9443".
 pub(crate) fn extract_node_id(addr: &str) -> String {

--- a/crates/runifi-core/src/cluster/protocol.rs
+++ b/crates/runifi-core/src/cluster/protocol.rs
@@ -9,6 +9,8 @@
 //! └──────────┴────────────────────────┘
 //! ```
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::election::ElectionRole;
@@ -93,6 +95,12 @@ pub enum MessagePayload {
     // ── Bulletins (Phase 2) ───────────────────────────────────────────
     /// Forward a bulletin from a remote node to the coordinator.
     BulletinForward(BulletinForwardData),
+
+    // ── State replication (Phase 3) ─────────────────────────────────
+    /// Cluster state update from coordinator.
+    StateUpdate(StateUpdateData),
+    /// Full state sync response (for joining nodes).
+    StateSync(StateSyncData),
 }
 
 // ── Heartbeat types ──────────────────────────────────────────────────────────
@@ -268,6 +276,24 @@ pub struct BulletinForwardData {
     pub message: String,
     /// Unix timestamp in milliseconds.
     pub timestamp_ms: u64,
+}
+
+// ── State replication types ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateUpdateData {
+    /// The component (processor) whose state was updated.
+    pub component_id: String,
+    /// The key-value state entries.
+    pub entries: HashMap<String, String>,
+    /// Version of this state snapshot.
+    pub version: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateSyncData {
+    /// Full state snapshot for all components, keyed by component ID.
+    pub states: HashMap<String, StateUpdateData>,
 }
 
 // ── Wire format helpers ──────────────────────────────────────────────────────

--- a/crates/runifi-core/src/cluster/state.rs
+++ b/crates/runifi-core/src/cluster/state.rs
@@ -1,0 +1,359 @@
+//! Cluster-scoped state provider for shared processor state.
+//!
+//! Mirrors the local state provider pattern but stores state under
+//! `state/cluster/{component-id}/state.json`. In a single-node deployment
+//! this behaves identically to local state. Once gossip-based state
+//! replication is enabled (Phase 3), the coordinator will broadcast
+//! `StateUpdate` messages to keep all nodes converged.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+use runifi_plugin_api::result::{PluginError, ProcessResult};
+use runifi_plugin_api::state::StateMap;
+
+/// On-disk representation of processor state.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedState {
+    version: i64,
+    entries: HashMap<String, String>,
+}
+
+/// In-memory state with a version counter, protected by a mutex.
+#[derive(Debug)]
+struct ProcessorState {
+    version: i64,
+    entries: HashMap<String, String>,
+}
+
+impl ProcessorState {
+    fn empty() -> Self {
+        Self {
+            version: -1,
+            entries: HashMap::new(),
+        }
+    }
+
+    fn to_state_map(&self) -> StateMap {
+        StateMap::new(self.entries.clone(), self.version)
+    }
+}
+
+/// Cluster-scoped state provider that manages shared state for all processors.
+///
+/// Thread-safe: uses per-component mutexes so concurrent access to different
+/// components does not contend.
+///
+/// In single-node mode this is a local file-backed store under `state/cluster/`.
+/// In multi-node mode the coordinator will replicate state updates via the
+/// `StateUpdate` / `StateSync` protocol messages.
+pub struct ClusterStateProvider {
+    /// Root directory for cluster state storage (e.g., `state/cluster/`).
+    base_dir: PathBuf,
+    /// Per-component state, lazily loaded from disk.
+    states: dashmap::DashMap<String, Arc<Mutex<ProcessorState>>>,
+}
+
+impl ClusterStateProvider {
+    /// Create a new cluster state provider rooted at the given directory.
+    ///
+    /// The directory is created if it does not exist.
+    pub fn new(base_dir: impl Into<PathBuf>) -> ProcessResult<Self> {
+        let base_dir = base_dir.into();
+        std::fs::create_dir_all(&base_dir)?;
+        Ok(Self {
+            base_dir,
+            states: dashmap::DashMap::new(),
+        })
+    }
+
+    /// Get or lazily load state for a component.
+    fn get_or_load(&self, component_id: &str) -> Arc<Mutex<ProcessorState>> {
+        if let Some(entry) = self.states.get(component_id) {
+            return entry.clone();
+        }
+
+        // Load from disk or create empty.
+        let state = self
+            .load_from_disk(component_id)
+            .unwrap_or_else(ProcessorState::empty);
+
+        let state = Arc::new(Mutex::new(state));
+        self.states
+            .entry(component_id.to_string())
+            .or_insert(state.clone());
+
+        // Re-fetch in case another thread inserted first.
+        self.states.get(component_id).unwrap().clone()
+    }
+
+    /// Load state from disk for a component.
+    fn load_from_disk(&self, component_id: &str) -> Option<ProcessorState> {
+        let path = self.state_file_path(component_id);
+        let data = std::fs::read_to_string(&path).ok()?;
+        let persisted: PersistedState = serde_json::from_str(&data).ok()?;
+        Some(ProcessorState {
+            version: persisted.version,
+            entries: persisted.entries,
+        })
+    }
+
+    /// Persist state to disk for a component.
+    fn save_to_disk(&self, component_id: &str, state: &ProcessorState) -> ProcessResult<()> {
+        let dir = self.component_dir(component_id);
+        std::fs::create_dir_all(&dir)?;
+
+        let persisted = PersistedState {
+            version: state.version,
+            entries: state.entries.clone(),
+        };
+
+        let data = serde_json::to_string_pretty(&persisted).map_err(|e| {
+            PluginError::ProcessingFailed(format!("Failed to serialize cluster state: {}", e))
+        })?;
+
+        // Atomic write: write to temp file then rename.
+        let tmp_path = dir.join("state.json.tmp");
+        let final_path = dir.join("state.json");
+        std::fs::write(&tmp_path, data)?;
+        std::fs::rename(&tmp_path, &final_path)?;
+
+        Ok(())
+    }
+
+    /// Remove persisted state from disk for a component.
+    fn remove_from_disk(&self, component_id: &str) -> ProcessResult<()> {
+        let dir = self.component_dir(component_id);
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir)?;
+        }
+        Ok(())
+    }
+
+    /// Get the directory path for a component's state.
+    fn component_dir(&self, component_id: &str) -> PathBuf {
+        self.base_dir.join(sanitize_id(component_id))
+    }
+
+    /// Get the state file path for a component.
+    fn state_file_path(&self, component_id: &str) -> PathBuf {
+        self.component_dir(component_id).join("state.json")
+    }
+
+    /// Get the current state for a component.
+    pub fn get_state(&self, component_id: &str) -> ProcessResult<StateMap> {
+        let state = self.get_or_load(component_id);
+        let locked = state.lock();
+        Ok(locked.to_state_map())
+    }
+
+    /// Set the state for a component, replacing any existing state.
+    pub fn set_state(
+        &self,
+        component_id: &str,
+        entries: HashMap<String, String>,
+    ) -> ProcessResult<()> {
+        let state = self.get_or_load(component_id);
+        let mut locked = state.lock();
+        locked.version += 1;
+        locked.entries = entries;
+        self.save_to_disk(component_id, &locked)?;
+        Ok(())
+    }
+
+    /// Compare-and-swap: replace state only if the version matches.
+    ///
+    /// Returns `true` if replacement succeeded, `false` if version mismatch.
+    pub fn replace(
+        &self,
+        component_id: &str,
+        old_version: i64,
+        new_entries: HashMap<String, String>,
+    ) -> ProcessResult<bool> {
+        let state = self.get_or_load(component_id);
+        let mut locked = state.lock();
+
+        if locked.version != old_version {
+            return Ok(false);
+        }
+
+        locked.version += 1;
+        locked.entries = new_entries;
+        self.save_to_disk(component_id, &locked)?;
+        Ok(true)
+    }
+
+    /// Clear all state for a component (resets version to -1).
+    pub fn clear(&self, component_id: &str) -> ProcessResult<()> {
+        let state = self.get_or_load(component_id);
+        let mut locked = state.lock();
+        locked.version = -1;
+        locked.entries.clear();
+        self.remove_from_disk(component_id)?;
+        Ok(())
+    }
+
+    /// Remove all state for a component (called when processor is removed from flow).
+    pub fn remove_component(&self, component_id: &str) -> ProcessResult<()> {
+        self.states.remove(component_id);
+        self.remove_from_disk(component_id)
+    }
+}
+
+/// Shared reference to a ClusterStateProvider.
+pub type SharedClusterStateProvider = Arc<ClusterStateProvider>;
+
+/// Sanitize a component ID for use as a directory name.
+fn sanitize_id(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let state = provider.get_state("proc-1").unwrap();
+        assert!(state.is_empty());
+        assert_eq!(state.version(), -1);
+    }
+
+    #[test]
+    fn test_set_and_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let entries = HashMap::from([
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+        ]);
+        provider.set_state("proc-1", entries).unwrap();
+
+        let state = provider.get_state("proc-1").unwrap();
+        assert_eq!(state.version(), 0);
+        assert_eq!(state.get("key1"), Some("value1"));
+        assert_eq!(state.get("key2"), Some("value2"));
+    }
+
+    #[test]
+    fn test_replace_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let entries = HashMap::from([("k".to_string(), "v1".to_string())]);
+        provider.set_state("proc-1", entries).unwrap();
+
+        let new_entries = HashMap::from([("k".to_string(), "v2".to_string())]);
+        let replaced = provider.replace("proc-1", 0, new_entries).unwrap();
+        assert!(replaced);
+
+        let state = provider.get_state("proc-1").unwrap();
+        assert_eq!(state.version(), 1);
+        assert_eq!(state.get("k"), Some("v2"));
+    }
+
+    #[test]
+    fn test_replace_version_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let entries = HashMap::from([("k".to_string(), "v1".to_string())]);
+        provider.set_state("proc-1", entries).unwrap();
+
+        let new_entries = HashMap::from([("k".to_string(), "v2".to_string())]);
+        let replaced = provider.replace("proc-1", 99, new_entries).unwrap();
+        assert!(!replaced);
+
+        let state = provider.get_state("proc-1").unwrap();
+        assert_eq!(state.version(), 0);
+        assert_eq!(state.get("k"), Some("v1"));
+    }
+
+    #[test]
+    fn test_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let entries = HashMap::from([("k".to_string(), "v".to_string())]);
+        provider.set_state("proc-1", entries).unwrap();
+        provider.clear("proc-1").unwrap();
+
+        let state = provider.get_state("proc-1").unwrap();
+        assert!(state.is_empty());
+        assert_eq!(state.version(), -1);
+    }
+
+    #[test]
+    fn test_persistence_across_instances() {
+        let dir = tempfile::tempdir().unwrap();
+
+        {
+            let provider = ClusterStateProvider::new(dir.path()).unwrap();
+            let entries = HashMap::from([("cursor".to_string(), "100".to_string())]);
+            provider.set_state("proc-1", entries).unwrap();
+        }
+
+        {
+            let provider = ClusterStateProvider::new(dir.path()).unwrap();
+            let state = provider.get_state("proc-1").unwrap();
+            assert_eq!(state.version(), 0);
+            assert_eq!(state.get("cursor"), Some("100"));
+        }
+    }
+
+    #[test]
+    fn test_multiple_components() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let e1 = HashMap::from([("k".to_string(), "comp1".to_string())]);
+        let e2 = HashMap::from([("k".to_string(), "comp2".to_string())]);
+        provider.set_state("comp-1", e1).unwrap();
+        provider.set_state("comp-2", e2).unwrap();
+
+        assert_eq!(
+            provider.get_state("comp-1").unwrap().get("k"),
+            Some("comp1")
+        );
+        assert_eq!(
+            provider.get_state("comp-2").unwrap().get("k"),
+            Some("comp2")
+        );
+
+        provider.clear("comp-1").unwrap();
+        assert!(provider.get_state("comp-1").unwrap().is_empty());
+        assert_eq!(
+            provider.get_state("comp-2").unwrap().get("k"),
+            Some("comp2")
+        );
+    }
+
+    #[test]
+    fn test_remove_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = ClusterStateProvider::new(dir.path()).unwrap();
+
+        let entries = HashMap::from([("k".to_string(), "v".to_string())]);
+        provider.set_state("proc-1", entries).unwrap();
+        provider.remove_component("proc-1").unwrap();
+
+        let state = provider.get_state("proc-1").unwrap();
+        assert!(state.is_empty());
+    }
+}

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
@@ -25,6 +25,7 @@ use super::processor_node::{
     SharedOutputConnections,
 };
 use crate::audit::{AuditAction, AuditEvent, AuditLogger, AuditTarget, NullAuditLogger};
+use crate::cluster::state::SharedClusterStateProvider;
 use crate::connection::back_pressure::BackPressureConfig;
 use crate::connection::flow_connection::{FlowConnection, QueuePriority};
 use crate::connection::query::FlowConnectionQuery;
@@ -63,6 +64,9 @@ pub struct FlowEngine {
     service_registry: SharedServiceRegistry,
     provenance_repo: SharedProvenanceRepository,
     state_provider: Option<SharedLocalStateProvider>,
+    cluster_state_provider: Option<SharedClusterStateProvider>,
+    /// Shared flag indicating whether this node is the primary in the cluster.
+    is_primary_node: Arc<AtomicBool>,
 
     nodes: Vec<NodeBuilder>,
     connections: Vec<ConnBuilder>,
@@ -113,6 +117,8 @@ impl FlowEngine {
             service_registry: SharedServiceRegistry::new(),
             provenance_repo: Arc::new(InMemoryProvenanceRepository::new()),
             state_provider: None,
+            cluster_state_provider: None,
+            is_primary_node: Arc::new(AtomicBool::new(true)),
             nodes: Vec::new(),
             connections: Vec::new(),
             next_node_id: 0,
@@ -146,6 +152,17 @@ impl FlowEngine {
     /// Set the local state provider for processor state persistence.
     pub fn set_state_provider(&mut self, provider: SharedLocalStateProvider) {
         self.state_provider = Some(provider);
+    }
+
+    /// Set the cluster-scoped state provider.
+    pub fn set_cluster_state_provider(&mut self, provider: SharedClusterStateProvider) {
+        self.cluster_state_provider = Some(provider);
+    }
+
+    /// Set whether this node is the primary in the cluster.
+    pub fn set_primary_node(&mut self, is_primary: bool) {
+        self.is_primary_node
+            .store(is_primary, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Get a reference to the provenance repository.
@@ -449,6 +466,11 @@ impl FlowEngine {
             if let Some(ref provider) = self.state_provider {
                 pn.set_state_provider(provider.clone());
             }
+            if let Some(ref provider) = self.cluster_state_provider {
+                pn.set_cluster_state_provider(provider.clone());
+            }
+            pn.set_execution_node(pn.processor_execution_node());
+            pn.set_primary_node_flag(self.is_primary_node.clone());
 
             for (src, rel, dst, fc) in &flow_connections {
                 if *src == node_builder.id {

--- a/crates/runifi-core/src/engine/processor_node.rs
+++ b/crates/runifi-core/src/engine/processor_node.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use parking_lot::RwLock;
 use tokio::sync::Notify;
@@ -12,12 +12,13 @@ use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::service::ServiceLookup;
 use runifi_plugin_api::session::ProcessSession;
 use runifi_plugin_api::state::StateManager;
-use runifi_plugin_api::{FlowFile, Processor};
+use runifi_plugin_api::{ExecutionNode, FlowFile, Processor};
 
 use super::bulletin::{BulletinBoard, BulletinSeverity};
 use super::metrics::{ProcessorMetrics, RunOnceResult};
 use super::supervisor::{InvocationResult, ProcessorSupervisor};
 use crate::cluster::load_balance::{LoadBalanceStrategy, LoadBalancer};
+use crate::cluster::state::SharedClusterStateProvider;
 use crate::connection::flow_connection::FlowConnection;
 use crate::id::IdGenerator;
 use crate::registry::service_registry::{RegistryServiceLookup, SharedServiceRegistry};
@@ -136,6 +137,12 @@ pub struct ProcessorNode {
     task_index: u32,
     concurrent_tasks: Arc<AtomicU64>,
     timer_notify: Option<Arc<Notify>>,
+    /// Cluster-scoped state provider for shared processor state.
+    cluster_state_provider: Option<SharedClusterStateProvider>,
+    /// Whether this processor should run on all nodes or only the primary.
+    execution_node: ExecutionNode,
+    /// Shared flag indicating whether this node is the primary in the cluster.
+    is_primary_node: Arc<AtomicBool>,
 }
 
 impl ProcessorNode {
@@ -178,6 +185,9 @@ impl ProcessorNode {
             task_index: 0,
             concurrent_tasks: Arc::new(AtomicU64::new(1)),
             timer_notify: None,
+            cluster_state_provider: None,
+            execution_node: ExecutionNode::All,
+            is_primary_node: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -219,6 +229,21 @@ impl ProcessorNode {
     /// Set the local state provider for processor state persistence.
     pub fn set_state_provider(&mut self, provider: SharedLocalStateProvider) {
         self.state_provider = Some(provider);
+    }
+
+    /// Set the cluster-scoped state provider.
+    pub fn set_cluster_state_provider(&mut self, provider: SharedClusterStateProvider) {
+        self.cluster_state_provider = Some(provider);
+    }
+
+    /// Set which nodes should execute this processor.
+    pub fn set_execution_node(&mut self, exec: ExecutionNode) {
+        self.execution_node = exec;
+    }
+
+    /// Set the shared primary node flag.
+    pub fn set_primary_node_flag(&mut self, flag: Arc<AtomicBool>) {
+        self.is_primary_node = flag;
     }
 
     pub fn set_task_index(&mut self, idx: u32) {
@@ -264,6 +289,11 @@ impl ProcessorNode {
         self.supervisor.relationships()
     }
 
+    /// Get the processor's execution node requirement.
+    pub fn processor_execution_node(&self) -> ExecutionNode {
+        self.supervisor.execution_node()
+    }
+
     /// Check if the circuit breaker is open.
     pub fn is_circuit_open(&self) -> bool {
         self.supervisor.is_circuit_open()
@@ -301,6 +331,7 @@ impl ProcessorNode {
         // mutable borrows of `self` elsewhere in the lifecycle loop.
         let service_registry_ref = self.service_registry.clone();
         let state_provider_ref = self.state_provider.clone();
+        let cluster_state_provider_ref = self.cluster_state_provider.clone();
         let processor_name = self.name.clone();
 
         // Last context, kept for on_stopped after lifecycle loop exits.
@@ -314,10 +345,18 @@ impl ProcessorNode {
 
         let make_state_manager = || -> Option<Box<dyn StateManager>> {
             state_provider_ref.as_ref().map(|p| {
-                Box::new(crate::repository::state_provider::CoreStateManager::new(
-                    p.clone(),
-                    processor_name.clone(),
-                )) as Box<dyn StateManager>
+                let manager = match cluster_state_provider_ref.as_ref() {
+                    Some(cp) => crate::repository::state_provider::CoreStateManager::with_cluster(
+                        p.clone(),
+                        cp.clone(),
+                        processor_name.clone(),
+                    ),
+                    None => crate::repository::state_provider::CoreStateManager::new(
+                        p.clone(),
+                        processor_name.clone(),
+                    ),
+                };
+                Box::new(manager) as Box<dyn StateManager>
             })
         };
 
@@ -448,6 +487,21 @@ impl ProcessorNode {
                             break 'lifecycle;
                         }
                         _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+                    }
+                    continue;
+                }
+
+                // Primary-node-only check: if this processor requires the primary
+                // node and we are not the primary, sleep and re-check.
+                if self.execution_node == ExecutionNode::Primary
+                    && !self.is_primary_node.load(Ordering::Relaxed)
+                {
+                    tokio::select! {
+                        _ = self.cancel_token.cancelled() => {
+                            tracing::info!(processor = %self.name, "Processor stopping (cancelled while waiting for primary)");
+                            break 'lifecycle;
+                        }
+                        _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {}
                     }
                     continue;
                 }
@@ -717,10 +771,18 @@ impl ProcessorNode {
             .map(|r| -> Box<dyn ServiceLookup> { Box::new(RegistryServiceLookup::new(r.clone())) });
 
         let state_manager: Option<Box<dyn StateManager>> = self.state_provider.as_ref().map(|p| {
-            Box::new(crate::repository::state_provider::CoreStateManager::new(
-                p.clone(),
-                self.name.clone(),
-            )) as Box<dyn StateManager>
+            let manager = match self.cluster_state_provider.as_ref() {
+                Some(cp) => crate::repository::state_provider::CoreStateManager::with_cluster(
+                    p.clone(),
+                    cp.clone(),
+                    self.name.clone(),
+                ),
+                None => crate::repository::state_provider::CoreStateManager::new(
+                    p.clone(),
+                    self.name.clone(),
+                ),
+            };
+            Box::new(manager) as Box<dyn StateManager>
         });
 
         let ctx = NodeProcessContext {

--- a/crates/runifi-core/src/engine/supervisor.rs
+++ b/crates/runifi-core/src/engine/supervisor.rs
@@ -154,6 +154,11 @@ impl ProcessorSupervisor {
         self.processor.property_descriptors()
     }
 
+    /// Get the processor's execution node requirement.
+    pub fn execution_node(&self) -> runifi_plugin_api::ExecutionNode {
+        self.processor.execution_node()
+    }
+
     /// Validate the processor's configuration.
     pub fn validate(
         &self,

--- a/crates/runifi-core/src/repository/state_provider.rs
+++ b/crates/runifi-core/src/repository/state_provider.rs
@@ -16,6 +16,8 @@ use serde::{Deserialize, Serialize};
 use runifi_plugin_api::result::{PluginError, ProcessResult};
 use runifi_plugin_api::state::{StateManager, StateMap, StateScope};
 
+use crate::cluster::state::SharedClusterStateProvider;
+
 /// On-disk representation of processor state.
 #[derive(Debug, Serialize, Deserialize)]
 struct PersistedState {
@@ -205,16 +207,34 @@ pub type SharedLocalStateProvider = Arc<LocalStateProvider>;
 
 /// Per-processor state manager that wraps a shared LocalStateProvider
 /// with a fixed processor ID. Implements the plugin-api StateManager trait.
+///
+/// When a `SharedClusterStateProvider` is present, `StateScope::Cluster`
+/// operations are delegated to it. Otherwise they return an error.
 pub struct CoreStateManager {
     provider: SharedLocalStateProvider,
+    cluster_provider: Option<SharedClusterStateProvider>,
     processor_id: String,
 }
 
 impl CoreStateManager {
-    /// Create a new state manager for a specific processor instance.
+    /// Create a new state manager for a specific processor instance (local only).
     pub fn new(provider: SharedLocalStateProvider, processor_id: String) -> Self {
         Self {
             provider,
+            cluster_provider: None,
+            processor_id,
+        }
+    }
+
+    /// Create a state manager with both local and cluster state support.
+    pub fn with_cluster(
+        provider: SharedLocalStateProvider,
+        cluster_provider: SharedClusterStateProvider,
+        processor_id: String,
+    ) -> Self {
+        Self {
+            provider,
+            cluster_provider: Some(cluster_provider),
             processor_id,
         }
     }
@@ -224,18 +244,26 @@ impl StateManager for CoreStateManager {
     fn get_state(&self, scope: StateScope) -> ProcessResult<StateMap> {
         match scope {
             StateScope::Local => self.provider.get_state(&self.processor_id),
-            StateScope::Cluster => Err(PluginError::ProcessingFailed(
-                "Cluster state scope is not yet implemented".to_string(),
-            )),
+            StateScope::Cluster => match &self.cluster_provider {
+                Some(cp) => cp.get_state(&self.processor_id),
+                None => Err(PluginError::ProcessingFailed(
+                    "Cluster state scope is not available (no cluster state provider configured)"
+                        .to_string(),
+                )),
+            },
         }
     }
 
     fn set_state(&self, state: HashMap<String, String>, scope: StateScope) -> ProcessResult<()> {
         match scope {
             StateScope::Local => self.provider.set_state(&self.processor_id, state),
-            StateScope::Cluster => Err(PluginError::ProcessingFailed(
-                "Cluster state scope is not yet implemented".to_string(),
-            )),
+            StateScope::Cluster => match &self.cluster_provider {
+                Some(cp) => cp.set_state(&self.processor_id, state),
+                None => Err(PluginError::ProcessingFailed(
+                    "Cluster state scope is not available (no cluster state provider configured)"
+                        .to_string(),
+                )),
+            },
         }
     }
 
@@ -250,18 +278,26 @@ impl StateManager for CoreStateManager {
                 self.provider
                     .replace(&self.processor_id, old_state.version(), new_state)
             }
-            StateScope::Cluster => Err(PluginError::ProcessingFailed(
-                "Cluster state scope is not yet implemented".to_string(),
-            )),
+            StateScope::Cluster => match &self.cluster_provider {
+                Some(cp) => cp.replace(&self.processor_id, old_state.version(), new_state),
+                None => Err(PluginError::ProcessingFailed(
+                    "Cluster state scope is not available (no cluster state provider configured)"
+                        .to_string(),
+                )),
+            },
         }
     }
 
     fn clear(&self, scope: StateScope) -> ProcessResult<()> {
         match scope {
             StateScope::Local => self.provider.clear(&self.processor_id),
-            StateScope::Cluster => Err(PluginError::ProcessingFailed(
-                "Cluster state scope is not yet implemented".to_string(),
-            )),
+            StateScope::Cluster => match &self.cluster_provider {
+                Some(cp) => cp.clear(&self.processor_id),
+                None => Err(PluginError::ProcessingFailed(
+                    "Cluster state scope is not available (no cluster state provider configured)"
+                        .to_string(),
+                )),
+            },
         }
     }
 }
@@ -490,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn test_core_state_manager_cluster_not_implemented() {
+    fn test_core_state_manager_cluster_not_configured() {
         let dir = tempfile::tempdir().unwrap();
         let provider = Arc::new(LocalStateProvider::new(dir.path()).unwrap());
 
@@ -501,6 +537,48 @@ mod tests {
 
         let result = manager.set_state(HashMap::new(), StateScope::Cluster);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_core_state_manager_with_cluster() {
+        let local_dir = tempfile::tempdir().unwrap();
+        let cluster_dir = tempfile::tempdir().unwrap();
+        let local = Arc::new(LocalStateProvider::new(local_dir.path()).unwrap());
+        let cluster =
+            Arc::new(crate::cluster::state::ClusterStateProvider::new(cluster_dir.path()).unwrap());
+
+        let manager = CoreStateManager::with_cluster(local, cluster, "proc-1".to_string());
+
+        // Cluster scope works when provider is configured.
+        let state = manager.get_state(StateScope::Cluster).unwrap();
+        assert!(state.is_empty());
+
+        let entries = HashMap::from([("cursor".to_string(), "42".to_string())]);
+        manager.set_state(entries, StateScope::Cluster).unwrap();
+
+        let state = manager.get_state(StateScope::Cluster).unwrap();
+        assert_eq!(state.version(), 0);
+        assert_eq!(state.get("cursor"), Some("42"));
+
+        // Local scope is independent.
+        let local_state = manager.get_state(StateScope::Local).unwrap();
+        assert!(local_state.is_empty());
+
+        // Replace with CAS on cluster scope.
+        let new_entries = HashMap::from([("cursor".to_string(), "100".to_string())]);
+        let ok = manager
+            .replace(&state, new_entries, StateScope::Cluster)
+            .unwrap();
+        assert!(ok);
+
+        let state = manager.get_state(StateScope::Cluster).unwrap();
+        assert_eq!(state.version(), 1);
+        assert_eq!(state.get("cursor"), Some("100"));
+
+        // Clear cluster scope.
+        manager.clear(StateScope::Cluster).unwrap();
+        let state = manager.get_state(StateScope::Cluster).unwrap();
+        assert!(state.is_empty());
     }
 
     #[test]

--- a/crates/runifi-plugin-api/src/lib.rs
+++ b/crates/runifi-plugin-api/src/lib.rs
@@ -30,3 +30,13 @@ pub use sink::{Sink, SinkDescriptor};
 pub use source::{Source, SourceDescriptor};
 pub use state::{StateManager, StateMap, StateScope, StatefulSpec};
 pub use validation::ValidationResult;
+
+/// Which nodes in a cluster should execute this processor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExecutionNode {
+    /// Execute on all nodes (default behavior).
+    #[default]
+    All,
+    /// Execute only on the primary node.
+    Primary,
+}

--- a/crates/runifi-plugin-api/src/processor.rs
+++ b/crates/runifi-plugin-api/src/processor.rs
@@ -1,3 +1,4 @@
+use crate::ExecutionNode;
 use crate::context::ProcessContext;
 use crate::property::PropertyDescriptor;
 use crate::relationship::Relationship;
@@ -61,6 +62,15 @@ pub trait Processor: Send + Sync + 'static {
     /// `StateManager` via `ProcessContext::state_manager()`.
     fn stateful(&self) -> Option<StatefulSpec> {
         None
+    }
+
+    /// Declare the execution node requirement for this processor.
+    ///
+    /// Returns `ExecutionNode::All` by default. Override to return
+    /// `ExecutionNode::Primary` for processors that should only run
+    /// on the primary node (e.g., ListFile, ListS3).
+    fn execution_node(&self) -> ExecutionNode {
+        ExecutionNode::All
     }
 }
 


### PR DESCRIPTION
## Summary

- **Cluster-Scoped State**: Adds `ClusterStateProvider` for shared processor state visible across all cluster nodes. State is persisted to `state/cluster/{component-id}/state.json` with atomic writes. `CoreStateManager` now delegates `StateScope::Cluster` operations to the cluster provider when configured. Protocol messages (`StateUpdate`, `StateSync`) are defined for future gossip-based replication.

- **Primary Node Only Scheduling**: Adds `ExecutionNode` enum (`All`, `Primary`) to the plugin API and a `execution_node()` method on the `Processor` trait. Processors configured as `ExecutionNode::Primary` only trigger on the primary node; non-primary nodes sleep-poll until promoted. A shared `AtomicBool` flag propagates primary status from the engine/coordinator.

## Changes

- `crates/runifi-plugin-api/src/lib.rs` — `ExecutionNode` enum
- `crates/runifi-plugin-api/src/processor.rs` — `execution_node()` default method on `Processor` trait
- `crates/runifi-core/src/cluster/state.rs` — **NEW** `ClusterStateProvider` with full CRUD + CAS + persistence
- `crates/runifi-core/src/cluster/protocol.rs` — `StateUpdate` / `StateSync` message types
- `crates/runifi-core/src/cluster/coordinator.rs` — Stub handler for state replication messages
- `crates/runifi-core/src/cluster/mod.rs` — Module + re-exports
- `crates/runifi-core/src/repository/state_provider.rs` — `CoreStateManager::with_cluster()` constructor, cluster delegation
- `crates/runifi-core/src/engine/processor_node.rs` — `execution_node`, `is_primary_node` fields + primary-only scheduling guard
- `crates/runifi-core/src/engine/flow_engine.rs` — `cluster_state_provider`, `is_primary_node` fields + wiring
- `crates/runifi-core/src/engine/supervisor.rs` — `execution_node()` delegation

## Test Plan

- [x] `ClusterStateProvider`: empty state, set/get, replace CAS success, replace version mismatch, clear, persistence across instances, multiple components, remove component (7 tests)
- [x] `CoreStateManager` with cluster: get/set/replace/clear on cluster scope, independence from local scope (1 comprehensive test)
- [x] `CoreStateManager` without cluster: error on cluster scope (existing test updated)
- [x] All existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #268