### PR TITLE
feat: Remote Process Groups and Site-to-Site protocol (#243)

### DIFF
--- a/crates/runifi-api/src/lib.rs
+++ b/crates/runifi-api/src/lib.rs
@@ -112,6 +112,7 @@ pub fn create_router_with_registry(
         .merge(routes::versions::routes())
         .merge(routes::cluster::routes())
         .merge(routes::process_groups::routes())
+        .merge(routes::remote_process_groups::routes())
         .merge(dashboard::routes())
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/crates/runifi-api/src/routes/mod.rs
+++ b/crates/runifi-api/src/routes/mod.rs
@@ -9,6 +9,7 @@ pub mod plugins;
 pub mod process_groups;
 pub mod processors;
 pub mod provenance;
+pub mod remote_process_groups;
 pub mod reporting_tasks;
 pub mod secrets;
 pub mod services;

--- a/crates/runifi-api/src/routes/remote_process_groups.rs
+++ b/crates/runifi-api/src/routes/remote_process_groups.rs
@@ -1,0 +1,454 @@
+//! API routes for Remote Process Groups and Site-to-Site port listing.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{delete as delete_method, get, post, put};
+use axum::{Json, Router, middleware};
+use serde::{Deserialize, Serialize};
+
+use runifi_core::engine::remote_process_group::{
+    RemotePortInfo, RemoteProcessGroup, RemoteProcessGroupInfo,
+};
+
+use crate::error::ApiError;
+use crate::rbac;
+use crate::state::ApiState;
+
+pub fn routes() -> Router<ApiState> {
+    // GET endpoints — ViewFlow (Viewer+)
+    let view_routes = Router::new()
+        .route(
+            "/api/v1/remote-process-groups",
+            get(list_remote_process_groups),
+        )
+        .route(
+            "/api/v1/remote-process-groups/{id}",
+            get(get_remote_process_group),
+        )
+        .route(
+            "/api/v1/remote-process-groups/{id}/ports",
+            get(list_remote_ports),
+        )
+        .route("/api/v1/site-to-site/ports", get(list_s2s_ports))
+        .layer(middleware::from_fn(rbac::require_view_flow));
+
+    // Mutation endpoints — ModifyFlow (Admin only)
+    let modify_routes = Router::new()
+        .route(
+            "/api/v1/remote-process-groups",
+            post(create_remote_process_group),
+        )
+        .route(
+            "/api/v1/remote-process-groups/{id}",
+            put(update_remote_process_group),
+        )
+        .route(
+            "/api/v1/remote-process-groups/{id}",
+            delete_method(delete_remote_process_group),
+        )
+        .route(
+            "/api/v1/remote-process-groups/{id}/transmission",
+            put(set_transmission),
+        )
+        .route(
+            "/api/v1/remote-process-groups/{id}/ports/{port_id}/transmission",
+            put(set_port_transmission),
+        )
+        .layer(middleware::from_fn(rbac::require_modify_flow));
+
+    view_routes.merge(modify_routes)
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateRpgRequest {
+    pub name: String,
+    pub target_uris: Vec<String>,
+    #[serde(default)]
+    pub transport_protocol: Option<String>,
+    #[serde(default)]
+    pub communications_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub yield_duration_ms: Option<u64>,
+    #[serde(default)]
+    pub batch_count: Option<usize>,
+    #[serde(default)]
+    pub batch_size_bytes: Option<u64>,
+    #[serde(default)]
+    pub batch_duration_ms: Option<u64>,
+    #[serde(default)]
+    pub proxy_host: Option<String>,
+    #[serde(default)]
+    pub proxy_port: Option<u16>,
+    #[serde(default)]
+    pub parent_group_id: Option<String>,
+    #[serde(default)]
+    pub position: Option<PositionDto>,
+    #[serde(default)]
+    pub comments: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateRpgRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub target_uris: Option<Vec<String>>,
+    #[serde(default)]
+    pub transport_protocol: Option<String>,
+    #[serde(default)]
+    pub communications_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub yield_duration_ms: Option<u64>,
+    #[serde(default)]
+    pub batch_count: Option<usize>,
+    #[serde(default)]
+    pub batch_size_bytes: Option<u64>,
+    #[serde(default)]
+    pub batch_duration_ms: Option<u64>,
+    #[serde(default)]
+    pub proxy_host: Option<Option<String>>,
+    #[serde(default)]
+    pub proxy_port: Option<Option<u16>>,
+    #[serde(default)]
+    pub comments: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct TransmissionRequest {
+    pub transmitting: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct PositionDto {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Serialize)]
+pub struct RpgResponse {
+    pub id: String,
+    pub name: String,
+    pub target_uris: Vec<String>,
+    pub transport_protocol: String,
+    pub communications_timeout_ms: u64,
+    pub yield_duration_ms: u64,
+    pub batch_count: usize,
+    pub batch_size_bytes: u64,
+    pub batch_duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy_port: Option<u16>,
+    pub transmitting: bool,
+    pub input_ports: Vec<RemotePortDto>,
+    pub output_ports: Vec<RemotePortDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_group_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<PositionDto>,
+    pub comments: String,
+    pub metrics: MetricsDto,
+}
+
+#[derive(Serialize)]
+pub struct RemotePortDto {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<String>,
+    pub connected: bool,
+    pub transmitting: bool,
+    pub exists_on_remote: bool,
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+    pub flow_files_sent: u64,
+    pub flow_files_received: u64,
+}
+
+#[derive(Serialize)]
+pub struct MetricsDto {
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+    pub flow_files_sent: u64,
+    pub flow_files_received: u64,
+    pub active_thread_count: u32,
+    pub transmission_status: String,
+}
+
+/// Response for the S2S ports endpoint (local ports available for S2S).
+#[derive(Serialize)]
+pub struct S2sPortDto {
+    pub id: String,
+    pub name: String,
+    pub port_type: String,
+    pub group_id: String,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+async fn list_remote_process_groups(State(state): State<ApiState>) -> Json<Vec<RpgResponse>> {
+    let rpgs = state.handle.list_remote_process_groups();
+    Json(rpgs.into_iter().map(to_response).collect())
+}
+
+async fn get_remote_process_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<RpgResponse>, ApiError> {
+    let rpg = state
+        .handle
+        .get_remote_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Remote process group not found: {}", id)))?;
+    Ok(Json(to_response(rpg)))
+}
+
+async fn create_remote_process_group(
+    State(state): State<ApiState>,
+    Json(body): Json<CreateRpgRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    validate_rpg_name(&body.name)?;
+
+    if body.target_uris.is_empty() {
+        return Err(ApiError::BadRequest(
+            "At least one target URI is required".to_string(),
+        ));
+    }
+
+    let mut rpg = RemoteProcessGroup::new(body.name, body.target_uris);
+
+    if let Some(tp) = body.transport_protocol {
+        rpg.transport_protocol = tp;
+    }
+    if let Some(ct) = body.communications_timeout_ms {
+        rpg.communications_timeout_ms = ct;
+    }
+    if let Some(yd) = body.yield_duration_ms {
+        rpg.yield_duration_ms = yd;
+    }
+    if let Some(bc) = body.batch_count {
+        rpg.batch_count = bc;
+    }
+    if let Some(bs) = body.batch_size_bytes {
+        rpg.batch_size_bytes = bs;
+    }
+    if let Some(bd) = body.batch_duration_ms {
+        rpg.batch_duration_ms = bd;
+    }
+    if let Some(ph) = body.proxy_host {
+        rpg.proxy_host = Some(ph);
+    }
+    if let Some(pp) = body.proxy_port {
+        rpg.proxy_port = Some(pp);
+    }
+    if let Some(pg) = body.parent_group_id {
+        rpg.parent_group_id = Some(pg);
+    }
+    if let Some(pos) = body.position {
+        rpg.position = Some((pos.x, pos.y));
+    }
+    if let Some(c) = body.comments {
+        rpg.comments = c;
+    }
+
+    let id = state.handle.add_remote_process_group(rpg);
+
+    let info = state
+        .handle
+        .get_remote_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest("Failed to retrieve created RPG".to_string()))?;
+
+    Ok((StatusCode::CREATED, Json(to_response(info))).into_response())
+}
+
+async fn update_remote_process_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateRpgRequest>,
+) -> Result<Json<RpgResponse>, ApiError> {
+    if let Some(ref name) = body.name {
+        validate_rpg_name(name)?;
+    }
+
+    state
+        .handle
+        .update_remote_process_group(
+            &id,
+            body.name,
+            body.target_uris,
+            body.transport_protocol,
+            body.communications_timeout_ms,
+            body.yield_duration_ms,
+            body.batch_count,
+            body.batch_size_bytes,
+            body.batch_duration_ms,
+            body.proxy_host,
+            body.proxy_port,
+            body.comments,
+        )
+        .map_err(ApiError::BadRequest)?;
+
+    let info = state
+        .handle
+        .get_remote_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Remote process group not found: {}", id)))?;
+
+    Ok(Json(to_response(info)))
+}
+
+async fn delete_remote_process_group(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .remove_remote_process_group(&id)
+        .map_err(ApiError::BadRequest)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn set_transmission(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    Json(body): Json<TransmissionRequest>,
+) -> Result<Json<RpgResponse>, ApiError> {
+    state
+        .handle
+        .set_rpg_transmitting(&id, body.transmitting)
+        .map_err(ApiError::BadRequest)?;
+
+    let info = state
+        .handle
+        .get_remote_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Remote process group not found: {}", id)))?;
+
+    Ok(Json(to_response(info)))
+}
+
+async fn list_remote_ports(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<RemotePortDto>>, ApiError> {
+    let info = state
+        .handle
+        .get_remote_process_group(&id)
+        .ok_or_else(|| ApiError::BadRequest(format!("Remote process group not found: {}", id)))?;
+
+    let mut ports: Vec<RemotePortDto> = info
+        .input_ports
+        .into_iter()
+        .chain(info.output_ports)
+        .map(port_to_dto)
+        .collect();
+
+    ports.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(Json(ports))
+}
+
+async fn set_port_transmission(
+    State(state): State<ApiState>,
+    Path((id, port_id)): Path<(String, String)>,
+    Json(body): Json<TransmissionRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    state
+        .handle
+        .set_rpg_port_transmitting(&id, &port_id, body.transmitting)
+        .map_err(ApiError::BadRequest)?;
+
+    Ok(Json(serde_json::json!({
+        "rpg_id": id,
+        "port_id": port_id,
+        "transmitting": body.transmitting,
+    })))
+}
+
+/// List local ports available for Site-to-Site (inbound endpoint).
+/// Returns all input/output ports on all process groups.
+async fn list_s2s_ports(State(state): State<ApiState>) -> Json<Vec<S2sPortDto>> {
+    let groups = state.handle.list_process_groups();
+    let mut ports = Vec::new();
+
+    for group in groups {
+        for port in &group.input_ports {
+            ports.push(S2sPortDto {
+                id: port.id.clone(),
+                name: port.name.clone(),
+                port_type: "INPUT_PORT".to_string(),
+                group_id: group.id.clone(),
+            });
+        }
+        for port in &group.output_ports {
+            ports.push(S2sPortDto {
+                id: port.id.clone(),
+                name: port.name.clone(),
+                port_type: "OUTPUT_PORT".to_string(),
+                group_id: group.id.clone(),
+            });
+        }
+    }
+
+    Json(ports)
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn validate_rpg_name(name: &str) -> Result<(), ApiError> {
+    if name.is_empty() {
+        return Err(ApiError::BadRequest(
+            "Remote process group name must not be empty".to_string(),
+        ));
+    }
+    if name.len() > 128 {
+        return Err(ApiError::BadRequest(
+            "Remote process group name must not exceed 128 characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn to_response(info: RemoteProcessGroupInfo) -> RpgResponse {
+    RpgResponse {
+        id: info.id,
+        name: info.name,
+        target_uris: info.target_uris,
+        transport_protocol: info.transport_protocol,
+        communications_timeout_ms: info.communications_timeout_ms,
+        yield_duration_ms: info.yield_duration_ms,
+        batch_count: info.batch_count,
+        batch_size_bytes: info.batch_size_bytes,
+        batch_duration_ms: info.batch_duration_ms,
+        proxy_host: info.proxy_host,
+        proxy_port: info.proxy_port,
+        transmitting: info.transmitting,
+        input_ports: info.input_ports.into_iter().map(port_to_dto).collect(),
+        output_ports: info.output_ports.into_iter().map(port_to_dto).collect(),
+        parent_group_id: info.parent_group_id,
+        position: info.position.map(|(x, y)| PositionDto { x, y }),
+        comments: info.comments,
+        metrics: MetricsDto {
+            bytes_sent: info.metrics.bytes_sent,
+            bytes_received: info.metrics.bytes_received,
+            flow_files_sent: info.metrics.flow_files_sent,
+            flow_files_received: info.metrics.flow_files_received,
+            active_thread_count: info.metrics.active_thread_count,
+            transmission_status: info.metrics.transmission_status.to_string(),
+        },
+    }
+}
+
+fn port_to_dto(port: RemotePortInfo) -> RemotePortDto {
+    RemotePortDto {
+        id: port.id,
+        name: port.name,
+        target_id: port.target_id,
+        connected: port.connected,
+        transmitting: port.transmitting,
+        exists_on_remote: port.exists_on_remote,
+        bytes_sent: port.bytes_sent,
+        bytes_received: port.bytes_received,
+        flow_files_sent: port.flow_files_sent,
+        flow_files_received: port.flow_files_received,
+    }
+}

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -577,6 +577,7 @@ impl FlowEngine {
                     self.state_provider.clone(),
                 ),
             ))),
+            remote_process_groups: Arc::new(dashmap::DashMap::new()),
         };
 
         // Wire persistence: pass only the data collections it needs for
@@ -590,6 +591,7 @@ impl FlowEngine {
                 self.service_registry.clone(),
                 labels,
                 process_groups,
+                engine_handle.remote_process_groups.clone(),
             );
             let persist_token = self.cancel_token.child_token();
             let persist_clone = persistence.clone();

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -21,6 +21,7 @@ use super::process_group::{PortInfo, PortType, ProcessGroupId, ProcessGroupInfo}
 use super::processor_node::{
     SchedulingStrategy, SharedInputConnections, SharedInputNotifiers, SharedOutputConnections,
 };
+use super::remote_process_group::RemoteProcessGroup;
 /// Mask value used for sensitive properties in API responses.
 ///
 /// When this value is received in a property update, the existing value
@@ -250,6 +251,8 @@ pub struct EngineHandle {
     pub state_provider: Option<SharedLocalStateProvider>,
     /// Reporting task manager for system-level monitoring tasks.
     pub reporting_task_manager: Option<super::reporting_task_manager::SharedReportingTaskManager>,
+    /// Remote Process Groups for Site-to-Site communication.
+    pub remote_process_groups: Arc<DashMap<String, RemoteProcessGroup>>,
 }
 
 impl EngineHandle {
@@ -1334,6 +1337,57 @@ impl EngineHandle {
             })
             .collect();
 
+        use super::persistence::{PersistedRemotePort, PersistedRemoteProcessGroup};
+
+        let remote_process_groups: Vec<PersistedRemoteProcessGroup> = self
+            .remote_process_groups
+            .iter()
+            .map(|entry| {
+                let rpg = entry.value();
+                PersistedRemoteProcessGroup {
+                    id: rpg.id.clone(),
+                    name: rpg.name.clone(),
+                    target_uris: rpg.target_uris.clone(),
+                    transport_protocol: rpg.transport_protocol.clone(),
+                    communications_timeout_ms: rpg.communications_timeout_ms,
+                    yield_duration_ms: rpg.yield_duration_ms,
+                    batch_count: rpg.batch_count,
+                    batch_size_bytes: rpg.batch_size_bytes,
+                    batch_duration_ms: rpg.batch_duration_ms,
+                    proxy_host: rpg.proxy_host.clone(),
+                    proxy_port: rpg.proxy_port,
+                    transmitting: rpg.transmitting,
+                    input_ports: rpg
+                        .input_ports
+                        .iter()
+                        .map(|p| PersistedRemotePort {
+                            id: p.id.clone(),
+                            name: p.name.clone(),
+                            target_id: p.target_id.clone(),
+                            connected: p.connected,
+                            transmitting: p.transmitting,
+                            exists_on_remote: p.exists_on_remote,
+                        })
+                        .collect(),
+                    output_ports: rpg
+                        .output_ports
+                        .iter()
+                        .map(|p| PersistedRemotePort {
+                            id: p.id.clone(),
+                            name: p.name.clone(),
+                            target_id: p.target_id.clone(),
+                            connected: p.connected,
+                            transmitting: p.transmitting,
+                            exists_on_remote: p.exists_on_remote,
+                        })
+                        .collect(),
+                    parent_group_id: rpg.parent_group_id.clone(),
+                    position: rpg.position,
+                    comments: rpg.comments.clone(),
+                }
+            })
+            .collect();
+
         PersistedFlowState {
             version: 1,
             flow_name: self.flow_name.clone(),
@@ -1343,6 +1397,7 @@ impl EngineHandle {
             services,
             labels,
             process_groups,
+            remote_process_groups,
         }
     }
 
@@ -1824,6 +1879,155 @@ impl EngineHandle {
         path.reverse();
         path
     }
+
+    // ── Remote Process Groups ────────────────────────────────────────────
+
+    /// Add a new Remote Process Group. Returns the generated ID.
+    pub fn add_remote_process_group(&self, rpg: RemoteProcessGroup) -> String {
+        let id = rpg.id.clone();
+        self.remote_process_groups.insert(id.clone(), rpg);
+        self.notify_persist();
+        id
+    }
+
+    /// Remove a Remote Process Group by ID.
+    pub fn remove_remote_process_group(&self, id: &str) -> Result<(), String> {
+        self.remote_process_groups
+            .remove(id)
+            .map(|_| {
+                self.notify_persist();
+            })
+            .ok_or_else(|| format!("Remote process group not found: {}", id))
+    }
+
+    /// Get a snapshot of a Remote Process Group by ID.
+    /// Returns cloneable summary data (not the Arc-wrapped original).
+    pub fn get_remote_process_group(
+        &self,
+        id: &str,
+    ) -> Option<super::remote_process_group::RemoteProcessGroupInfo> {
+        self.remote_process_groups
+            .get(id)
+            .map(|entry| rpg_to_info(entry.value()))
+    }
+
+    /// List all Remote Process Groups.
+    pub fn list_remote_process_groups(
+        &self,
+    ) -> Vec<super::remote_process_group::RemoteProcessGroupInfo> {
+        self.remote_process_groups
+            .iter()
+            .map(|entry| rpg_to_info(entry.value()))
+            .collect()
+    }
+
+    /// Update the configuration of a Remote Process Group.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_remote_process_group(
+        &self,
+        id: &str,
+        name: Option<String>,
+        target_uris: Option<Vec<String>>,
+        transport_protocol: Option<String>,
+        communications_timeout_ms: Option<u64>,
+        yield_duration_ms: Option<u64>,
+        batch_count: Option<usize>,
+        batch_size_bytes: Option<u64>,
+        batch_duration_ms: Option<u64>,
+        proxy_host: Option<Option<String>>,
+        proxy_port: Option<Option<u16>>,
+        comments: Option<String>,
+    ) -> Result<(), String> {
+        let mut entry = self
+            .remote_process_groups
+            .get_mut(id)
+            .ok_or_else(|| format!("Remote process group not found: {}", id))?;
+
+        let rpg = entry.value_mut();
+
+        if let Some(n) = name {
+            rpg.name = n;
+        }
+        if let Some(uris) = target_uris {
+            rpg.target_uris = uris;
+        }
+        if let Some(tp) = transport_protocol {
+            rpg.transport_protocol = tp;
+        }
+        if let Some(ct) = communications_timeout_ms {
+            rpg.communications_timeout_ms = ct;
+        }
+        if let Some(yd) = yield_duration_ms {
+            rpg.yield_duration_ms = yd;
+        }
+        if let Some(bc) = batch_count {
+            rpg.batch_count = bc;
+        }
+        if let Some(bs) = batch_size_bytes {
+            rpg.batch_size_bytes = bs;
+        }
+        if let Some(bd) = batch_duration_ms {
+            rpg.batch_duration_ms = bd;
+        }
+        if let Some(ph) = proxy_host {
+            rpg.proxy_host = ph;
+        }
+        if let Some(pp) = proxy_port {
+            rpg.proxy_port = pp;
+        }
+        if let Some(c) = comments {
+            rpg.comments = c;
+        }
+
+        drop(entry);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Set the global transmitting flag for an RPG.
+    pub fn set_rpg_transmitting(&self, id: &str, transmitting: bool) -> Result<(), String> {
+        let mut entry = self
+            .remote_process_groups
+            .get_mut(id)
+            .ok_or_else(|| format!("Remote process group not found: {}", id))?;
+        entry.value_mut().transmitting = transmitting;
+        drop(entry);
+        self.notify_persist();
+        Ok(())
+    }
+
+    /// Set the transmitting flag for a specific port within an RPG.
+    pub fn set_rpg_port_transmitting(
+        &self,
+        rpg_id: &str,
+        port_id: &str,
+        transmitting: bool,
+    ) -> Result<(), String> {
+        let mut entry = self
+            .remote_process_groups
+            .get_mut(rpg_id)
+            .ok_or_else(|| format!("Remote process group not found: {}", rpg_id))?;
+
+        let rpg = entry.value_mut();
+
+        for port in rpg
+            .input_ports
+            .iter_mut()
+            .chain(rpg.output_ports.iter_mut())
+        {
+            if port.id == port_id {
+                port.transmitting = transmitting;
+                drop(entry);
+                self.notify_persist();
+                return Ok(());
+            }
+        }
+
+        Err(format!(
+            "Port '{}' not found in remote process group '{}'",
+            port_id, rpg_id
+        ))
+    }
 }
 
 /// Scoped flow topology for a process group.
@@ -1837,4 +2041,46 @@ pub struct GroupFlowInfo {
     pub connections: Vec<ConnectionInfo>,
     /// Child process groups nested in this group.
     pub child_groups: Vec<ProcessGroupInfo>,
+}
+
+/// Convert a `RemoteProcessGroup` to its cloneable info snapshot.
+fn rpg_to_info(rpg: &RemoteProcessGroup) -> super::remote_process_group::RemoteProcessGroupInfo {
+    use super::remote_process_group::{RemotePortInfo, RemoteProcessGroupInfo};
+    use std::sync::atomic::Ordering;
+
+    let port_to_info = |p: &super::remote_process_group::RemotePortStatus| -> RemotePortInfo {
+        RemotePortInfo {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            target_id: p.target_id.clone(),
+            connected: p.connected,
+            transmitting: p.transmitting,
+            exists_on_remote: p.exists_on_remote,
+            bytes_sent: p.bytes_sent.load(Ordering::Relaxed),
+            bytes_received: p.bytes_received.load(Ordering::Relaxed),
+            flow_files_sent: p.flow_files_sent.load(Ordering::Relaxed),
+            flow_files_received: p.flow_files_received.load(Ordering::Relaxed),
+        }
+    };
+
+    RemoteProcessGroupInfo {
+        id: rpg.id.clone(),
+        name: rpg.name.clone(),
+        target_uris: rpg.target_uris.clone(),
+        transport_protocol: rpg.transport_protocol.clone(),
+        communications_timeout_ms: rpg.communications_timeout_ms,
+        yield_duration_ms: rpg.yield_duration_ms,
+        batch_count: rpg.batch_count,
+        batch_size_bytes: rpg.batch_size_bytes,
+        batch_duration_ms: rpg.batch_duration_ms,
+        proxy_host: rpg.proxy_host.clone(),
+        proxy_port: rpg.proxy_port,
+        transmitting: rpg.transmitting,
+        input_ports: rpg.input_ports.iter().map(port_to_info).collect(),
+        output_ports: rpg.output_ports.iter().map(port_to_info).collect(),
+        parent_group_id: rpg.parent_group_id.clone(),
+        position: rpg.position,
+        comments: rpg.comments.clone(),
+        metrics: rpg.metrics(),
+    }
 }

--- a/crates/runifi-core/src/engine/mod.rs
+++ b/crates/runifi-core/src/engine/mod.rs
@@ -7,6 +7,7 @@ pub mod mutation_handler;
 pub mod persistence;
 pub mod process_group;
 pub mod processor_node;
+pub mod remote_process_group;
 pub mod reporting_supervisor;
 pub mod reporting_task_manager;
 pub mod stateless_executor;

--- a/crates/runifi-core/src/engine/persistence.rs
+++ b/crates/runifi-core/src/engine/persistence.rs
@@ -13,6 +13,7 @@ use zeroize::Zeroizing;
 
 use super::handle::{ConnectionInfo, LabelInfo, Position, ProcessorInfo};
 use super::process_group::ProcessGroupInfo;
+use super::remote_process_group::RemoteProcessGroup;
 
 /// File names for persisted flow state.
 const FLOW_STATE_FILE: &str = "flow.json";
@@ -46,6 +47,8 @@ pub struct PersistedFlowState {
     pub labels: Vec<PersistedLabel>,
     #[serde(default)]
     pub process_groups: Vec<PersistedProcessGroup>,
+    #[serde(default)]
+    pub remote_process_groups: Vec<PersistedRemoteProcessGroup>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -191,6 +194,76 @@ pub struct PersistedPort {
     pub port_type: String,
 }
 
+/// Persisted Remote Process Group data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedRemoteProcessGroup {
+    pub id: String,
+    pub name: String,
+    pub target_uris: Vec<String>,
+    #[serde(default = "default_transport_protocol")]
+    pub transport_protocol: String,
+    #[serde(default = "default_communications_timeout_ms")]
+    pub communications_timeout_ms: u64,
+    #[serde(default = "default_yield_duration_ms")]
+    pub yield_duration_ms: u64,
+    #[serde(default = "default_batch_count")]
+    pub batch_count: usize,
+    #[serde(default = "default_batch_size_bytes")]
+    pub batch_size_bytes: u64,
+    #[serde(default = "default_batch_duration_ms")]
+    pub batch_duration_ms: u64,
+    #[serde(default)]
+    pub proxy_host: Option<String>,
+    #[serde(default)]
+    pub proxy_port: Option<u16>,
+    #[serde(default)]
+    pub transmitting: bool,
+    #[serde(default)]
+    pub input_ports: Vec<PersistedRemotePort>,
+    #[serde(default)]
+    pub output_ports: Vec<PersistedRemotePort>,
+    #[serde(default)]
+    pub parent_group_id: Option<String>,
+    #[serde(default)]
+    pub position: Option<(f64, f64)>,
+    #[serde(default)]
+    pub comments: String,
+}
+
+/// Persisted remote port data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedRemotePort {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub target_id: Option<String>,
+    #[serde(default)]
+    pub connected: bool,
+    #[serde(default)]
+    pub transmitting: bool,
+    #[serde(default)]
+    pub exists_on_remote: bool,
+}
+
+fn default_transport_protocol() -> String {
+    "QUIC".to_string()
+}
+fn default_communications_timeout_ms() -> u64 {
+    30_000
+}
+fn default_yield_duration_ms() -> u64 {
+    1_000
+}
+fn default_batch_count() -> usize {
+    100
+}
+fn default_batch_size_bytes() -> u64 {
+    5_000_000
+}
+fn default_batch_duration_ms() -> u64 {
+    5_000
+}
+
 // ── Snapshot source — breaks the Arc cycle ────────────────────────────────────
 
 /// The subset of engine state needed for persistence snapshotting.
@@ -206,6 +279,7 @@ pub(crate) struct SnapshotSource {
     pub service_registry: crate::registry::service_registry::SharedServiceRegistry,
     pub labels: Arc<RwLock<Vec<LabelInfo>>>,
     pub process_groups: Arc<RwLock<Vec<ProcessGroupInfo>>>,
+    pub remote_process_groups: Arc<DashMap<String, RemoteProcessGroup>>,
 }
 
 // ── Snapshot from live engine state ───────────────────────────────────────────
@@ -437,6 +511,57 @@ impl PersistedFlowState {
             })
             .collect();
 
+        let remote_process_groups: Vec<PersistedRemoteProcessGroup> = source
+            .remote_process_groups
+            .iter()
+            .map(|entry| {
+                let rpg = entry.value();
+                let input_ports: Vec<PersistedRemotePort> = rpg
+                    .input_ports
+                    .iter()
+                    .map(|p| PersistedRemotePort {
+                        id: p.id.clone(),
+                        name: p.name.clone(),
+                        target_id: p.target_id.clone(),
+                        connected: p.connected,
+                        transmitting: p.transmitting,
+                        exists_on_remote: p.exists_on_remote,
+                    })
+                    .collect();
+                let output_ports: Vec<PersistedRemotePort> = rpg
+                    .output_ports
+                    .iter()
+                    .map(|p| PersistedRemotePort {
+                        id: p.id.clone(),
+                        name: p.name.clone(),
+                        target_id: p.target_id.clone(),
+                        connected: p.connected,
+                        transmitting: p.transmitting,
+                        exists_on_remote: p.exists_on_remote,
+                    })
+                    .collect();
+                PersistedRemoteProcessGroup {
+                    id: rpg.id.clone(),
+                    name: rpg.name.clone(),
+                    target_uris: rpg.target_uris.clone(),
+                    transport_protocol: rpg.transport_protocol.clone(),
+                    communications_timeout_ms: rpg.communications_timeout_ms,
+                    yield_duration_ms: rpg.yield_duration_ms,
+                    batch_count: rpg.batch_count,
+                    batch_size_bytes: rpg.batch_size_bytes,
+                    batch_duration_ms: rpg.batch_duration_ms,
+                    proxy_host: rpg.proxy_host.clone(),
+                    proxy_port: rpg.proxy_port,
+                    transmitting: rpg.transmitting,
+                    input_ports,
+                    output_ports,
+                    parent_group_id: rpg.parent_group_id.clone(),
+                    position: rpg.position,
+                    comments: rpg.comments.clone(),
+                }
+            })
+            .collect();
+
         Self {
             version: CURRENT_VERSION,
             flow_name: source.flow_name.clone(),
@@ -446,6 +571,7 @@ impl PersistedFlowState {
             services,
             labels,
             process_groups,
+            remote_process_groups,
         }
     }
 }
@@ -685,6 +811,7 @@ impl FlowPersistence {
         service_registry: crate::registry::service_registry::SharedServiceRegistry,
         labels: Arc<RwLock<Vec<LabelInfo>>>,
         process_groups: Arc<RwLock<Vec<ProcessGroupInfo>>>,
+        remote_process_groups: Arc<DashMap<String, RemoteProcessGroup>>,
     ) {
         *self.inner.source.write() = Some(SnapshotSource {
             flow_name,
@@ -694,6 +821,7 @@ impl FlowPersistence {
             service_registry,
             labels,
             process_groups,
+            remote_process_groups,
         });
     }
 
@@ -805,6 +933,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         }
     }
 
@@ -882,6 +1011,7 @@ mod tests {
                 font_size: 14.0,
             }],
             process_groups: vec![],
+            remote_process_groups: vec![],
         };
 
         let json = serde_json::to_string_pretty(&state).unwrap();
@@ -933,6 +1063,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         };
         atomic_write(&conf_dir, &state2).unwrap();
 
@@ -1033,6 +1164,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         };
 
         atomic_write(&conf_dir, &state).unwrap();
@@ -1075,6 +1207,7 @@ mod tests {
         let service_registry = crate::registry::service_registry::SharedServiceRegistry::new();
         let labels = Arc::new(RwLock::new(Vec::new()));
         let process_groups = Arc::new(RwLock::new(Vec::new()));
+        let remote_process_groups = Arc::new(DashMap::new());
         persistence.set_source(
             "debounce-test".to_string(),
             processors,
@@ -1083,6 +1216,7 @@ mod tests {
             service_registry,
             labels,
             process_groups,
+            remote_process_groups,
         );
 
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -1154,6 +1288,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         };
 
         // Decrypt with the correct key.
@@ -1200,6 +1335,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         };
 
         // No key provided — should fail.

--- a/crates/runifi-core/src/engine/remote_process_group.rs
+++ b/crates/runifi-core/src/engine/remote_process_group.rs
@@ -1,0 +1,329 @@
+//! Remote Process Group (RPG) data structures.
+//!
+//! An RPG represents a reference to a remote RuniFi instance on the flow canvas.
+//! It holds configuration for Site-to-Site (S2S) communication and tracks the
+//! status of remote input/output ports used for inter-instance data transfer.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+// ── ID generation ────────────────────────────────────────────────────────────
+
+static RPG_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Generate a unique RPG ID.
+pub fn next_rpg_id() -> String {
+    let id = RPG_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("rpg-{}", id)
+}
+
+/// Reset the RPG ID counter (used when restoring persisted state).
+pub fn reset_rpg_id_counter(next_id: u64) {
+    RPG_ID_COUNTER.store(next_id, Ordering::Relaxed);
+}
+
+// ── Core types ───────────────────────────────────────────────────────────────
+
+/// A Remote Process Group — represents a remote RuniFi instance on the canvas.
+#[derive(Debug)]
+pub struct RemoteProcessGroup {
+    /// Unique identifier.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Remote instance URLs (one or more for failover).
+    pub target_uris: Vec<String>,
+    /// Transport protocol ("QUIC").
+    pub transport_protocol: String,
+    /// Communications timeout in milliseconds.
+    pub communications_timeout_ms: u64,
+    /// Yield duration in milliseconds when no data is available.
+    pub yield_duration_ms: u64,
+    /// Maximum FlowFiles per batch.
+    pub batch_count: usize,
+    /// Maximum bytes per batch.
+    pub batch_size_bytes: u64,
+    /// Maximum batch duration in milliseconds.
+    pub batch_duration_ms: u64,
+    /// Optional proxy host.
+    pub proxy_host: Option<String>,
+    /// Optional proxy port.
+    pub proxy_port: Option<u16>,
+    /// Whether transmission is globally enabled for this RPG.
+    pub transmitting: bool,
+    /// Remote input ports discovered or configured.
+    pub input_ports: Vec<RemotePortStatus>,
+    /// Remote output ports discovered or configured.
+    pub output_ports: Vec<RemotePortStatus>,
+    /// Last time remote ports were refreshed from the remote instance.
+    pub last_refresh: Option<Instant>,
+    /// Authentication token for the remote instance.
+    pub auth_token: Option<String>,
+    /// Parent process group ID.
+    pub parent_group_id: Option<String>,
+    /// Canvas position (x, y).
+    pub position: Option<(f64, f64)>,
+    /// User comments.
+    pub comments: String,
+}
+
+impl RemoteProcessGroup {
+    /// Create a new RPG with the given name and target URIs.
+    pub fn new(name: String, target_uris: Vec<String>) -> Self {
+        Self {
+            id: next_rpg_id(),
+            name,
+            target_uris,
+            transport_protocol: "QUIC".to_string(),
+            communications_timeout_ms: 30_000,
+            yield_duration_ms: 1_000,
+            batch_count: 100,
+            batch_size_bytes: 5_000_000,
+            batch_duration_ms: 5_000,
+            proxy_host: None,
+            proxy_port: None,
+            transmitting: false,
+            input_ports: Vec::new(),
+            output_ports: Vec::new(),
+            last_refresh: None,
+            auth_token: None,
+            parent_group_id: None,
+            position: None,
+            comments: String::new(),
+        }
+    }
+
+    /// Aggregate metrics from all ports.
+    pub fn metrics(&self) -> RemoteProcessGroupMetrics {
+        let mut m = RemoteProcessGroupMetrics {
+            bytes_sent: 0,
+            bytes_received: 0,
+            flow_files_sent: 0,
+            flow_files_received: 0,
+            active_thread_count: 0,
+            transmission_status: if self.transmitting {
+                TransmissionStatus::Transmitting
+            } else {
+                TransmissionStatus::Stopped
+            },
+        };
+
+        for port in &self.input_ports {
+            m.bytes_sent += port.bytes_sent.load(Ordering::Relaxed);
+            m.bytes_received += port.bytes_received.load(Ordering::Relaxed);
+            m.flow_files_sent += port.flow_files_sent.load(Ordering::Relaxed);
+            m.flow_files_received += port.flow_files_received.load(Ordering::Relaxed);
+            m.active_thread_count += port.active_threads.load(Ordering::Relaxed);
+        }
+
+        for port in &self.output_ports {
+            m.bytes_sent += port.bytes_sent.load(Ordering::Relaxed);
+            m.bytes_received += port.bytes_received.load(Ordering::Relaxed);
+            m.flow_files_sent += port.flow_files_sent.load(Ordering::Relaxed);
+            m.flow_files_received += port.flow_files_received.load(Ordering::Relaxed);
+            m.active_thread_count += port.active_threads.load(Ordering::Relaxed);
+        }
+
+        m
+    }
+}
+
+/// Status and metrics for a single remote port.
+#[derive(Debug)]
+pub struct RemotePortStatus {
+    /// Unique identifier for this port mapping.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// ID of the port on the remote instance.
+    pub target_id: Option<String>,
+    /// Whether this port is connected to a local connection.
+    pub connected: bool,
+    /// Whether this individual port is enabled for transmission.
+    pub transmitting: bool,
+    /// Whether the port exists on the remote instance (verified on refresh).
+    pub exists_on_remote: bool,
+    // Metrics (atomics for lock-free concurrent access)
+    pub bytes_sent: AtomicU64,
+    pub bytes_received: AtomicU64,
+    pub flow_files_sent: AtomicU64,
+    pub flow_files_received: AtomicU64,
+    pub active_threads: AtomicU32,
+}
+
+impl RemotePortStatus {
+    /// Create a new port status with the given id and name.
+    pub fn new(id: String, name: String) -> Self {
+        Self {
+            id,
+            name,
+            target_id: None,
+            connected: false,
+            transmitting: false,
+            exists_on_remote: false,
+            bytes_sent: AtomicU64::new(0),
+            bytes_received: AtomicU64::new(0),
+            flow_files_sent: AtomicU64::new(0),
+            flow_files_received: AtomicU64::new(0),
+            active_threads: AtomicU32::new(0),
+        }
+    }
+}
+
+/// Aggregated metrics for a Remote Process Group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteProcessGroupMetrics {
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+    pub flow_files_sent: u64,
+    pub flow_files_received: u64,
+    pub active_thread_count: u32,
+    pub transmission_status: TransmissionStatus,
+}
+
+/// Transmission status for an RPG.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TransmissionStatus {
+    Transmitting,
+    Stopped,
+    Error(String),
+}
+
+impl std::fmt::Display for TransmissionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransmissionStatus::Transmitting => write!(f, "TRANSMITTING"),
+            TransmissionStatus::Stopped => write!(f, "STOPPED"),
+            TransmissionStatus::Error(msg) => write!(f, "ERROR: {}", msg),
+        }
+    }
+}
+
+/// Cloneable snapshot of an RPG, suitable for API responses.
+/// Unlike `RemoteProcessGroup` (which has atomics), this is a plain data struct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteProcessGroupInfo {
+    pub id: String,
+    pub name: String,
+    pub target_uris: Vec<String>,
+    pub transport_protocol: String,
+    pub communications_timeout_ms: u64,
+    pub yield_duration_ms: u64,
+    pub batch_count: usize,
+    pub batch_size_bytes: u64,
+    pub batch_duration_ms: u64,
+    pub proxy_host: Option<String>,
+    pub proxy_port: Option<u16>,
+    pub transmitting: bool,
+    pub input_ports: Vec<RemotePortInfo>,
+    pub output_ports: Vec<RemotePortInfo>,
+    pub parent_group_id: Option<String>,
+    pub position: Option<(f64, f64)>,
+    pub comments: String,
+    pub metrics: RemoteProcessGroupMetrics,
+}
+
+/// Cloneable snapshot of a remote port status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemotePortInfo {
+    pub id: String,
+    pub name: String,
+    pub target_id: Option<String>,
+    pub connected: bool,
+    pub transmitting: bool,
+    pub exists_on_remote: bool,
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+    pub flow_files_sent: u64,
+    pub flow_files_received: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_rpg() {
+        let rpg = RemoteProcessGroup::new(
+            "remote-cluster".to_string(),
+            vec!["https://remote:8443".to_string()],
+        );
+        assert!(rpg.id.starts_with("rpg-"));
+        assert_eq!(rpg.name, "remote-cluster");
+        assert_eq!(rpg.target_uris.len(), 1);
+        assert_eq!(rpg.transport_protocol, "QUIC");
+        assert!(!rpg.transmitting);
+        assert!(rpg.input_ports.is_empty());
+        assert!(rpg.output_ports.is_empty());
+    }
+
+    #[test]
+    fn test_rpg_metrics_empty() {
+        let rpg = RemoteProcessGroup::new("test".to_string(), vec![]);
+        let m = rpg.metrics();
+        assert_eq!(m.bytes_sent, 0);
+        assert_eq!(m.bytes_received, 0);
+        assert_eq!(m.flow_files_sent, 0);
+        assert_eq!(m.flow_files_received, 0);
+        assert_eq!(m.active_thread_count, 0);
+        assert_eq!(m.transmission_status, TransmissionStatus::Stopped);
+    }
+
+    #[test]
+    fn test_rpg_metrics_aggregation() {
+        let mut rpg = RemoteProcessGroup::new("test".to_string(), vec![]);
+        rpg.transmitting = true;
+
+        let port1 = RemotePortStatus::new("p1".to_string(), "port-1".to_string());
+        port1.bytes_sent.store(100, Ordering::Relaxed);
+        port1.flow_files_sent.store(5, Ordering::Relaxed);
+
+        let port2 = RemotePortStatus::new("p2".to_string(), "port-2".to_string());
+        port2.bytes_received.store(200, Ordering::Relaxed);
+        port2.flow_files_received.store(10, Ordering::Relaxed);
+        port2.active_threads.store(2, Ordering::Relaxed);
+
+        rpg.input_ports.push(port1);
+        rpg.output_ports.push(port2);
+
+        let m = rpg.metrics();
+        assert_eq!(m.bytes_sent, 100);
+        assert_eq!(m.bytes_received, 200);
+        assert_eq!(m.flow_files_sent, 5);
+        assert_eq!(m.flow_files_received, 10);
+        assert_eq!(m.active_thread_count, 2);
+        assert_eq!(m.transmission_status, TransmissionStatus::Transmitting);
+    }
+
+    #[test]
+    fn test_port_status_new() {
+        let port = RemotePortStatus::new("port-1".to_string(), "test-port".to_string());
+        assert_eq!(port.id, "port-1");
+        assert_eq!(port.name, "test-port");
+        assert!(!port.connected);
+        assert!(!port.transmitting);
+        assert!(!port.exists_on_remote);
+        assert_eq!(port.bytes_sent.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_transmission_status_display() {
+        assert_eq!(TransmissionStatus::Transmitting.to_string(), "TRANSMITTING");
+        assert_eq!(TransmissionStatus::Stopped.to_string(), "STOPPED");
+        assert_eq!(
+            TransmissionStatus::Error("timeout".to_string()).to_string(),
+            "ERROR: timeout"
+        );
+    }
+
+    #[test]
+    fn test_rpg_id_generation() {
+        let id1 = next_rpg_id();
+        let id2 = next_rpg_id();
+        assert_ne!(id1, id2);
+        assert!(id1.starts_with("rpg-"));
+        assert!(id2.starts_with("rpg-"));
+    }
+}

--- a/crates/runifi-core/src/versioning/diff.rs
+++ b/crates/runifi-core/src/versioning/diff.rs
@@ -271,6 +271,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         }
     }
 

--- a/crates/runifi-core/src/versioning/version_store.rs
+++ b/crates/runifi-core/src/versioning/version_store.rs
@@ -371,6 +371,7 @@ mod tests {
             services: vec![],
             labels: vec![],
             process_groups: vec![],
+            remote_process_groups: vec![],
         }
     }
 

--- a/crates/runifi-transport/src/lib.rs
+++ b/crates/runifi-transport/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod client;
 pub mod error;
 pub mod protocol;
+pub mod s2s;
 pub mod server;
 pub mod tls;
 pub mod transfer;
@@ -20,5 +21,6 @@ pub mod transfer;
 pub use client::{ClientConfig, QuicClient};
 pub use error::{TransportError, TransportResult};
 pub use protocol::WireFlowFile;
+pub use s2s::{RemotePort, RemotePortType, S2sConfig, S2sFrame, TransportProtocol};
 pub use server::{QuicServer, ServerConfig};
 pub use tls::CertKeyPair;

--- a/crates/runifi-transport/src/protocol.rs
+++ b/crates/runifi-transport/src/protocol.rs
@@ -45,6 +45,21 @@ pub enum FrameType {
     FlowFileBatch = 0x05,
     /// End of stream marker.
     EndOfStream = 0xFF,
+    // ── Site-to-Site protocol frames ─────────────────────────────────────────
+    /// S2S port enumeration request.
+    S2sPortEnumRequest = 0x10,
+    /// S2S port enumeration response.
+    S2sPortEnumResponse = 0x11,
+    /// S2S peer status request.
+    S2sPeerStatusRequest = 0x12,
+    /// S2S peer status response.
+    S2sPeerStatusResponse = 0x13,
+    /// S2S transaction begin.
+    S2sTxnBegin = 0x14,
+    /// S2S transaction commit.
+    S2sTxnCommit = 0x15,
+    /// S2S transaction rollback.
+    S2sTxnRollback = 0x16,
 }
 
 impl FrameType {
@@ -55,6 +70,13 @@ impl FrameType {
             0x03 => Ok(Self::Ack),
             0x04 => Ok(Self::BackPressure),
             0x05 => Ok(Self::FlowFileBatch),
+            0x10 => Ok(Self::S2sPortEnumRequest),
+            0x11 => Ok(Self::S2sPortEnumResponse),
+            0x12 => Ok(Self::S2sPeerStatusRequest),
+            0x13 => Ok(Self::S2sPeerStatusResponse),
+            0x14 => Ok(Self::S2sTxnBegin),
+            0x15 => Ok(Self::S2sTxnCommit),
+            0x16 => Ok(Self::S2sTxnRollback),
             0xFF => Ok(Self::EndOfStream),
             other => Err(TransportError::Protocol(format!(
                 "unknown frame type: 0x{other:02x}"
@@ -466,6 +488,17 @@ pub fn decode_frame(data: &[u8]) -> TransportResult<DecodedFrame> {
             Ok(DecodedFrame::BackPressure { available_capacity })
         }
         FrameType::EndOfStream => Ok(DecodedFrame::EndOfStream),
+        // S2S frames are handled by the s2s module's own decode functions.
+        FrameType::S2sPortEnumRequest
+        | FrameType::S2sPortEnumResponse
+        | FrameType::S2sPeerStatusRequest
+        | FrameType::S2sPeerStatusResponse
+        | FrameType::S2sTxnBegin
+        | FrameType::S2sTxnCommit
+        | FrameType::S2sTxnRollback => Err(TransportError::Protocol(format!(
+            "S2S frame type 0x{:02x} should be decoded via the s2s module",
+            frame_type as u8,
+        ))),
     }
 }
 

--- a/crates/runifi-transport/src/s2s.rs
+++ b/crates/runifi-transport/src/s2s.rs
@@ -1,0 +1,466 @@
+//! Site-to-Site (S2S) protocol types and frame encode/decode.
+//!
+//! S2S extends the base QUIC protocol with peer communication for
+//! remote process group support: port enumeration, peer health status,
+//! and transactional FlowFile transfers between RuniFi instances.
+
+use std::time::Duration;
+
+use bytes::{Buf, BufMut, BytesMut};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{TransportError, TransportResult};
+use crate::protocol::FrameType;
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/// Configuration for a Site-to-Site connection to a remote instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S2sConfig {
+    /// Remote instance URL (e.g., "https://remote-host:8443").
+    pub remote_url: String,
+    /// Transport protocol to use.
+    pub transport_protocol: TransportProtocol,
+    /// Timeout for communications with the remote instance.
+    #[serde(with = "duration_ms")]
+    pub communications_timeout: Duration,
+    /// Yield duration when no data is available.
+    #[serde(with = "duration_ms")]
+    pub yield_duration: Duration,
+    /// Maximum number of FlowFiles per transaction batch.
+    pub batch_count: usize,
+    /// Maximum bytes per transaction batch.
+    pub batch_size_bytes: u64,
+    /// Maximum duration for a transaction batch.
+    #[serde(with = "duration_ms")]
+    pub batch_duration: Duration,
+}
+
+impl Default for S2sConfig {
+    fn default() -> Self {
+        Self {
+            remote_url: String::new(),
+            transport_protocol: TransportProtocol::Quic,
+            communications_timeout: Duration::from_secs(30),
+            yield_duration: Duration::from_secs(1),
+            batch_count: 100,
+            batch_size_bytes: 5_000_000,
+            batch_duration: Duration::from_secs(5),
+        }
+    }
+}
+
+/// Transport protocol for S2S communication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransportProtocol {
+    /// QUIC transport (default and only supported protocol).
+    Quic,
+}
+
+impl std::fmt::Display for TransportProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransportProtocol::Quic => write!(f, "QUIC"),
+        }
+    }
+}
+
+// ── Remote port types ────────────────────────────────────────────────────────
+
+/// Information about a port on a remote RuniFi instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemotePort {
+    /// Unique identifier for this port on the remote instance.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Whether this is an input or output port.
+    pub port_type: RemotePortType,
+    /// Whether the port is connected to a local connection.
+    pub connected: bool,
+    /// Whether the port is actively transmitting.
+    pub transmitting: bool,
+}
+
+/// The type of a remote port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RemotePortType {
+    /// Receives FlowFiles from the remote instance (remote output port).
+    Input,
+    /// Sends FlowFiles to the remote instance (remote input port).
+    Output,
+}
+
+impl std::fmt::Display for RemotePortType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RemotePortType::Input => write!(f, "INPUT"),
+            RemotePortType::Output => write!(f, "OUTPUT"),
+        }
+    }
+}
+
+// ── S2S decoded frames ───────────────────────────────────────────────────────
+
+/// A decoded S2S protocol frame.
+#[derive(Debug, Clone)]
+pub enum S2sFrame {
+    /// Request to enumerate available ports on the remote instance.
+    PortEnumRequest,
+    /// Response with available ports.
+    PortEnumResponse { ports: Vec<RemotePort> },
+    /// Request for peer health/load status.
+    PeerStatusRequest,
+    /// Response with peer health/load status.
+    PeerStatusResponse {
+        /// Load factor (0.0 = idle, 1.0 = fully loaded).
+        load: f64,
+        /// Number of FlowFiles currently queued.
+        flow_files_queued: u64,
+    },
+    /// Begin a new transaction for the specified port.
+    TxnBegin { port_id: String },
+    /// Commit an active transaction.
+    TxnCommit { transaction_id: String },
+    /// Roll back an active transaction.
+    TxnRollback { transaction_id: String },
+}
+
+// ── Encoding ─────────────────────────────────────────────────────────────────
+
+/// Encode a port enumeration request frame.
+pub fn encode_port_enum_request() -> BytesMut {
+    let mut buf = BytesMut::with_capacity(1);
+    buf.put_u8(FrameType::S2sPortEnumRequest as u8);
+    buf
+}
+
+/// Encode a port enumeration response frame.
+pub fn encode_port_enum_response(ports: &[RemotePort]) -> BytesMut {
+    let mut size = 1 + 4; // frame_type + port_count
+    for p in ports {
+        // id_len(2) + id + name_len(2) + name + port_type(1) + connected(1) + transmitting(1)
+        size += 2 + p.id.len() + 2 + p.name.len() + 1 + 1 + 1;
+    }
+
+    let mut buf = BytesMut::with_capacity(size);
+    buf.put_u8(FrameType::S2sPortEnumResponse as u8);
+    buf.put_u32(ports.len() as u32);
+
+    for p in ports {
+        buf.put_u16(p.id.len() as u16);
+        buf.put_slice(p.id.as_bytes());
+        buf.put_u16(p.name.len() as u16);
+        buf.put_slice(p.name.as_bytes());
+        buf.put_u8(match p.port_type {
+            RemotePortType::Input => 0,
+            RemotePortType::Output => 1,
+        });
+        buf.put_u8(u8::from(p.connected));
+        buf.put_u8(u8::from(p.transmitting));
+    }
+
+    buf
+}
+
+/// Encode a peer status request frame.
+pub fn encode_peer_status_request() -> BytesMut {
+    let mut buf = BytesMut::with_capacity(1);
+    buf.put_u8(FrameType::S2sPeerStatusRequest as u8);
+    buf
+}
+
+/// Encode a peer status response frame.
+pub fn encode_peer_status_response(load: f64, flow_files_queued: u64) -> BytesMut {
+    let mut buf = BytesMut::with_capacity(1 + 8 + 8);
+    buf.put_u8(FrameType::S2sPeerStatusResponse as u8);
+    buf.put_f64(load);
+    buf.put_u64(flow_files_queued);
+    buf
+}
+
+/// Encode a transaction begin frame.
+pub fn encode_txn_begin(port_id: &str) -> BytesMut {
+    let mut buf = BytesMut::with_capacity(1 + 2 + port_id.len());
+    buf.put_u8(FrameType::S2sTxnBegin as u8);
+    buf.put_u16(port_id.len() as u16);
+    buf.put_slice(port_id.as_bytes());
+    buf
+}
+
+/// Encode a transaction commit frame.
+pub fn encode_txn_commit(transaction_id: &str) -> BytesMut {
+    let mut buf = BytesMut::with_capacity(1 + 2 + transaction_id.len());
+    buf.put_u8(FrameType::S2sTxnCommit as u8);
+    buf.put_u16(transaction_id.len() as u16);
+    buf.put_slice(transaction_id.as_bytes());
+    buf
+}
+
+/// Encode a transaction rollback frame.
+pub fn encode_txn_rollback(transaction_id: &str) -> BytesMut {
+    let mut buf = BytesMut::with_capacity(1 + 2 + transaction_id.len());
+    buf.put_u8(FrameType::S2sTxnRollback as u8);
+    buf.put_u16(transaction_id.len() as u16);
+    buf.put_slice(transaction_id.as_bytes());
+    buf
+}
+
+// ── Decoding ─────────────────────────────────────────────────────────────────
+
+/// Decode a length-prefixed UTF-8 string (u16 length prefix) from a buffer.
+fn decode_string(buf: &mut &[u8]) -> TransportResult<String> {
+    if buf.remaining() < 2 {
+        return Err(TransportError::Protocol("missing string length".into()));
+    }
+    let len = buf.get_u16() as usize;
+    if buf.remaining() < len {
+        return Err(TransportError::Protocol("truncated string".into()));
+    }
+    let s = std::str::from_utf8(&buf[..len])
+        .map_err(|e| TransportError::Protocol(format!("invalid UTF-8: {e}")))?
+        .to_string();
+    buf.advance(len);
+    Ok(s)
+}
+
+/// Decode an S2S frame from raw bytes. The first byte must be the frame type.
+pub fn decode_s2s_frame(data: &[u8]) -> TransportResult<S2sFrame> {
+    if data.is_empty() {
+        return Err(TransportError::Protocol("empty S2S frame".into()));
+    }
+
+    let frame_type = FrameType::from_u8(data[0])?;
+    let mut buf = &data[1..];
+
+    match frame_type {
+        FrameType::S2sPortEnumRequest => Ok(S2sFrame::PortEnumRequest),
+
+        FrameType::S2sPortEnumResponse => {
+            if buf.remaining() < 4 {
+                return Err(TransportError::Protocol("missing port count".into()));
+            }
+            let count = buf.get_u32() as usize;
+            let mut ports = Vec::with_capacity(count);
+
+            for _ in 0..count {
+                let id = decode_string(&mut buf)?;
+                let name = decode_string(&mut buf)?;
+
+                if buf.remaining() < 3 {
+                    return Err(TransportError::Protocol("truncated port entry".into()));
+                }
+                let port_type = match buf.get_u8() {
+                    0 => RemotePortType::Input,
+                    1 => RemotePortType::Output,
+                    other => {
+                        return Err(TransportError::Protocol(format!(
+                            "unknown port type: {other}"
+                        )));
+                    }
+                };
+                let connected = buf.get_u8() != 0;
+                let transmitting = buf.get_u8() != 0;
+
+                ports.push(RemotePort {
+                    id,
+                    name,
+                    port_type,
+                    connected,
+                    transmitting,
+                });
+            }
+
+            Ok(S2sFrame::PortEnumResponse { ports })
+        }
+
+        FrameType::S2sPeerStatusRequest => Ok(S2sFrame::PeerStatusRequest),
+
+        FrameType::S2sPeerStatusResponse => {
+            if buf.remaining() < 16 {
+                return Err(TransportError::Protocol(
+                    "peer status response too short".into(),
+                ));
+            }
+            let load = buf.get_f64();
+            let flow_files_queued = buf.get_u64();
+            Ok(S2sFrame::PeerStatusResponse {
+                load,
+                flow_files_queued,
+            })
+        }
+
+        FrameType::S2sTxnBegin => {
+            let port_id = decode_string(&mut buf)?;
+            Ok(S2sFrame::TxnBegin { port_id })
+        }
+
+        FrameType::S2sTxnCommit => {
+            let transaction_id = decode_string(&mut buf)?;
+            Ok(S2sFrame::TxnCommit { transaction_id })
+        }
+
+        FrameType::S2sTxnRollback => {
+            let transaction_id = decode_string(&mut buf)?;
+            Ok(S2sFrame::TxnRollback { transaction_id })
+        }
+
+        _ => Err(TransportError::Protocol(format!(
+            "not an S2S frame type: 0x{:02x}",
+            frame_type as u8,
+        ))),
+    }
+}
+
+// ── Serde helper for Duration as milliseconds ────────────────────────────────
+
+mod duration_ms {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(duration.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
+        let ms = u64::deserialize(deserializer)?;
+        Ok(Duration::from_millis(ms))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn port_enum_request_round_trip() {
+        let encoded = encode_port_enum_request();
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        assert!(matches!(decoded, S2sFrame::PortEnumRequest));
+    }
+
+    #[test]
+    fn port_enum_response_round_trip() {
+        let ports = vec![
+            RemotePort {
+                id: "port-1".into(),
+                name: "raw-input".into(),
+                port_type: RemotePortType::Input,
+                connected: true,
+                transmitting: true,
+            },
+            RemotePort {
+                id: "port-2".into(),
+                name: "processed-output".into(),
+                port_type: RemotePortType::Output,
+                connected: false,
+                transmitting: false,
+            },
+        ];
+
+        let encoded = encode_port_enum_response(&ports);
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+
+        match decoded {
+            S2sFrame::PortEnumResponse {
+                ports: decoded_ports,
+            } => {
+                assert_eq!(decoded_ports.len(), 2);
+                assert_eq!(decoded_ports[0].id, "port-1");
+                assert_eq!(decoded_ports[0].name, "raw-input");
+                assert_eq!(decoded_ports[0].port_type, RemotePortType::Input);
+                assert!(decoded_ports[0].connected);
+                assert!(decoded_ports[0].transmitting);
+                assert_eq!(decoded_ports[1].id, "port-2");
+                assert_eq!(decoded_ports[1].port_type, RemotePortType::Output);
+                assert!(!decoded_ports[1].connected);
+            }
+            _ => panic!("expected PortEnumResponse"),
+        }
+    }
+
+    #[test]
+    fn port_enum_response_empty_round_trip() {
+        let encoded = encode_port_enum_response(&[]);
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        match decoded {
+            S2sFrame::PortEnumResponse { ports } => assert!(ports.is_empty()),
+            _ => panic!("expected PortEnumResponse"),
+        }
+    }
+
+    #[test]
+    fn peer_status_request_round_trip() {
+        let encoded = encode_peer_status_request();
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        assert!(matches!(decoded, S2sFrame::PeerStatusRequest));
+    }
+
+    #[test]
+    fn peer_status_response_round_trip() {
+        let encoded = encode_peer_status_response(0.75, 12345);
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        match decoded {
+            S2sFrame::PeerStatusResponse {
+                load,
+                flow_files_queued,
+            } => {
+                assert!((load - 0.75).abs() < f64::EPSILON);
+                assert_eq!(flow_files_queued, 12345);
+            }
+            _ => panic!("expected PeerStatusResponse"),
+        }
+    }
+
+    #[test]
+    fn txn_begin_round_trip() {
+        let encoded = encode_txn_begin("port-abc-123");
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        match decoded {
+            S2sFrame::TxnBegin { port_id } => assert_eq!(port_id, "port-abc-123"),
+            _ => panic!("expected TxnBegin"),
+        }
+    }
+
+    #[test]
+    fn txn_commit_round_trip() {
+        let encoded = encode_txn_commit("txn-001");
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        match decoded {
+            S2sFrame::TxnCommit { transaction_id } => assert_eq!(transaction_id, "txn-001"),
+            _ => panic!("expected TxnCommit"),
+        }
+    }
+
+    #[test]
+    fn txn_rollback_round_trip() {
+        let encoded = encode_txn_rollback("txn-002");
+        let decoded = decode_s2s_frame(&encoded).unwrap();
+        match decoded {
+            S2sFrame::TxnRollback { transaction_id } => assert_eq!(transaction_id, "txn-002"),
+            _ => panic!("expected TxnRollback"),
+        }
+    }
+
+    #[test]
+    fn s2s_config_default() {
+        let config = S2sConfig::default();
+        assert_eq!(config.transport_protocol, TransportProtocol::Quic);
+        assert_eq!(config.communications_timeout, Duration::from_secs(30));
+        assert_eq!(config.batch_count, 100);
+    }
+
+    #[test]
+    fn empty_frame_returns_error() {
+        let result = decode_s2s_frame(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn non_s2s_frame_returns_error() {
+        // FrameType::Handshake = 0x01 is not an S2S frame
+        let result = decode_s2s_frame(&[0x01]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds Remote Process Group (RPG) support and Site-to-Site (S2S) protocol for inter-instance data transfer over QUIC. This enables connecting separate RuniFi instances on the canvas for multi-datacenter and edge-to-core data flow architectures.

### Changes

**Transport Layer (`runifi-transport`)**
- Extended wire protocol with S2S frame types (0x10–0x16): port enumeration request/response, peer status, transaction begin/commit/rollback
- New `s2s.rs` module with `S2sConfig`, `RemotePort`, `TransportProtocol`, encode/decode functions
- Full round-trip unit tests for all S2S frame types

**Core Engine (`runifi-core`)**
- `RemoteProcessGroup` data model with target URIs, transport config, batch settings, proxy support
- `RemotePortStatus` with atomic metrics counters (bytes sent/received, FlowFiles, active threads)
- Per-RPG and per-port transmission control (enable/disable without removing connections)
- `EngineHandle` methods: CRUD, transmission toggle, snapshot to `RemoteProcessGroupInfo`
- Flow persistence: `PersistedRemoteProcessGroup` with serde defaults for backward compatibility

**API Layer (`runifi-api`)**
- Full CRUD at `/api/v1/remote-process-groups` with RBAC (ViewFlow for reads, ModifyFlow for mutations)
- `PUT .../transmission` — enable/disable RPG transmission
- `GET .../ports` — list remote ports with metrics
- `PUT .../ports/{port_id}/transmission` — per-port transmission control
- `GET /api/v1/site-to-site/ports` — list local ports available for S2S (inbound endpoint)
- Input validation (name length, required target URIs)

### Files Changed
- **New**: `s2s.rs`, `remote_process_group.rs`, `remote_process_groups.rs` (routes)
- **Modified**: `protocol.rs`, `lib.rs` (transport), `handle.rs`, `persistence.rs`, `flow_engine.rs`, `mod.rs` (engine), `lib.rs`, `mod.rs` (API), `diff.rs`, `version_store.rs` (versioning)

## Test Plan

- [x] S2S frame encode/decode round-trip tests (all 7 frame types)
- [x] RPG model tests (creation, metrics aggregation, port status, ID generation)
- [x] Persistence backward compatibility (serde defaults)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests green)

Closes #243