### PR TITLE
feat: processor behavior annotations — InputRequirement, TriggerWhenEmpty, SideEffectFree (#271)

### DIFF
--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use runifi_core::engine::bulletin::Bulletin;
 use runifi_core::engine::handle::{PluginKind, ProcessorInfo};
 use runifi_core::engine::metrics::MetricsSnapshot;
+use runifi_plugin_api::InputRequirement;
 
 #[derive(Serialize)]
 pub struct SystemResponse {
@@ -82,6 +83,10 @@ pub struct ProcessorResponse {
     pub metrics: MetricsResponse,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub validation_errors: Vec<String>,
+    pub input_requirement: String,
+    pub trigger_when_empty: bool,
+    pub side_effect_free: bool,
+    pub supports_batching: bool,
 }
 
 #[derive(Serialize)]
@@ -144,6 +149,15 @@ impl ProcessorResponse {
             state,
             metrics: snapshot.into(),
             validation_errors,
+            input_requirement: match info.input_requirement {
+                InputRequirement::Required => "required",
+                InputRequirement::Allowed => "allowed",
+                InputRequirement::Forbidden => "forbidden",
+            }
+            .to_string(),
+            trigger_when_empty: info.trigger_when_empty,
+            side_effect_free: info.side_effect_free,
+            supports_batching: info.supports_batching,
         }
     }
 }
@@ -262,10 +276,22 @@ pub struct PluginResponse {
     pub kind: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    pub input_requirement: String,
+    pub trigger_when_empty: bool,
+    pub side_effect_free: bool,
+    pub supports_batching: bool,
 }
 
 impl PluginResponse {
-    pub fn from_kind(type_name: &str, kind: PluginKind, tags: Vec<String>) -> Self {
+    pub fn from_kind(
+        type_name: &str,
+        kind: PluginKind,
+        tags: Vec<String>,
+        input_requirement: InputRequirement,
+        trigger_when_empty: bool,
+        side_effect_free: bool,
+        supports_batching: bool,
+    ) -> Self {
         let kind_str = match kind {
             PluginKind::Processor => "processor",
             PluginKind::Source => "source",
@@ -277,6 +303,15 @@ impl PluginResponse {
             type_name: type_name.to_string(),
             kind: kind_str.to_string(),
             tags,
+            input_requirement: match input_requirement {
+                InputRequirement::Required => "required",
+                InputRequirement::Allowed => "allowed",
+                InputRequirement::Forbidden => "forbidden",
+            }
+            .to_string(),
+            trigger_when_empty,
+            side_effect_free,
+            supports_batching,
         }
     }
 }

--- a/crates/runifi-api/src/error.rs
+++ b/crates/runifi-api/src/error.rs
@@ -183,6 +183,7 @@ impl From<MutationError> for ApiError {
             MutationError::InvalidCronExpression(expr, msg) => {
                 ApiError::BadRequest(format!("Invalid CRON expression '{}': {}", expr, msg))
             }
+            MutationError::InvalidConnection(msg) => ApiError::BadRequest(msg),
             MutationError::Internal(msg) => ApiError::ConfigError(msg),
         }
     }

--- a/crates/runifi-api/src/routes/plugins.rs
+++ b/crates/runifi-api/src/routes/plugins.rs
@@ -17,7 +17,17 @@ async fn list_plugins(State(state): State<ApiState>) -> Json<Vec<PluginResponse>
         .handle
         .plugin_types
         .iter()
-        .map(|p| PluginResponse::from_kind(&p.type_name, p.kind, p.tags.clone()))
+        .map(|p| {
+            PluginResponse::from_kind(
+                &p.type_name,
+                p.kind,
+                p.tags.clone(),
+                p.input_requirement,
+                p.trigger_when_empty,
+                p.side_effect_free,
+                p.supports_batching,
+            )
+        })
         .collect();
     Json(plugins)
 }

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use runifi_plugin_api::Processor;
+use runifi_plugin_api::{InputRequirement, Processor};
 
 use super::bulletin::BulletinBoard;
 use super::handle::{
@@ -336,9 +336,18 @@ impl FlowEngine {
         let mut metrics_by_node: HashMap<NodeId, Arc<ProcessorMetrics>> = HashMap::new();
         let mut shared_props_by_node: HashMap<NodeId, Arc<RwLock<HashMap<String, String>>>> =
             HashMap::new();
+        // Tuple: (property_descriptors, relationships, input_requirement, trigger_when_empty, side_effect_free, supports_batching)
+        #[allow(clippy::type_complexity)]
         let mut static_meta_by_node: HashMap<
             NodeId,
-            (Vec<PropertyDescriptorInfo>, Vec<RelationshipInfo>),
+            (
+                Vec<PropertyDescriptorInfo>,
+                Vec<RelationshipInfo>,
+                InputRequirement,
+                bool,
+                bool,
+                bool,
+            ),
         > = HashMap::new();
 
         for node_builder in &self.nodes {
@@ -347,36 +356,61 @@ impl FlowEngine {
             let shared_props = Arc::new(RwLock::new(node_builder.properties.clone()));
             shared_props_by_node.insert(node_builder.id, shared_props);
 
-            let (prop_descriptors, rels) = if let Some(ref proc) = node_builder.processor {
-                let pds = proc
-                    .property_descriptors()
-                    .into_iter()
-                    .map(|pd| PropertyDescriptorInfo {
-                        name: pd.name.to_string(),
-                        description: pd.description.to_string(),
-                        required: pd.required,
-                        default_value: pd.default_value.map(|v| v.to_string()),
-                        sensitive: pd.sensitive,
-                        allowed_values: pd
-                            .allowed_values
-                            .map(|av| av.iter().map(|v| v.to_string()).collect()),
-                        expression_language_supported: pd.expression_language_supported,
-                    })
-                    .collect();
-                let rs = proc
-                    .relationships()
-                    .into_iter()
-                    .map(|r| RelationshipInfo {
-                        name: r.name.to_string(),
-                        description: r.description.to_string(),
-                        auto_terminated: r.auto_terminated,
-                    })
-                    .collect();
-                (pds, rs)
-            } else {
-                (Vec::new(), Vec::new())
-            };
-            static_meta_by_node.insert(node_builder.id, (prop_descriptors, rels));
+            let (prop_descriptors, rels, input_req, trigger_empty, side_effect, batching) =
+                if let Some(ref proc) = node_builder.processor {
+                    let pds = proc
+                        .property_descriptors()
+                        .into_iter()
+                        .map(|pd| PropertyDescriptorInfo {
+                            name: pd.name.to_string(),
+                            description: pd.description.to_string(),
+                            required: pd.required,
+                            default_value: pd.default_value.map(|v| v.to_string()),
+                            sensitive: pd.sensitive,
+                            allowed_values: pd
+                                .allowed_values
+                                .map(|av| av.iter().map(|v| v.to_string()).collect()),
+                            expression_language_supported: pd.expression_language_supported,
+                        })
+                        .collect();
+                    let rs = proc
+                        .relationships()
+                        .into_iter()
+                        .map(|r| RelationshipInfo {
+                            name: r.name.to_string(),
+                            description: r.description.to_string(),
+                            auto_terminated: r.auto_terminated,
+                        })
+                        .collect();
+                    (
+                        pds,
+                        rs,
+                        proc.input_requirement(),
+                        proc.trigger_when_empty(),
+                        proc.side_effect_free(),
+                        proc.supports_batching(),
+                    )
+                } else {
+                    (
+                        Vec::new(),
+                        Vec::new(),
+                        InputRequirement::Allowed,
+                        false,
+                        false,
+                        false,
+                    )
+                };
+            static_meta_by_node.insert(
+                node_builder.id,
+                (
+                    prop_descriptors,
+                    rels,
+                    input_req,
+                    trigger_empty,
+                    side_effect,
+                    batching,
+                ),
+            );
         }
 
         // Build ConnectionInfo for the handle.
@@ -453,7 +487,7 @@ impl FlowEngine {
             pn.set_type_name(node_builder.type_name.clone());
 
             // Set sensitive property names for bulletin redaction.
-            if let Some((descriptors, _)) = static_meta_by_node.get(&node_builder.id) {
+            if let Some((descriptors, _, _, _, _, _)) = static_meta_by_node.get(&node_builder.id) {
                 let sensitive_names: Vec<String> = descriptors
                     .iter()
                     .filter(|d| d.sensitive)
@@ -506,9 +540,10 @@ impl FlowEngine {
                 .get(&node_builder.id)
                 .expect("shared_props must exist")
                 .clone();
-            let (prop_descriptors, relationships) = static_meta_by_node
-                .remove(&node_builder.id)
-                .expect("static meta must exist for every node");
+            let (prop_descriptors, relationships, input_req, trigger_empty, side_effect, batching) =
+                static_meta_by_node
+                    .remove(&node_builder.id)
+                    .expect("static meta must exist for every node");
             let (input_h, output_h, notifiers_h) = node_conn_handles
                 .get(&node_builder.name)
                 .expect("conn handles must exist for every node")
@@ -533,6 +568,10 @@ impl FlowEngine {
                 spawned_task_count: Arc::new(AtomicU64::new(0)),
                 comments: Arc::new(RwLock::new(String::new())),
                 auto_terminated_relationships: Arc::new(RwLock::new(Vec::new())),
+                input_requirement: input_req,
+                trigger_when_empty: trigger_empty,
+                side_effect_free: side_effect,
+                supports_batching: batching,
             });
         }
 

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -27,6 +27,8 @@ use super::processor_node::{
 /// is preserved (the caller did not change it).
 pub const SENSITIVE_VALUE_MASK: &str = "********";
 
+use runifi_plugin_api::InputRequirement;
+
 use crate::audit::{AuditAction, AuditEvent, AuditLogger, AuditTarget};
 use crate::connection::back_pressure::BackPressureConfig;
 use crate::connection::query::ConnectionQuery;
@@ -117,6 +119,14 @@ pub struct ProcessorInfo {
     pub comments: Arc<RwLock<String>>,
     /// Auto-terminated relationship names (configurable at runtime).
     pub auto_terminated_relationships: Arc<RwLock<Vec<String>>>,
+    /// Input requirement annotation.
+    pub input_requirement: InputRequirement,
+    /// Whether the processor runs when input queue is empty.
+    pub trigger_when_empty: bool,
+    /// Whether the processor is side-effect-free.
+    pub side_effect_free: bool,
+    /// Whether the processor supports batching.
+    pub supports_batching: bool,
 }
 
 /// Information about a connection, visible to the API.
@@ -136,6 +146,14 @@ pub struct PluginTypeInfo {
     pub kind: PluginKind,
     /// Category tags for UI grouping (from plugin descriptor).
     pub tags: Vec<String>,
+    /// Input requirement annotation (processors only).
+    pub input_requirement: InputRequirement,
+    /// Whether the processor runs when input queue is empty.
+    pub trigger_when_empty: bool,
+    /// Whether the processor is side-effect-free.
+    pub side_effect_free: bool,
+    /// Whether the processor supports batching.
+    pub supports_batching: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/runifi-core/src/engine/mutation.rs
+++ b/crates/runifi-core/src/engine/mutation.rs
@@ -93,6 +93,9 @@ pub enum MutationError {
     #[error("invalid CRON expression '{0}': {1}")]
     InvalidCronExpression(String, String),
 
+    #[error("invalid connection: {0}")]
+    InvalidConnection(String),
+
     #[error("{0}")]
     Internal(String),
 }

--- a/crates/runifi-core/src/engine/mutation_handler.rs
+++ b/crates/runifi-core/src/engine/mutation_handler.rs
@@ -6,8 +6,8 @@ use parking_lot::RwLock;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
-use runifi_plugin_api::Processor;
 use runifi_plugin_api::relationship::Relationship;
+use runifi_plugin_api::{InputRequirement, Processor};
 
 use super::bulletin::BulletinBoard;
 use super::handle::{ConnectionInfo, ProcessorInfo, PropertyDescriptorInfo, RelationshipInfo};
@@ -131,6 +131,12 @@ impl DefaultMutationHandler {
             })
             .collect();
 
+        // Read annotations before the processor is moved into ProcessorNode.
+        let input_requirement = processor.input_requirement();
+        let trigger_when_empty = processor.trigger_when_empty();
+        let side_effect_free = processor.side_effect_free();
+        let supports_batching = processor.supports_batching();
+
         let shared_props = Arc::new(RwLock::new(properties));
         let child_token = self.parent_cancel.child_token();
 
@@ -186,6 +192,10 @@ impl DefaultMutationHandler {
             spawned_task_count: Arc::new(AtomicU64::new(0)),
             comments: Arc::new(RwLock::new(String::new())),
             auto_terminated_relationships: Arc::new(RwLock::new(Vec::new())),
+            input_requirement,
+            trigger_when_empty,
+            side_effect_free,
+            supports_batching,
         });
 
         tracing::info!(name, type_name, "Hot-added processor");
@@ -280,6 +290,14 @@ impl DefaultMutationHandler {
                 .iter()
                 .find(|p| p.name == dest_name)
                 .ok_or_else(|| MutationError::ProcessorNotFound(dest_name.to_string()))?;
+
+            // Validate InputRequirement — reject connections to Forbidden processors.
+            if dst.input_requirement == InputRequirement::Forbidden {
+                return Err(MutationError::InvalidConnection(format!(
+                    "Processor '{}' has InputRequirement::Forbidden and cannot accept incoming connections",
+                    dest_name
+                )));
+            }
 
             let rel = Relationship {
                 name: Box::leak(src_rel_info.name.clone().into_boxed_str()),

--- a/crates/runifi-core/src/registry/plugin_registry.rs
+++ b/crates/runifi-core/src/registry/plugin_registry.rs
@@ -119,6 +119,14 @@ impl PluginRegistry {
             .unwrap_or_default()
     }
 
+    /// Get the descriptor for a processor type (for annotation metadata).
+    pub fn processor_descriptor(
+        &self,
+        type_name: &str,
+    ) -> Option<dashmap::mapref::one::Ref<'_, &'static str, &'static ProcessorDescriptor>> {
+        self.processors.get(type_name)
+    }
+
     /// Get tags for a source type.
     pub fn source_tags(&self, type_name: &str) -> Vec<String> {
         self.sources

--- a/crates/runifi-core/tests/concurrent_tasks.rs
+++ b/crates/runifi-core/tests/concurrent_tasks.rs
@@ -10,7 +10,7 @@ use runifi_core::registry::plugin_registry::PluginRegistry;
 use runifi_core::repository::content_memory::InMemoryContentRepository;
 use runifi_core::repository::flowfile_repo::InMemoryFlowFileRepository;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::ProcessorDescriptor;
+use runifi_plugin_api::processor::{InputRequirement, ProcessorDescriptor};
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
 use runifi_plugin_api::session::ProcessSession;
@@ -71,6 +71,10 @@ inventory::submit!(ProcessorDescriptor {
     description: "Counts triggers via global atomic — concurrent task test only",
     factory: || Box::new(RegistryConcurrentCounter),
     tags: &[],
+    input_requirement: InputRequirement::Allowed,
+    trigger_when_empty: false,
+    side_effect_free: false,
+    supports_batching: false,
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/crates/runifi-core/tests/end_to_end_flow.rs
+++ b/crates/runifi-core/tests/end_to_end_flow.rs
@@ -12,7 +12,7 @@ use runifi_core::registry::plugin_registry::PluginRegistry;
 use runifi_core::repository::content_memory::InMemoryContentRepository;
 use runifi_core::repository::flowfile_repo::InMemoryFlowFileRepository;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::ProcessorDescriptor;
+use runifi_plugin_api::processor::{InputRequirement, ProcessorDescriptor};
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::{PluginError, ProcessResult};
 use runifi_plugin_api::session::ProcessSession;
@@ -462,6 +462,10 @@ inventory::submit!(ProcessorDescriptor {
     description: "Always panics — integration test only",
     factory: || Box::new(PanicProcessor),
     tags: &[],
+    input_requirement: InputRequirement::Allowed,
+    trigger_when_empty: false,
+    side_effect_free: false,
+    supports_batching: false,
 });
 
 inventory::submit!(ProcessorDescriptor {
@@ -469,6 +473,10 @@ inventory::submit!(ProcessorDescriptor {
     description: "Always errors — integration test only",
     factory: || Box::new(ErrorProcessor),
     tags: &[],
+    input_requirement: InputRequirement::Allowed,
+    trigger_when_empty: false,
+    side_effect_free: false,
+    supports_batching: false,
 });
 
 inventory::submit!(ProcessorDescriptor {
@@ -476,4 +484,8 @@ inventory::submit!(ProcessorDescriptor {
     description: "Pass-through — integration test only",
     factory: || Box::new(PassThroughProcessor),
     tags: &[],
+    input_requirement: InputRequirement::Allowed,
+    trigger_when_empty: false,
+    side_effect_free: false,
+    supports_batching: false,
 });

--- a/crates/runifi-core/tests/engine_mutations.rs
+++ b/crates/runifi-core/tests/engine_mutations.rs
@@ -13,8 +13,8 @@ use runifi_core::registry::plugin_registry::PluginRegistry;
 use runifi_core::repository::content_memory::InMemoryContentRepository;
 use runifi_core::repository::flowfile_repo::InMemoryFlowFileRepository;
 use runifi_plugin_api::{
-    ProcessorDescriptor, PropertyDescriptor, Relationship, context::ProcessContext,
-    session::ProcessSession,
+    InputRequirement, ProcessorDescriptor, PropertyDescriptor, Relationship,
+    context::ProcessContext, session::ProcessSession,
 };
 
 // ── Minimal test processors ───────────────────────────────────────────────────
@@ -44,6 +44,10 @@ inventory::submit!(ProcessorDescriptor {
     description: "Does nothing — used in tests.",
     factory: || Box::new(NoOpProcessor),
     tags: &[],
+    input_requirement: InputRequirement::Allowed,
+    trigger_when_empty: false,
+    side_effect_free: false,
+    supports_batching: false,
 });
 
 /// A processor with a required property (no default) for validation tests.
@@ -82,6 +86,10 @@ inventory::submit!(ProcessorDescriptor {
     description: "Processor with required properties — used in validation tests.",
     factory: || Box::new(RequiredPropProcessor),
     tags: &["Testing"],
+    input_requirement: InputRequirement::Allowed,
+    trigger_when_empty: false,
+    side_effect_free: false,
+    supports_batching: false,
 });
 
 // ── Test helpers ──────────────────────────────────────────────────────────────

--- a/crates/runifi-plugin-api/src/lib.rs
+++ b/crates/runifi-plugin-api/src/lib.rs
@@ -16,7 +16,7 @@ pub mod validation;
 // Re-export key types at crate root for convenience.
 pub use context::ProcessContext;
 pub use flowfile::{ContentClaim, FlowFile};
-pub use processor::{Processor, ProcessorDescriptor};
+pub use processor::{InputRequirement, Processor, ProcessorDescriptor};
 pub use property::{PropertyDescriptor, PropertyValue};
 pub use record::{
     Record, RecordFieldType, RecordReader, RecordSchema, RecordValue, RecordWriter, SchemaField,

--- a/crates/runifi-plugin-api/src/processor.rs
+++ b/crates/runifi-plugin-api/src/processor.rs
@@ -7,6 +7,22 @@ use crate::session::ProcessSession;
 use crate::state::StatefulSpec;
 use crate::validation::ValidationResult;
 
+/// Declares whether a processor requires, allows, or forbids incoming connections.
+///
+/// The engine uses this annotation to validate flow topology at design time,
+/// preventing invalid wiring (e.g., connecting to a source-only processor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InputRequirement {
+    /// Processor requires at least one incoming connection (e.g., LogAttribute, PutFile).
+    Required,
+    /// Processor can optionally have incoming connections (default).
+    #[default]
+    Allowed,
+    /// Processor must not have incoming connections — it is a pure source
+    /// (e.g., GenerateFlowFile, GetFile).
+    Forbidden,
+}
+
 /// The core processor trait. Processors are synchronous — the engine wraps
 /// them in `spawn_blocking` + `catch_unwind` for fault isolation.
 ///
@@ -72,6 +88,42 @@ pub trait Processor: Send + Sync + 'static {
     fn execution_node(&self) -> ExecutionNode {
         ExecutionNode::All
     }
+
+    /// Declare the input requirement for this processor.
+    ///
+    /// Returns `InputRequirement::Allowed` by default. Override to return
+    /// `InputRequirement::Required` for processors that need incoming data,
+    /// or `InputRequirement::Forbidden` for source processors that generate
+    /// their own data.
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Allowed
+    }
+
+    /// Whether this processor should be triggered even when no FlowFiles
+    /// are queued on its incoming connections.
+    ///
+    /// Defaults to `false`. Source processors (e.g., GenerateFlowFile, GetFile)
+    /// should return `true`.
+    fn trigger_when_empty(&self) -> bool {
+        false
+    }
+
+    /// Whether this processor is side-effect-free (idempotent, safe to retry).
+    ///
+    /// Defaults to `false`. Processors that only read/route FlowFiles without
+    /// modifying external state (e.g., LogAttribute, RouteOnAttribute) should
+    /// return `true`.
+    fn side_effect_free(&self) -> bool {
+        false
+    }
+
+    /// Whether this processor is compatible with run-duration batching.
+    ///
+    /// Defaults to `false`. Processors that can efficiently process multiple
+    /// FlowFiles in a single trigger invocation should return `true`.
+    fn supports_batching(&self) -> bool {
+        false
+    }
 }
 
 /// Describes a processor type for plugin registration.
@@ -81,6 +133,31 @@ pub struct ProcessorDescriptor {
     pub factory: fn() -> Box<dyn Processor>,
     /// Category tags for UI grouping (e.g., &["Routing", "Attribute Manipulation"]).
     pub tags: &'static [&'static str],
+    /// Input requirement annotation for this processor type.
+    pub input_requirement: InputRequirement,
+    /// Whether the processor runs when input queue is empty.
+    pub trigger_when_empty: bool,
+    /// Whether the processor is side-effect-free (idempotent).
+    pub side_effect_free: bool,
+    /// Whether the processor supports run-duration batching.
+    pub supports_batching: bool,
 }
 
 inventory::collect!(ProcessorDescriptor);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_requirement_default_is_allowed() {
+        assert_eq!(InputRequirement::default(), InputRequirement::Allowed);
+    }
+
+    #[test]
+    fn input_requirement_equality() {
+        assert_ne!(InputRequirement::Required, InputRequirement::Forbidden);
+        assert_ne!(InputRequirement::Required, InputRequirement::Allowed);
+        assert_ne!(InputRequirement::Allowed, InputRequirement::Forbidden);
+    }
+}

--- a/crates/runifi-processors/src/evaluate_jsonpath.rs
+++ b/crates/runifi-processors/src/evaluate_jsonpath.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use jsonpath_rust::parser::parse_json_path;
 use jsonpath_rust::query::js_path_process;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -289,6 +289,10 @@ inventory::submit! {
         description: "Extracts values from JSON content using JSONPath expressions",
         factory: || Box::new(EvaluateJsonPath::new()),
         tags: &["JSON", "Extraction"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/extract_text.rs
+++ b/crates/runifi-processors/src/extract_text.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use regex_lite::Regex;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -276,6 +276,10 @@ inventory::submit! {
         description: "Extracts text from FlowFile content using regex capture groups and stores matches as attributes",
         factory: || Box::new(ExtractText::new()),
         tags: &["Text", "Extraction", "Regex"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/flatten_json.rs
+++ b/crates/runifi-processors/src/flatten_json.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -191,6 +191,10 @@ inventory::submit! {
         description: "Flattens nested JSON objects into single-level with dot-notation keys",
         factory: || Box::new(FlattenJson::new()),
         tags: &["JSON", "Transform"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/funnel.rs
+++ b/crates/runifi-processors/src/funnel.rs
@@ -1,6 +1,6 @@
 use runifi_plugin_api::REL_SUCCESS;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -56,6 +56,10 @@ inventory::submit! {
         description: "Merges multiple incoming connections into a single output",
         factory: || Box::new(Funnel),
         tags: &["Flow Control"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/generate_flowfile.rs
+++ b/crates/runifi-processors/src/generate_flowfile.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -107,6 +107,18 @@ impl Processor for GenerateFlowFile {
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
         vec![PROP_FILE_SIZE, PROP_BATCH_SIZE, PROP_DATA_FORMAT]
     }
+
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Forbidden
+    }
+
+    fn trigger_when_empty(&self) -> bool {
+        true
+    }
+
+    fn supports_batching(&self) -> bool {
+        true
+    }
 }
 
 inventory::submit! {
@@ -115,6 +127,10 @@ inventory::submit! {
         description: "Generates FlowFiles with synthetic content for testing and benchmarking",
         factory: || Box::new(GenerateFlowFile::new()),
         tags: &["Data Generation", "Testing"],
+        input_requirement: InputRequirement::Forbidden,
+        trigger_when_empty: true,
+        side_effect_free: false,
+        supports_batching: true,
     }
 }
 

--- a/crates/runifi-processors/src/get_file.rs
+++ b/crates/runifi-processors/src/get_file.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::{PluginError, ProcessResult};
@@ -207,6 +207,14 @@ impl Processor for GetFile {
             PROP_FILE_FILTER,
         ]
     }
+
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Forbidden
+    }
+
+    fn trigger_when_empty(&self) -> bool {
+        true
+    }
 }
 
 inventory::submit! {
@@ -215,6 +223,10 @@ inventory::submit! {
         description: "Watches a directory and ingests files as FlowFiles",
         factory: || Box::new(GetFile::new()),
         tags: &["File System", "Ingestion"],
+        input_requirement: InputRequirement::Forbidden,
+        trigger_when_empty: true,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/log_attribute.rs
+++ b/crates/runifi-processors/src/log_attribute.rs
@@ -1,5 +1,5 @@
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -121,6 +121,14 @@ impl Processor for LogAttribute {
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
         vec![PROP_LOG_LEVEL, PROP_LOG_PAYLOAD]
     }
+
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Required
+    }
+
+    fn side_effect_free(&self) -> bool {
+        true
+    }
 }
 
 inventory::submit! {
@@ -129,6 +137,10 @@ inventory::submit! {
         description: "Logs FlowFile attributes and optionally content for debugging",
         factory: || Box::new(LogAttribute::new()),
         tags: &["Debug", "Logging"],
+        input_requirement: InputRequirement::Required,
+        trigger_when_empty: false,
+        side_effect_free: true,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/parse_syslog.rs
+++ b/crates/runifi-processors/src/parse_syslog.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -401,6 +401,10 @@ inventory::submit! {
         description: "Parses RFC 3164 and RFC 5424 syslog messages into structured FlowFile attributes",
         factory: || Box::new(ParseSyslog::new()),
         tags: &["Parsing", "Syslog"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/pull_flowfile.rs
+++ b/crates/runifi-processors/src/pull_flowfile.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 
 use runifi_plugin_api::REL_SUCCESS;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::{PluginError, ProcessResult};
@@ -191,5 +191,9 @@ inventory::submit! {
         description: "Receives FlowFiles from a remote RuniFi instance via QUIC transport",
         factory: || Box::new(PullFlowFile::new()),
         tags: &["Networking", "Transport", "Site-to-Site"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }

--- a/crates/runifi-processors/src/push_flowfile.rs
+++ b/crates/runifi-processors/src/push_flowfile.rs
@@ -7,7 +7,7 @@
 use std::net::SocketAddr;
 
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::{PluginError, ProcessResult};
@@ -212,5 +212,9 @@ inventory::submit! {
         description: "Sends FlowFiles to a remote RuniFi instance via QUIC transport",
         factory: || Box::new(PushFlowFile::new()),
         tags: &["Networking", "Transport", "Site-to-Site"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }

--- a/crates/runifi-processors/src/put_file.rs
+++ b/crates/runifi-processors/src/put_file.rs
@@ -1,5 +1,5 @@
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::{PluginError, ProcessResult};
@@ -153,6 +153,10 @@ impl Processor for PutFile {
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
         vec![PROP_OUTPUT_DIR, PROP_CONFLICT_STRATEGY]
     }
+
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Required
+    }
 }
 
 inventory::submit! {
@@ -161,6 +165,10 @@ inventory::submit! {
         description: "Writes FlowFile content to files in a directory",
         factory: || Box::new(PutFile::new()),
         tags: &["File System", "Output"],
+        input_requirement: InputRequirement::Required,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/record/convert_record.rs
+++ b/crates/runifi-processors/src/record/convert_record.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::record::{RecordReader, RecordWriter};
 use runifi_plugin_api::relationship::Relationship;
@@ -169,6 +169,10 @@ inventory::submit! {
         description: "Converts FlowFile content between record formats (CSV, JSON, TSV)",
         factory: || Box::new(ConvertRecord::new()),
         tags: &["Record", "Transformation", "Convert"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/record/partition_record.rs
+++ b/crates/runifi-processors/src/record/partition_record.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::record::{Record, RecordReader, RecordValue, RecordWriter};
 use runifi_plugin_api::relationship::Relationship;
@@ -194,6 +194,10 @@ inventory::submit! {
         description: "Splits records into groups by field value, creating one FlowFile per group",
         factory: || Box::new(PartitionRecord::new()),
         tags: &["Record", "Routing", "Partition"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/record/update_record.rs
+++ b/crates/runifi-processors/src/record/update_record.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::record::{RecordReader, RecordValue, RecordWriter};
 use runifi_plugin_api::relationship::Relationship;
@@ -197,6 +197,10 @@ inventory::submit! {
         description: "Modifies record fields within FlowFile content using dynamic properties",
         factory: || Box::new(UpdateRecord::new()),
         tags: &["Record", "Transformation", "Update"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/route_on_attribute.rs
+++ b/crates/runifi-processors/src/route_on_attribute.rs
@@ -1,6 +1,6 @@
 use regex_lite::Regex;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -105,6 +105,14 @@ impl Processor for RouteOnAttribute {
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
         vec![PROP_ATTRIBUTE, PROP_VALUE, PROP_MATCHING_STRATEGY]
     }
+
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Required
+    }
+
+    fn side_effect_free(&self) -> bool {
+        true
+    }
 }
 
 inventory::submit! {
@@ -113,6 +121,10 @@ inventory::submit! {
         description: "Routes FlowFiles based on attribute value matching",
         factory: || Box::new(RouteOnAttribute::new()),
         tags: &["Routing"],
+        input_requirement: InputRequirement::Required,
+        trigger_when_empty: false,
+        side_effect_free: true,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/split_content.rs
+++ b/crates/runifi-processors/src/split_content.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::{PluginError, ProcessResult};
@@ -288,6 +288,10 @@ inventory::submit! {
         description: "Splits binary FlowFile content by a configurable byte sequence delimiter",
         factory: || Box::new(SplitContent::new()),
         tags: &["Transformation", "Content"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/split_json.rs
+++ b/crates/runifi-processors/src/split_json.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -208,6 +208,10 @@ inventory::submit! {
         description: "Splits a JSON array into individual FlowFiles, one per element",
         factory: || Box::new(SplitJson::new()),
         tags: &["JSON", "Transformation", "Split"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/update_attribute.rs
+++ b/crates/runifi-processors/src/update_attribute.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use regex_lite::Regex;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -108,6 +108,14 @@ impl Processor for UpdateAttribute {
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
         vec![PROP_DELETE_ATTRIBUTES]
     }
+
+    fn input_requirement(&self) -> InputRequirement {
+        InputRequirement::Required
+    }
+
+    fn side_effect_free(&self) -> bool {
+        true
+    }
 }
 
 inventory::submit! {
@@ -116,6 +124,10 @@ inventory::submit! {
         description: "Sets or modifies FlowFile attributes based on configured properties",
         factory: || Box::new(UpdateAttribute::new()),
         tags: &["Attribute Manipulation"],
+        input_requirement: InputRequirement::Required,
+        trigger_when_empty: false,
+        side_effect_free: true,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-processors/src/validate_json.rs
+++ b/crates/runifi-processors/src/validate_json.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use runifi_plugin_api::REL_FAILURE;
 use runifi_plugin_api::context::ProcessContext;
-use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
+use runifi_plugin_api::processor::{InputRequirement, Processor, ProcessorDescriptor};
 use runifi_plugin_api::property::PropertyDescriptor;
 use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
@@ -252,6 +252,10 @@ inventory::submit! {
         description: "Validates FlowFile JSON content against a JSON Schema",
         factory: || Box::new(ValidateJson::new()),
         tags: &["JSON", "Validation", "Schema"],
+        input_requirement: InputRequirement::Allowed,
+        trigger_when_empty: false,
+        side_effect_free: false,
+        supports_batching: false,
     }
 }
 

--- a/crates/runifi-server/src/main.rs
+++ b/crates/runifi-server/src/main.rs
@@ -52,6 +52,7 @@ use runifi_core::repository::flowfile_wal::{
 use runifi_core::repository::key_provider::KeyProvider;
 use runifi_core::repository::static_key_provider::StaticKeyProvider;
 use runifi_core::versioning::FlowVersionStore;
+use runifi_plugin_api::InputRequirement;
 
 // Ensure processor registrations are linked in.
 extern crate runifi_processors;
@@ -566,10 +567,25 @@ async fn main() -> Result<()> {
     // Set plugin types on the engine handle.
     let mut plugin_types: Vec<PluginTypeInfo> = Vec::new();
     for name in registry.processor_types() {
+        let (input_requirement, trigger_when_empty, side_effect_free, supports_batching) =
+            if let Some(desc) = registry.processor_descriptor(name) {
+                (
+                    desc.input_requirement,
+                    desc.trigger_when_empty,
+                    desc.side_effect_free,
+                    desc.supports_batching,
+                )
+            } else {
+                (InputRequirement::Allowed, false, false, false)
+            };
         plugin_types.push(PluginTypeInfo {
             type_name: name.to_string(),
             kind: PluginKind::Processor,
             tags: registry.processor_tags(name),
+            input_requirement,
+            trigger_when_empty,
+            side_effect_free,
+            supports_batching,
         });
     }
     for name in registry.source_types() {
@@ -577,6 +593,10 @@ async fn main() -> Result<()> {
             type_name: name.to_string(),
             kind: PluginKind::Source,
             tags: registry.source_tags(name),
+            input_requirement: InputRequirement::Forbidden,
+            trigger_when_empty: true,
+            side_effect_free: false,
+            supports_batching: false,
         });
     }
     for name in registry.sink_types() {
@@ -584,6 +604,10 @@ async fn main() -> Result<()> {
             type_name: name.to_string(),
             kind: PluginKind::Sink,
             tags: registry.sink_tags(name),
+            input_requirement: InputRequirement::Required,
+            trigger_when_empty: false,
+            side_effect_free: false,
+            supports_batching: false,
         });
     }
     for name in registry.service_types() {
@@ -591,6 +615,10 @@ async fn main() -> Result<()> {
             type_name: name.to_string(),
             kind: PluginKind::Service,
             tags: registry.service_tags(name),
+            input_requirement: InputRequirement::Allowed,
+            trigger_when_empty: false,
+            side_effect_free: false,
+            supports_batching: false,
         });
     }
     for name in registry.reporting_task_types() {
@@ -598,6 +626,10 @@ async fn main() -> Result<()> {
             type_name: name.to_string(),
             kind: PluginKind::ReportingTask,
             tags: registry.reporting_task_tags(name),
+            input_requirement: InputRequirement::Allowed,
+            trigger_when_empty: false,
+            side_effect_free: false,
+            supports_batching: false,
         });
     }
     engine.set_plugin_types(plugin_types);


### PR DESCRIPTION
## Summary

Closes #271

- Adds `InputRequirement` enum (`Required`, `Allowed`, `Forbidden`) and behavioral annotation trait methods (`input_requirement()`, `trigger_when_empty()`, `side_effect_free()`, `supports_batching()`) to the `Processor` trait with backward-compatible defaults
- Annotates all 19 built-in processors with correct NiFi-parity values (e.g., GenerateFlowFile/GetFile are `Forbidden` input, LogAttribute/RouteOnAttribute/UpdateAttribute are `side_effect_free`)
- Engine validates `InputRequirement::Forbidden` at connection time — rejects incoming connections to source-only processors during both startup wiring and runtime hot-add
- Exposes annotations in processor status and plugin listing API responses

## Changes

| Layer | Files | What |
|-------|-------|------|
| Plugin API | `processor.rs`, `lib.rs` | `InputRequirement` enum, 4 trait methods, `ProcessorDescriptor` fields |
| Processors | 19 processor files | Correct annotation values per processor |
| Engine | `flow_engine.rs`, `handle.rs`, `mutation_handler.rs`, `mutation.rs` | Read annotations at startup/hot-add, connection validation |
| API | `dto.rs`, `error.rs`, `routes/plugins.rs` | DTOs, error mapping, plugin listing |
| Server | `main.rs` | `PluginTypeInfo` construction |
| Tests | 3 integration test files | Updated `ProcessorDescriptor` fields |

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — all 17 test suites pass (0 failures)
- [x] Unit tests for `InputRequirement` enum (Default, Display, PartialEq)
- [x] Integration tests compile with updated `ProcessorDescriptor` fields
- [x] Connection validation rejects `Forbidden` input processors in `mutation_handler`