### PR TITLE
feat: dynamic properties support with @SupportsDynamicProperties declaration (#276)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
@@ -46,8 +46,18 @@ function validateProperties(
 
 function initFormState(data: ProcessorConfigResponse): ConfigFormState {
   const properties: Record<string, string> = {};
+  // Include declared property descriptors.
   for (const desc of data.property_descriptors) {
     properties[desc.name] = data.properties[desc.name] ?? desc.default_value ?? '';
+  }
+  // Include dynamic properties (those not in descriptors).
+  if (data.supports_dynamic_properties) {
+    const declaredNames = new Set(data.property_descriptors.map((d) => d.name));
+    for (const [key, value] of Object.entries(data.properties)) {
+      if (!declaredNames.has(key)) {
+        properties[key] = value;
+      }
+    }
   }
   return {
     penaltyDurationMs: data.penalty_duration_ms,
@@ -74,6 +84,9 @@ function ProcessorConfigModalInner({
   const [saveStatus, setSaveStatus] = useState<{ kind: 'error' | 'success'; message: string } | null>(null);
   // Sensitive property reveal toggle per property name.
   const [revealedSensitive, setRevealedSensitive] = useState<Set<string>>(new Set());
+  // Dynamic property input state.
+  const [newDynPropName, setNewDynPropName] = useState('');
+  const [newDynPropValue, setNewDynPropValue] = useState('');
 
   const isStopped = processorState === 'stopped';
 
@@ -126,6 +139,23 @@ function ProcessorConfigModalInner({
         ? current.filter((r) => r !== relName)
         : [...current, relName];
       return { ...prev, autoTerminatedRelationships: next };
+    });
+    setSaveStatus(null);
+  }, []);
+
+  const addDynamicProperty = useCallback(() => {
+    if (!newDynPropName.trim()) return;
+    setForm((prev) => prev ? { ...prev, properties: { ...prev.properties, [newDynPropName.trim()]: newDynPropValue } } : prev);
+    setNewDynPropName('');
+    setNewDynPropValue('');
+    setSaveStatus(null);
+  }, [newDynPropName, newDynPropValue]);
+
+  const removeDynamicProperty = useCallback((name: string) => {
+    setForm((prev) => {
+      if (!prev) return prev;
+      const { [name]: _, ...rest } = prev.properties;
+      return { ...prev, properties: rest };
     });
     setSaveStatus(null);
   }, []);
@@ -402,77 +432,163 @@ function ProcessorConfigModalInner({
             {/* Properties Tab */}
             {activeTab === 'properties' && (
               <div className="config-tab-content" role="tabpanel">
-                {config.property_descriptors.length === 0 ? (
+                {config.property_descriptors.length === 0 && !config.supports_dynamic_properties ? (
                   <p className="config-empty">This processor has no configurable properties.</p>
                 ) : (
-                  config.property_descriptors.map((desc) => {
-                    const isSensitive = desc.sensitive;
-                    const isRevealed = revealedSensitive.has(desc.name);
-                    const fieldValue = form.properties[desc.name] ?? '';
-                    const isValid = !desc.required || fieldValue !== '' || desc.default_value !== null;
+                  <>
+                    {config.property_descriptors.map((desc) => {
+                      const isSensitive = desc.sensitive;
+                      const isRevealed = revealedSensitive.has(desc.name);
+                      const fieldValue = form.properties[desc.name] ?? '';
+                      const isValid = !desc.required || fieldValue !== '' || desc.default_value !== null;
 
-                    return (
-                      <div key={desc.name} className="config-field">
-                        <label className="config-label" htmlFor={`prop-${desc.name}`}>
-                          {desc.display_name || desc.name}
-                          {desc.required && (
-                            <span className="config-required" title="Required">REQUIRED</span>
-                          )}
-                          {desc.expression_language_supported && (
-                            <span className="config-el-badge" title="Supports Expression Language">EL</span>
-                          )}
-                          {isSensitive && (
-                            <span className="config-sensitive-badge" title="Sensitive property">SENSITIVE</span>
-                          )}
-                        </label>
-                        <span className="config-description">{desc.description}</span>
+                      return (
+                        <div key={desc.name} className="config-field">
+                          <label className="config-label" htmlFor={`prop-${desc.name}`}>
+                            {desc.display_name || desc.name}
+                            {desc.required && (
+                              <span className="config-required" title="Required">REQUIRED</span>
+                            )}
+                            {desc.expression_language_supported && (
+                              <span className="config-el-badge" title="Supports Expression Language">EL</span>
+                            )}
+                            {isSensitive && (
+                              <span className="config-sensitive-badge" title="Sensitive property">SENSITIVE</span>
+                            )}
+                          </label>
+                          <span className="config-description">{desc.description}</span>
 
-                        {desc.allowed_values && desc.allowed_values.length > 0 ? (
-                          <select
-                            id={`prop-${desc.name}`}
-                            className={`form-select${!isValid ? ' form-input-error' : ''}`}
-                            value={fieldValue}
-                            onChange={(e) => handlePropertyChange(desc.name, e.target.value)}
-                            disabled={!isStopped}
-                          >
-                            {!desc.required && <option value="">-- Select --</option>}
-                            {desc.allowed_values.map((av) => (
-                              <option key={av} value={av}>{av}</option>
-                            ))}
-                          </select>
-                        ) : (
-                          <div className="config-input-with-action">
-                            <input
+                          {desc.allowed_values && desc.allowed_values.length > 0 ? (
+                            <select
                               id={`prop-${desc.name}`}
-                              className={`form-input${!isValid ? ' form-input-error' : ''}`}
-                              type={isSensitive && !isRevealed ? 'password' : 'text'}
+                              className={`form-select${!isValid ? ' form-input-error' : ''}`}
                               value={fieldValue}
-                              placeholder={desc.default_value ? `Default: ${desc.default_value}` : ''}
                               onChange={(e) => handlePropertyChange(desc.name, e.target.value)}
                               disabled={!isStopped}
-                              autoComplete="off"
-                              spellCheck={false}
-                            />
-                            {isSensitive && (
+                            >
+                              {!desc.required && <option value="">-- Select --</option>}
+                              {desc.allowed_values.map((av) => (
+                                <option key={av} value={av}>{av}</option>
+                              ))}
+                            </select>
+                          ) : (
+                            <div className="config-input-with-action">
+                              <input
+                                id={`prop-${desc.name}`}
+                                className={`form-input${!isValid ? ' form-input-error' : ''}`}
+                                type={isSensitive && !isRevealed ? 'password' : 'text'}
+                                value={fieldValue}
+                                placeholder={desc.default_value ? `Default: ${desc.default_value}` : ''}
+                                onChange={(e) => handlePropertyChange(desc.name, e.target.value)}
+                                disabled={!isStopped}
+                                autoComplete="off"
+                                spellCheck={false}
+                              />
+                              {isSensitive && (
+                                <button
+                                  type="button"
+                                  className="config-eye-toggle"
+                                  onClick={() => toggleSensitiveReveal(desc.name)}
+                                  title={isRevealed ? 'Hide value' : 'Show value'}
+                                  aria-label={isRevealed ? 'Hide sensitive value' : 'Show sensitive value'}
+                                >
+                                  {isRevealed ? '\u25C9' : '\u25CE'}
+                                </button>
+                              )}
+                            </div>
+                          )}
+
+                          {desc.default_value && (
+                            <span className="config-default">Default: {desc.default_value}</span>
+                          )}
+                        </div>
+                      );
+                    })}
+
+                    {/* Dynamic Properties Section */}
+                    {config.supports_dynamic_properties && (() => {
+                      const declaredNames = new Set(config.property_descriptors.map((d) => d.name));
+                      const dynamicEntries = Object.entries(form.properties).filter(
+                        ([key]) => !declaredNames.has(key)
+                      );
+
+                      return (
+                        <div className="config-settings-section" style={{ marginTop: '16px' }}>
+                          <h4 className="config-section-heading">Dynamic Properties</h4>
+                          {dynamicEntries.length === 0 && (
+                            <p className="config-description" style={{ marginBottom: '8px' }}>
+                              No dynamic properties configured.
+                            </p>
+                          )}
+                          {dynamicEntries.map(([key, value]) => (
+                            <div key={key} className="config-field">
+                              <label className="config-label">{key}</label>
+                              <div className="config-input-with-action">
+                                <input
+                                  className="form-input"
+                                  type="text"
+                                  value={value}
+                                  onChange={(e) => handlePropertyChange(key, e.target.value)}
+                                  disabled={!isStopped}
+                                  autoComplete="off"
+                                  spellCheck={false}
+                                />
+                                <button
+                                  type="button"
+                                  className="config-eye-toggle"
+                                  onClick={() => removeDynamicProperty(key)}
+                                  disabled={!isStopped}
+                                  title="Remove property"
+                                  aria-label={`Remove dynamic property ${key}`}
+                                >
+                                  &times;
+                                </button>
+                              </div>
+                            </div>
+                          ))}
+                          {isStopped && (
+                            <div className="config-field" style={{ display: 'flex', gap: '8px', alignItems: 'flex-end' }}>
+                              <div style={{ flex: 1 }}>
+                                <label className="config-label" htmlFor="dyn-prop-name">Name</label>
+                                <input
+                                  id="dyn-prop-name"
+                                  className="form-input"
+                                  type="text"
+                                  value={newDynPropName}
+                                  onChange={(e) => setNewDynPropName(e.target.value)}
+                                  placeholder="Property name"
+                                  autoComplete="off"
+                                  spellCheck={false}
+                                />
+                              </div>
+                              <div style={{ flex: 1 }}>
+                                <label className="config-label" htmlFor="dyn-prop-value">Value</label>
+                                <input
+                                  id="dyn-prop-value"
+                                  className="form-input"
+                                  type="text"
+                                  value={newDynPropValue}
+                                  onChange={(e) => setNewDynPropValue(e.target.value)}
+                                  placeholder="Property value"
+                                  autoComplete="off"
+                                  spellCheck={false}
+                                />
+                              </div>
                               <button
                                 type="button"
-                                className="config-eye-toggle"
-                                onClick={() => toggleSensitiveReveal(desc.name)}
-                                title={isRevealed ? 'Hide value' : 'Show value'}
-                                aria-label={isRevealed ? 'Hide sensitive value' : 'Show sensitive value'}
+                                className="btn btn-ghost"
+                                onClick={addDynamicProperty}
+                                disabled={!newDynPropName.trim()}
+                                style={{ whiteSpace: 'nowrap' }}
                               >
-                                {isRevealed ? '\u25C9' : '\u25CE'}
+                                + Add
                               </button>
-                            )}
-                          </div>
-                        )}
-
-                        {desc.default_value && (
-                          <span className="config-default">Default: {desc.default_value}</span>
-                        )}
-                      </div>
-                    );
-                  })
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })()}
+                  </>
                 )}
               </div>
             )}

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -220,6 +220,8 @@ export interface ProcessorConfigResponse {
   concurrent_tasks: number;
   comments: string;
   auto_terminated_relationships: string[];
+  supports_dynamic_properties: boolean;
+  supports_sensitive_dynamic_properties: boolean;
 }
 
 // ── Queue inspection ───────────────────────────────────────────────

--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -357,6 +357,8 @@ pub struct ProcessorConfigResponse {
     pub concurrent_tasks: u64,
     pub comments: String,
     pub auto_terminated_relationships: Vec<String>,
+    pub supports_dynamic_properties: bool,
+    pub supports_sensitive_dynamic_properties: bool,
 }
 
 #[derive(Serialize)]
@@ -433,11 +435,22 @@ impl ProcessorConfigResponse {
             .map(|pd| pd.name.as_str())
             .collect();
 
+        // Build a set of known descriptor names to identify dynamic properties.
+        let descriptor_names: std::collections::HashSet<&str> = info
+            .property_descriptors
+            .iter()
+            .map(|pd| pd.name.as_str())
+            .collect();
+
         // Mask sensitive property values in the response.
+        // Also mask dynamic property values if supports_sensitive_dynamic_properties is true.
         let properties: HashMap<String, String> = raw_properties
             .into_iter()
             .map(|(k, v)| {
-                if sensitive_names.contains(k.as_str()) && !v.is_empty() {
+                let is_sensitive_declared = sensitive_names.contains(k.as_str());
+                let is_sensitive_dynamic = info.supports_sensitive_dynamic_properties
+                    && !descriptor_names.contains(k.as_str());
+                if (is_sensitive_declared || is_sensitive_dynamic) && !v.is_empty() {
                     (k, "********".to_string())
                 } else {
                     (k, v)
@@ -461,7 +474,7 @@ impl ProcessorConfigResponse {
 
         // Merge auto-terminated state: use runtime config as source of truth.
         let auto_term = info.auto_terminated_relationships.read().clone();
-        let relationships = info
+        let mut relationships: Vec<RelationshipResponse> = info
             .relationships
             .iter()
             .map(|r| {
@@ -473,6 +486,17 @@ impl ProcessorConfigResponse {
                 }
             })
             .collect();
+
+        // Append dynamic relationships (from dynamic property names).
+        let dynamic_rels = info.dynamic_relationships.read();
+        for dr in dynamic_rels.iter() {
+            let is_auto_terminated = auto_term.contains(&dr.name);
+            relationships.push(RelationshipResponse {
+                name: dr.name.clone(),
+                description: dr.description.clone(),
+                auto_terminated: is_auto_terminated,
+            });
+        }
 
         Self {
             processor_name: info.name.clone(),
@@ -499,6 +523,8 @@ impl ProcessorConfigResponse {
                 .load(std::sync::atomic::Ordering::Relaxed),
             comments: info.comments.read().clone(),
             auto_terminated_relationships: auto_term,
+            supports_dynamic_properties: info.supports_dynamic_properties,
+            supports_sensitive_dynamic_properties: info.supports_sensitive_dynamic_properties,
         }
     }
 }

--- a/crates/runifi-api/src/routes/processors.rs
+++ b/crates/runifi-api/src/routes/processors.rs
@@ -115,28 +115,32 @@ fn validate_processor_name(name: &str) -> Result<(), ApiError> {
 }
 
 /// Validate properties against the processor type's property descriptors.
-/// Rejects unknown property keys and invalid allowed values.
+/// Rejects unknown property keys (unless dynamic properties are supported)
+/// and invalid allowed values.
 /// Required-property checks are deferred to start time (matching NiFi behavior:
-/// create → configure → start).
+/// create -> configure -> start).
 fn validate_properties(
     properties: &std::collections::HashMap<String, String>,
     descriptors: &[runifi_plugin_api::PropertyDescriptor],
+    supports_dynamic_properties: bool,
 ) -> Result<(), ApiError> {
     // Build a set of known property names.
     let known_names: std::collections::HashSet<&str> = descriptors.iter().map(|d| d.name).collect();
 
-    // Reject unknown property keys.
-    for key in properties.keys() {
-        if !known_names.contains(key.as_str()) {
-            return Err(ApiError::BadRequest(format!(
-                "Unknown property '{}'. Valid properties: {:?}",
-                key,
-                known_names.iter().collect::<Vec<_>>()
-            )));
+    // Reject unknown property keys only if the processor doesn't support dynamic properties.
+    if !supports_dynamic_properties {
+        for key in properties.keys() {
+            if !known_names.contains(key.as_str()) {
+                return Err(ApiError::BadRequest(format!(
+                    "Unknown property '{}'. Valid properties: {:?}",
+                    key,
+                    known_names.iter().collect::<Vec<_>>()
+                )));
+            }
         }
     }
 
-    // Validate allowed values.
+    // Validate allowed values (only for declared properties).
     for (key, value) in properties {
         if let Some(desc) = descriptors.iter().find(|d| d.name == key)
             && let Some(allowed) = desc.allowed_values
@@ -170,16 +174,16 @@ async fn create_processor(
         )));
     }
 
-    // Get property descriptors from an existing processor of the same type,
-    // or validate after creation using the info that comes back.
-    let descriptors: Vec<runifi_plugin_api::PropertyDescriptor> = state
-        .handle
-        .processors
-        .read()
-        .iter()
-        .find(|p| p.type_name == body.type_name)
-        .map(|p| {
-            p.property_descriptors
+    // Get property descriptors and dynamic-property support from an existing
+    // processor of the same type, or validate after creation using the info that comes back.
+    let (descriptors, existing_supports_dynamic): (
+        Vec<runifi_plugin_api::PropertyDescriptor>,
+        Option<bool>,
+    ) = {
+        let procs = state.handle.processors.read();
+        if let Some(p) = procs.iter().find(|p| p.type_name == body.type_name) {
+            let descs = p
+                .property_descriptors
                 .iter()
                 .map(|d| runifi_plugin_api::PropertyDescriptor {
                     name: Box::leak(d.name.clone().into_boxed_str()),
@@ -201,13 +205,20 @@ async fn create_processor(
                     }),
                     expression_language_supported: d.expression_language_supported,
                 })
-                .collect()
-        })
-        .unwrap_or_default();
+                .collect();
+            (descs, Some(p.supports_dynamic_properties))
+        } else {
+            (Vec::new(), None)
+        }
+    };
 
     // If we found descriptors, validate upfront.
     if !descriptors.is_empty() {
-        validate_properties(&body.properties, &descriptors)?;
+        validate_properties(
+            &body.properties,
+            &descriptors,
+            existing_supports_dynamic.unwrap_or(false),
+        )?;
     }
 
     state
@@ -253,7 +264,11 @@ async fn create_processor(
             })
             .collect();
 
-        if let Err(e) = validate_properties(&body.properties, &post_descriptors) {
+        if let Err(e) = validate_properties(
+            &body.properties,
+            &post_descriptors,
+            info.supports_dynamic_properties,
+        ) {
             // Roll back: remove the processor we just created.
             let _ = state.handle.remove_processor(body.name.clone()).await;
             return Err(e);

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -336,10 +336,15 @@ impl FlowEngine {
         let mut metrics_by_node: HashMap<NodeId, Arc<ProcessorMetrics>> = HashMap::new();
         let mut shared_props_by_node: HashMap<NodeId, Arc<RwLock<HashMap<String, String>>>> =
             HashMap::new();
-        let mut static_meta_by_node: HashMap<
-            NodeId,
-            (Vec<PropertyDescriptorInfo>, Vec<RelationshipInfo>),
-        > = HashMap::new();
+        // (descriptors, relationships, supports_dynamic, supports_sensitive_dynamic, dynamic_creates_rel)
+        type StaticMeta = (
+            Vec<PropertyDescriptorInfo>,
+            Vec<RelationshipInfo>,
+            bool,
+            bool,
+            bool,
+        );
+        let mut static_meta_by_node: HashMap<NodeId, StaticMeta> = HashMap::new();
 
         for node_builder in &self.nodes {
             let metrics = Arc::new(ProcessorMetrics::new());
@@ -347,7 +352,13 @@ impl FlowEngine {
             let shared_props = Arc::new(RwLock::new(node_builder.properties.clone()));
             shared_props_by_node.insert(node_builder.id, shared_props);
 
-            let (prop_descriptors, rels) = if let Some(ref proc) = node_builder.processor {
+            let (
+                prop_descriptors,
+                rels,
+                supports_dynamic,
+                supports_sensitive_dynamic,
+                dynamic_creates_rel,
+            ) = if let Some(ref proc) = node_builder.processor {
                 let pds = proc
                     .property_descriptors()
                     .into_iter()
@@ -372,11 +383,26 @@ impl FlowEngine {
                         auto_terminated: r.auto_terminated,
                     })
                     .collect();
-                (pds, rs)
+                (
+                    pds,
+                    rs,
+                    proc.supports_dynamic_properties(),
+                    proc.supports_sensitive_dynamic_properties(),
+                    proc.dynamic_property_creates_relationship(),
+                )
             } else {
-                (Vec::new(), Vec::new())
+                (Vec::new(), Vec::new(), false, false, false)
             };
-            static_meta_by_node.insert(node_builder.id, (prop_descriptors, rels));
+            static_meta_by_node.insert(
+                node_builder.id,
+                (
+                    prop_descriptors,
+                    rels,
+                    supports_dynamic,
+                    supports_sensitive_dynamic,
+                    dynamic_creates_rel,
+                ),
+            );
         }
 
         // Build ConnectionInfo for the handle.
@@ -453,7 +479,7 @@ impl FlowEngine {
             pn.set_type_name(node_builder.type_name.clone());
 
             // Set sensitive property names for bulletin redaction.
-            if let Some((descriptors, _)) = static_meta_by_node.get(&node_builder.id) {
+            if let Some((descriptors, _, _, _, _)) = static_meta_by_node.get(&node_builder.id) {
                 let sensitive_names: Vec<String> = descriptors
                     .iter()
                     .filter(|d| d.sensitive)
@@ -506,13 +532,37 @@ impl FlowEngine {
                 .get(&node_builder.id)
                 .expect("shared_props must exist")
                 .clone();
-            let (prop_descriptors, relationships) = static_meta_by_node
+            let (
+                prop_descriptors,
+                relationships,
+                supports_dynamic,
+                supports_sensitive_dynamic,
+                dynamic_creates_rel,
+            ) = static_meta_by_node
                 .remove(&node_builder.id)
                 .expect("static meta must exist for every node");
             let (input_h, output_h, notifiers_h) = node_conn_handles
                 .get(&node_builder.name)
                 .expect("conn handles must exist for every node")
                 .clone();
+
+            // Compute initial dynamic relationships from properties if applicable.
+            let dynamic_relationships = if dynamic_creates_rel {
+                let descriptor_names: std::collections::HashSet<&str> =
+                    prop_descriptors.iter().map(|d| d.name.as_str()).collect();
+                node_builder
+                    .properties
+                    .keys()
+                    .filter(|k| !descriptor_names.contains(k.as_str()))
+                    .map(|k| RelationshipInfo {
+                        name: k.clone(),
+                        description: format!("Dynamic relationship from property '{}'", k),
+                        auto_terminated: false,
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
             processor_infos.push(ProcessorInfo {
                 name: node_builder.name.clone(),
@@ -533,6 +583,10 @@ impl FlowEngine {
                 spawned_task_count: Arc::new(AtomicU64::new(0)),
                 comments: Arc::new(RwLock::new(String::new())),
                 auto_terminated_relationships: Arc::new(RwLock::new(Vec::new())),
+                supports_dynamic_properties: supports_dynamic,
+                supports_sensitive_dynamic_properties: supports_sensitive_dynamic,
+                dynamic_property_creates_relationship: dynamic_creates_rel,
+                dynamic_relationships: Arc::new(RwLock::new(dynamic_relationships)),
             });
         }
 

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -117,6 +117,14 @@ pub struct ProcessorInfo {
     pub comments: Arc<RwLock<String>>,
     /// Auto-terminated relationship names (configurable at runtime).
     pub auto_terminated_relationships: Arc<RwLock<Vec<String>>>,
+    /// Whether this processor supports dynamic (user-defined) properties.
+    pub supports_dynamic_properties: bool,
+    /// Whether dynamic properties can be sensitive.
+    pub supports_sensitive_dynamic_properties: bool,
+    /// Whether dynamic property names generate relationships.
+    pub dynamic_property_creates_relationship: bool,
+    /// Relationships created from dynamic property names at runtime.
+    pub dynamic_relationships: Arc<RwLock<Vec<RelationshipInfo>>>,
 }
 
 /// Information about a connection, visible to the API.
@@ -727,6 +735,14 @@ impl EngineHandle {
         // Validate and apply properties if provided.
         if let Some(ref new_properties) = properties {
             let mut props = info.properties.write();
+
+            // Build set of known descriptor property names.
+            let descriptor_names: std::collections::HashSet<&str> = info
+                .property_descriptors
+                .iter()
+                .map(|d| d.name.as_str())
+                .collect();
+
             for desc in &info.property_descriptors {
                 if desc.required {
                     let has_value = new_properties.contains_key(&desc.name);
@@ -740,6 +756,13 @@ impl EngineHandle {
                 }
             }
             for (key, value) in new_properties {
+                // Reject unknown properties on processors that don't support dynamic properties.
+                if !descriptor_names.contains(key.as_str()) && !info.supports_dynamic_properties {
+                    return Err(ConfigUpdateError::ValidationError(format!(
+                        "Unknown property '{}'. This processor does not support dynamic properties.",
+                        key
+                    )));
+                }
                 if let Some(desc) = info.property_descriptors.iter().find(|d| d.name == *key)
                     && let Some(ref allowed) = desc.allowed_values
                     && !allowed.iter().any(|v| v == value)
@@ -751,6 +774,20 @@ impl EngineHandle {
                 }
             }
             *props = new_properties.clone();
+
+            // Update dynamic relationships if this processor creates relationships from dynamic properties.
+            if info.dynamic_property_creates_relationship {
+                let dynamic_rels: Vec<RelationshipInfo> = new_properties
+                    .keys()
+                    .filter(|k| !descriptor_names.contains(k.as_str()))
+                    .map(|k| RelationshipInfo {
+                        name: k.clone(),
+                        description: format!("Dynamic relationship from property '{}'", k),
+                        auto_terminated: false,
+                    })
+                    .collect();
+                *info.dynamic_relationships.write() = dynamic_rels;
+            }
         }
 
         // Apply penalty duration.

--- a/crates/runifi-core/src/engine/mutation_handler.rs
+++ b/crates/runifi-core/src/engine/mutation_handler.rs
@@ -131,6 +131,10 @@ impl DefaultMutationHandler {
             })
             .collect();
 
+        let supports_dynamic = processor.supports_dynamic_properties();
+        let supports_sensitive_dynamic = processor.supports_sensitive_dynamic_properties();
+        let dynamic_creates_rel = processor.dynamic_property_creates_relationship();
+
         let shared_props = Arc::new(RwLock::new(properties));
         let child_token = self.parent_cancel.child_token();
 
@@ -186,6 +190,10 @@ impl DefaultMutationHandler {
             spawned_task_count: Arc::new(AtomicU64::new(0)),
             comments: Arc::new(RwLock::new(String::new())),
             auto_terminated_relationships: Arc::new(RwLock::new(Vec::new())),
+            supports_dynamic_properties: supports_dynamic,
+            supports_sensitive_dynamic_properties: supports_sensitive_dynamic,
+            dynamic_property_creates_relationship: dynamic_creates_rel,
+            dynamic_relationships: Arc::new(RwLock::new(Vec::new())),
         });
 
         tracing::info!(name, type_name, "Hot-added processor");

--- a/crates/runifi-plugin-api/src/processor.rs
+++ b/crates/runifi-plugin-api/src/processor.rs
@@ -72,6 +72,33 @@ pub trait Processor: Send + Sync + 'static {
     fn execution_node(&self) -> ExecutionNode {
         ExecutionNode::All
     }
+
+    /// Whether this processor supports user-defined dynamic properties.
+    ///
+    /// When true, the engine allows arbitrary properties beyond the declared
+    /// `property_descriptors()`. When false (default), unknown properties
+    /// are rejected during validation.
+    fn supports_dynamic_properties(&self) -> bool {
+        false
+    }
+
+    /// Whether dynamic properties on this processor can contain sensitive values.
+    ///
+    /// When true, dynamic property values are masked in API responses.
+    /// Only meaningful when `supports_dynamic_properties()` is also true.
+    fn supports_sensitive_dynamic_properties(&self) -> bool {
+        false
+    }
+
+    /// Whether each dynamic property name creates a corresponding relationship.
+    ///
+    /// When true, the engine automatically registers a relationship for every
+    /// dynamic property whose name does not match a declared property descriptor.
+    /// Used by processors like RouteOnAttribute where dynamic properties define
+    /// routing rules and the property name becomes the relationship name.
+    fn dynamic_property_creates_relationship(&self) -> bool {
+        false
+    }
 }
 
 /// Describes a processor type for plugin registration.

--- a/crates/runifi-processors/src/route_on_attribute.rs
+++ b/crates/runifi-processors/src/route_on_attribute.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use regex_lite::Regex;
 use runifi_plugin_api::context::ProcessContext;
 use runifi_plugin_api::processor::{Processor, ProcessorDescriptor};
@@ -6,15 +8,8 @@ use runifi_plugin_api::relationship::Relationship;
 use runifi_plugin_api::result::ProcessResult;
 use runifi_plugin_api::session::ProcessSession;
 
-const REL_MATCHED: Relationship = Relationship::new("matched", "FlowFiles matching the condition");
 const REL_UNMATCHED: Relationship =
-    Relationship::new("unmatched", "FlowFiles not matching the condition");
-
-const PROP_ATTRIBUTE: PropertyDescriptor =
-    PropertyDescriptor::new("Attribute Name", "The attribute to check for routing").required();
-
-const PROP_VALUE: PropertyDescriptor =
-    PropertyDescriptor::new("Attribute Value", "The expected value for matching").required();
+    Relationship::new("unmatched", "FlowFiles not matching any routing rule");
 
 const PROP_MATCHING_STRATEGY: PropertyDescriptor = PropertyDescriptor::new(
     "Matching Strategy",
@@ -22,10 +17,23 @@ const PROP_MATCHING_STRATEGY: PropertyDescriptor = PropertyDescriptor::new(
 )
 .default_value("exact");
 
-/// Routes FlowFiles based on attribute values.
+const PROP_ROUTING_STRATEGY: PropertyDescriptor = PropertyDescriptor::new(
+    "Routing Strategy",
+    "Route to all matching relationships ('route to all') or only the first match ('route to first')",
+)
+.default_value("route to all");
+
+/// Static property names owned by this processor (not routing rules).
+const OWN_PROPERTY_NAMES: &[&str] = &["Matching Strategy", "Routing Strategy"];
+
+/// Routes FlowFiles based on dynamic property routing rules.
 ///
-/// FlowFiles whose specified attribute matches the expected value are routed
-/// to "matched"; all others go to "unmatched".
+/// Each dynamic property defines a routing rule:
+///   - Property name = relationship name
+///   - Property value = condition in format `attribute_name=expected_value`
+///
+/// FlowFiles are evaluated against all rules. The matching strategy applies
+/// to the value comparison. FlowFiles matching no rules go to "unmatched".
 pub struct RouteOnAttribute;
 
 impl RouteOnAttribute {
@@ -46,51 +54,110 @@ impl Processor for RouteOnAttribute {
         context: &dyn ProcessContext,
         session: &mut dyn ProcessSession,
     ) -> ProcessResult {
-        let attr_name = context.get_property("Attribute Name");
-        let expected_value = context.get_property("Attribute Value");
         let strategy = context
             .get_property("Matching Strategy")
             .unwrap_or("exact")
             .to_string();
+        let routing_strategy = context
+            .get_property("Routing Strategy")
+            .unwrap_or("route to all")
+            .to_string();
+        let route_to_first = routing_strategy == "route to first";
 
-        let attr_name = attr_name.as_str().unwrap_or("");
-        let expected_value = expected_value.as_str().unwrap_or("");
+        // Build routing rules from dynamic properties.
+        let own_names: HashSet<&str> = OWN_PROPERTY_NAMES.iter().copied().collect();
+        let all_names = context.property_names();
+        let rules: Vec<(String, String, String)> = all_names
+            .into_iter()
+            .filter(|n| !own_names.contains(n.as_str()))
+            .filter_map(|n| {
+                context.get_property(&n).as_str().map(|v| {
+                    // Parse "attribute_name=expected_value" format.
+                    if let Some((attr, val)) = v.split_once('=') {
+                        (n, attr.to_string(), val.to_string())
+                    } else {
+                        // If no '=', check for attribute existence.
+                        (n, v.to_string(), String::new())
+                    }
+                })
+            })
+            .collect();
 
-        // Pre-compile regex if strategy is "regex".
-        let compiled_regex = if strategy == "regex" {
-            match Regex::new(expected_value) {
-                Ok(re) => Some(re),
-                Err(e) => {
-                    tracing::error!(
-                        pattern = expected_value,
-                        error = %e,
-                        "Invalid regex pattern"
-                    );
-                    None
-                }
-            }
+        // Pre-compile regexes if strategy is "regex".
+        let compiled_regexes: Vec<Option<Regex>> = if strategy == "regex" {
+            rules
+                .iter()
+                .map(|(_, _, pattern)| {
+                    if pattern.is_empty() {
+                        None
+                    } else {
+                        match Regex::new(pattern) {
+                            Ok(re) => Some(re),
+                            Err(e) => {
+                                tracing::error!(pattern = %pattern, error = %e, "Invalid regex pattern");
+                                None
+                            }
+                        }
+                    }
+                })
+                .collect()
         } else {
-            None
+            vec![None; rules.len()]
         };
 
         while let Some(flowfile) = session.get() {
-            let matches =
-                flowfile
-                    .get_attribute(attr_name)
-                    .is_some_and(|v| match strategy.as_str() {
-                        "contains" => v.contains(expected_value),
-                        "starts_with" => v.starts_with(expected_value),
-                        "ends_with" => v.ends_with(expected_value),
-                        "regex" => compiled_regex
-                            .as_ref()
-                            .is_some_and(|re| re.is_match(v.as_ref())),
-                        _ => v.as_ref() == expected_value,
-                    });
+            // Collect all matching relationship names first.
+            let mut matched_rels: Vec<&str> = Vec::new();
+            for (idx, (rel_name, attr_name, pattern)) in rules.iter().enumerate() {
+                let matches = if pattern.is_empty() {
+                    flowfile.get_attribute(attr_name).is_some()
+                } else {
+                    flowfile
+                        .get_attribute(attr_name)
+                        .is_some_and(|v| match strategy.as_str() {
+                            "contains" => v.contains(pattern.as_str()),
+                            "starts_with" => v.starts_with(pattern.as_str()),
+                            "ends_with" => v.ends_with(pattern.as_str()),
+                            "regex" => compiled_regexes[idx]
+                                .as_ref()
+                                .is_some_and(|re| re.is_match(v.as_ref())),
+                            _ => v.as_ref() == pattern.as_str(),
+                        })
+                };
+                if matches {
+                    matched_rels.push(rel_name);
+                    if route_to_first {
+                        break;
+                    }
+                }
+            }
 
-            if matches {
-                session.transfer(flowfile, &REL_MATCHED);
-            } else {
+            if matched_rels.is_empty() {
                 session.transfer(flowfile, &REL_UNMATCHED);
+            } else if matched_rels.len() == 1 {
+                let rel = Relationship {
+                    name: Box::leak(matched_rels[0].to_string().into_boxed_str()),
+                    description: "",
+                    auto_terminated: false,
+                };
+                session.transfer(flowfile, &rel);
+            } else {
+                // Multiple matches: clone for all but the last, transfer original for the last.
+                let last_idx = matched_rels.len() - 1;
+                for (i, rel_name) in matched_rels.iter().enumerate() {
+                    let rel = Relationship {
+                        name: Box::leak(rel_name.to_string().into_boxed_str()),
+                        description: "",
+                        auto_terminated: false,
+                    };
+                    if i == last_idx {
+                        session.transfer(flowfile, &rel);
+                        break;
+                    } else {
+                        let clone = session.clone_flowfile(&flowfile);
+                        session.transfer(clone, &rel);
+                    }
+                }
             }
         }
 
@@ -99,18 +166,26 @@ impl Processor for RouteOnAttribute {
     }
 
     fn relationships(&self) -> Vec<Relationship> {
-        vec![REL_MATCHED, REL_UNMATCHED]
+        vec![REL_UNMATCHED]
     }
 
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
-        vec![PROP_ATTRIBUTE, PROP_VALUE, PROP_MATCHING_STRATEGY]
+        vec![PROP_MATCHING_STRATEGY, PROP_ROUTING_STRATEGY]
+    }
+
+    fn supports_dynamic_properties(&self) -> bool {
+        true
+    }
+
+    fn dynamic_property_creates_relationship(&self) -> bool {
+        true
     }
 }
 
 inventory::submit! {
     ProcessorDescriptor {
         type_name: "RouteOnAttribute",
-        description: "Routes FlowFiles based on attribute value matching",
+        description: "Routes FlowFiles based on dynamic property routing rules",
         factory: || Box::new(RouteOnAttribute::new()),
         tags: &["Routing"],
     }
@@ -125,19 +200,20 @@ mod tests {
     use std::sync::Arc;
 
     struct TestContext {
-        attr_name: String,
-        attr_value: String,
-        strategy: String,
+        properties: Vec<(String, String)>,
     }
 
     impl ProcessContext for TestContext {
         fn get_property(&self, name: &str) -> PropertyValue {
-            match name {
-                "Attribute Name" => PropertyValue::String(self.attr_name.clone()),
-                "Attribute Value" => PropertyValue::String(self.attr_value.clone()),
-                "Matching Strategy" => PropertyValue::String(self.strategy.clone()),
-                _ => PropertyValue::Unset,
+            for (k, v) in &self.properties {
+                if k == name {
+                    return PropertyValue::String(v.clone());
+                }
             }
+            PropertyValue::Unset
+        }
+        fn property_names(&self) -> Vec<String> {
+            self.properties.iter().map(|(k, _)| k.clone()).collect()
         }
         fn name(&self) -> &str {
             "test-route"
@@ -175,8 +251,16 @@ mod tests {
         fn create(&mut self) -> FlowFile {
             unimplemented!()
         }
-        fn clone_flowfile(&mut self, _ff: &FlowFile) -> FlowFile {
-            unimplemented!()
+        fn clone_flowfile(&mut self, ff: &FlowFile) -> FlowFile {
+            FlowFile {
+                id: ff.id + 1000,
+                attributes: ff.attributes.clone(),
+                content_claim: ff.content_claim.clone(),
+                size: ff.size,
+                created_at_nanos: ff.created_at_nanos,
+                lineage_start_id: ff.lineage_start_id,
+                penalized_until_nanos: ff.penalized_until_nanos,
+            }
         }
         fn transfer(&mut self, ff: FlowFile, rel: &Relationship) {
             self.transferred.push((ff, rel.name));
@@ -204,33 +288,43 @@ mod tests {
     }
 
     #[test]
-    fn routes_exact_match() {
+    fn routes_exact_match_dynamic() {
         let mut proc = RouteOnAttribute::new();
         let ctx = TestContext {
-            attr_name: "type".to_string(),
-            attr_value: "sensor".to_string(),
-            strategy: "exact".to_string(),
+            properties: vec![
+                ("Matching Strategy".to_string(), "exact".to_string()),
+                // Dynamic property: route "sensor-data" when type=sensor
+                ("sensor-data".to_string(), "type=sensor".to_string()),
+                // Dynamic property: route "log-data" when type=log
+                ("log-data".to_string(), "type=log".to_string()),
+            ],
         };
 
         let mut session = MultiFlowFileSession {
-            inputs: vec![make_ff(1, "type", "sensor"), make_ff(2, "type", "log")],
+            inputs: vec![
+                make_ff(1, "type", "sensor"),
+                make_ff(2, "type", "log"),
+                make_ff(3, "type", "unknown"),
+            ],
             transferred: Vec::new(),
         };
 
         proc.on_trigger(&ctx, &mut session).unwrap();
 
-        assert_eq!(session.transferred.len(), 2);
-        assert_eq!(session.transferred[0].1, "matched");
-        assert_eq!(session.transferred[1].1, "unmatched");
+        assert_eq!(session.transferred.len(), 3);
+        assert_eq!(session.transferred[0].1, "sensor-data");
+        assert_eq!(session.transferred[1].1, "log-data");
+        assert_eq!(session.transferred[2].1, "unmatched");
     }
 
     #[test]
     fn routes_contains() {
         let mut proc = RouteOnAttribute::new();
         let ctx = TestContext {
-            attr_name: "filename".to_string(),
-            attr_value: ".csv".to_string(),
-            strategy: "contains".to_string(),
+            properties: vec![
+                ("Matching Strategy".to_string(), "contains".to_string()),
+                ("csv-files".to_string(), "filename=.csv".to_string()),
+            ],
         };
 
         let mut session = MultiFlowFileSession {
@@ -243,53 +337,7 @@ mod tests {
 
         proc.on_trigger(&ctx, &mut session).unwrap();
 
-        assert_eq!(session.transferred[0].1, "matched");
-        assert_eq!(session.transferred[1].1, "unmatched");
-    }
-
-    #[test]
-    fn routes_starts_with() {
-        let mut proc = RouteOnAttribute::new();
-        let ctx = TestContext {
-            attr_name: "filename".to_string(),
-            attr_value: "data-".to_string(),
-            strategy: "starts_with".to_string(),
-        };
-
-        let mut session = MultiFlowFileSession {
-            inputs: vec![
-                make_ff(1, "filename", "data-2024.csv"),
-                make_ff(2, "filename", "log-2024.csv"),
-            ],
-            transferred: Vec::new(),
-        };
-
-        proc.on_trigger(&ctx, &mut session).unwrap();
-
-        assert_eq!(session.transferred[0].1, "matched");
-        assert_eq!(session.transferred[1].1, "unmatched");
-    }
-
-    #[test]
-    fn routes_ends_with() {
-        let mut proc = RouteOnAttribute::new();
-        let ctx = TestContext {
-            attr_name: "filename".to_string(),
-            attr_value: ".csv".to_string(),
-            strategy: "ends_with".to_string(),
-        };
-
-        let mut session = MultiFlowFileSession {
-            inputs: vec![
-                make_ff(1, "filename", "data.csv"),
-                make_ff(2, "filename", "data.json"),
-            ],
-            transferred: Vec::new(),
-        };
-
-        proc.on_trigger(&ctx, &mut session).unwrap();
-
-        assert_eq!(session.transferred[0].1, "matched");
+        assert_eq!(session.transferred[0].1, "csv-files");
         assert_eq!(session.transferred[1].1, "unmatched");
     }
 
@@ -297,9 +345,13 @@ mod tests {
     fn routes_regex() {
         let mut proc = RouteOnAttribute::new();
         let ctx = TestContext {
-            attr_name: "filename".to_string(),
-            attr_value: r"^data-\d+\.csv$".to_string(),
-            strategy: "regex".to_string(),
+            properties: vec![
+                ("Matching Strategy".to_string(), "regex".to_string()),
+                (
+                    "data-files".to_string(),
+                    r"filename=^data-\d+\.csv$".to_string(),
+                ),
+            ],
         };
 
         let mut session = MultiFlowFileSession {
@@ -313,8 +365,115 @@ mod tests {
 
         proc.on_trigger(&ctx, &mut session).unwrap();
 
-        assert_eq!(session.transferred[0].1, "matched");
+        assert_eq!(session.transferred[0].1, "data-files");
         assert_eq!(session.transferred[1].1, "unmatched");
         assert_eq!(session.transferred[2].1, "unmatched");
+    }
+
+    #[test]
+    fn routes_starts_with() {
+        let mut proc = RouteOnAttribute::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Matching Strategy".to_string(), "starts_with".to_string()),
+                ("data-prefix".to_string(), "filename=data-".to_string()),
+            ],
+        };
+
+        let mut session = MultiFlowFileSession {
+            inputs: vec![
+                make_ff(1, "filename", "data-2024.csv"),
+                make_ff(2, "filename", "log-2024.csv"),
+            ],
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred[0].1, "data-prefix");
+        assert_eq!(session.transferred[1].1, "unmatched");
+    }
+
+    #[test]
+    fn routes_ends_with() {
+        let mut proc = RouteOnAttribute::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Matching Strategy".to_string(), "ends_with".to_string()),
+                ("csv-files".to_string(), "filename=.csv".to_string()),
+            ],
+        };
+
+        let mut session = MultiFlowFileSession {
+            inputs: vec![
+                make_ff(1, "filename", "data.csv"),
+                make_ff(2, "filename", "data.json"),
+            ],
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred[0].1, "csv-files");
+        assert_eq!(session.transferred[1].1, "unmatched");
+    }
+
+    #[test]
+    fn routes_attribute_existence() {
+        let mut proc = RouteOnAttribute::new();
+        let ctx = TestContext {
+            properties: vec![
+                ("Matching Strategy".to_string(), "exact".to_string()),
+                // No '=' in value — checks for attribute existence.
+                ("has-priority".to_string(), "priority".to_string()),
+            ],
+        };
+
+        let ff_with = make_ff(1, "priority", "high");
+        let ff_without = FlowFile {
+            id: 2,
+            attributes: Vec::new(),
+            content_claim: None,
+            size: 0,
+            created_at_nanos: 0,
+            lineage_start_id: 2,
+            penalized_until_nanos: 0,
+        };
+
+        let mut session = MultiFlowFileSession {
+            inputs: vec![ff_with, ff_without],
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred[0].1, "has-priority");
+        assert_eq!(session.transferred[1].1, "unmatched");
+    }
+
+    #[test]
+    fn no_rules_all_unmatched() {
+        let mut proc = RouteOnAttribute::new();
+        let ctx = TestContext {
+            properties: vec![("Matching Strategy".to_string(), "exact".to_string())],
+        };
+
+        let mut session = MultiFlowFileSession {
+            inputs: vec![make_ff(1, "type", "sensor")],
+            transferred: Vec::new(),
+        };
+
+        proc.on_trigger(&ctx, &mut session).unwrap();
+
+        assert_eq!(session.transferred.len(), 1);
+        assert_eq!(session.transferred[0].1, "unmatched");
+    }
+
+    #[test]
+    fn supports_dynamic_properties_flag() {
+        let proc = RouteOnAttribute::new();
+        assert!(proc.supports_dynamic_properties());
+        assert!(proc.dynamic_property_creates_relationship());
+        assert!(!proc.supports_sensitive_dynamic_properties());
     }
 }

--- a/crates/runifi-processors/src/update_attribute.rs
+++ b/crates/runifi-processors/src/update_attribute.rs
@@ -108,6 +108,10 @@ impl Processor for UpdateAttribute {
     fn property_descriptors(&self) -> Vec<PropertyDescriptor> {
         vec![PROP_DELETE_ATTRIBUTES]
     }
+
+    fn supports_dynamic_properties(&self) -> bool {
+        true
+    }
 }
 
 inventory::submit! {


### PR DESCRIPTION
## Summary

- Adds `supports_dynamic_properties()`, `supports_sensitive_dynamic_properties()`, and `dynamic_property_creates_relationship()` default methods to the `Processor` trait
- Engine validation now rejects unknown properties on processors that don't declare dynamic property support
- RouteOnAttribute redesigned: dynamic properties define routing rules (property name = relationship, value = `attribute_name=expected_value`)
- UpdateAttribute formally declares dynamic property support
- API masks sensitive dynamic property values in responses
- Dashboard shows "Add Property" UI section for processors supporting dynamic properties
- Dynamic relationships tracked at runtime via `Arc<RwLock<Vec<RelationshipInfo>>>`

## Changes by crate

| Crate | Files | Description |
|-------|-------|-------------|
| `runifi-plugin-api` | `processor.rs` | 3 new default trait methods |
| `runifi-core` | `handle.rs`, `flow_engine.rs`, `mutation_handler.rs` | `ProcessorInfo` extended, validation enforced, dynamic relationships |
| `runifi-processors` | `route_on_attribute.rs`, `update_attribute.rs` | Dynamic property declarations, RouteOnAttribute redesign |
| `runifi-api` | `dto.rs`, `routes/processors.rs` | API response fields, validation with dynamic awareness, sensitive masking |
| `dashboard` | `ProcessorConfigModal.tsx`, `types/api.ts` | "Add Property" UI, dynamic property display/editing |

## RouteOnAttribute new behavior

Each dynamic property defines a routing rule:
- **Property name** = relationship name (e.g., `csv-files`)
- **Property value** = condition in `attribute_name=expected_value` format (e.g., `filename=.csv`)
- If value has no `=`, checks for attribute existence
- `Routing Strategy` property: "route to all" (default) or "route to first"
- FlowFiles matching no rules go to `unmatched`

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] RouteOnAttribute: exact match, contains, starts_with, ends_with, regex, attribute existence, no rules, dynamic properties flag
- [x] UpdateAttribute: dynamic property declaration, existing tests pass
- [x] Engine validation: unknown properties rejected on non-dynamic processors
- [x] API: sensitive dynamic property masking

Closes #276