### PR TITLE
feat: system diagnostics dashboard UI (#290)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/App.tsx
+++ b/crates/runifi-api/dashboard-react/src/App.tsx
@@ -8,6 +8,7 @@ import { Breadcrumb } from './components/Breadcrumb';
 import { ToastNotifier } from './components/ToastNotifier';
 import { ControllerServicesPanel } from './components/ControllerServicesPanel';
 import { BulletinBoard } from './components/BulletinBoard';
+import { SystemDiagnosticsModal } from './components/SystemDiagnosticsModal';
 import { useFlowTopology } from './hooks/useFlowTopology';
 import { useGroupNavigation } from './hooks/useGroupNavigation';
 import { useSseMetrics } from './hooks/useSseMetrics';
@@ -34,6 +35,7 @@ export function App() {
   const [addPluginAtCenter, setAddPluginAtCenter] = useState<PluginDescriptor | null>(null);
   const [bulletinOpen, setBulletinOpen] = useState(false);
   const [controllerServicesOpen, setControllerServicesOpen] = useState(false);
+  const [systemDiagnosticsOpen, setSystemDiagnosticsOpen] = useState(false);
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [colorRequestNodeIds, setColorRequestNodeIds] = useState<string[] | null>(null);
 
@@ -88,6 +90,7 @@ export function App() {
         sseStatus={sseStatus}
         onOpenBulletins={toggleBulletins}
         onOpenControllerServices={() => setControllerServicesOpen(true)}
+        onOpenSystemDiagnostics={() => setSystemDiagnosticsOpen(true)}
       />
       <ComponentToolbar
         plugins={plugins}
@@ -172,6 +175,12 @@ export function App() {
           plugins={plugins}
           onToast={pushToast}
           onClose={() => setControllerServicesOpen(false)}
+        />
+      )}
+
+      {systemDiagnosticsOpen && (
+        <SystemDiagnosticsModal
+          onClose={() => setSystemDiagnosticsOpen(false)}
         />
       )}
     </div>

--- a/crates/runifi-api/dashboard-react/src/components/Header.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/Header.tsx
@@ -8,6 +8,7 @@ interface HeaderProps {
   sseStatus: SseStatus;
   onOpenControllerServices?: () => void;
   onOpenBulletins?: () => void;
+  onOpenSystemDiagnostics?: () => void;
 }
 
 interface MenuItem {
@@ -25,14 +26,14 @@ const MENU_ITEMS: MenuItem[] = [
   { label: 'Controller Services', action: 'controller-services', icon: '\u2699' },
   { label: 'Data Provenance', action: 'data-provenance', icon: '\uD83D\uDD0D', disabled: true, disabledReason: 'Not yet implemented', separator: true },
   { label: 'Flow Configuration History', action: 'flow-history', icon: '\uD83D\uDCC4', disabled: true, disabledReason: 'Not yet implemented' },
-  { label: 'System Diagnostics', action: 'system-diagnostics', icon: '\uD83D\uDCCA', disabled: true, disabledReason: 'Not yet implemented', separator: true },
+  { label: 'System Diagnostics', action: 'system-diagnostics', icon: '\uD83D\uDCCA', separator: true },
   { label: 'Users & Groups', action: 'users', icon: '\uD83D\uDC65', adminOnly: true, disabled: true, disabledReason: 'Not yet implemented', separator: true },
   { label: 'Help', action: 'help', icon: '?' },
   { label: 'About RuniFi', action: 'about', icon: '\u24D8', separator: true },
   { label: 'Logout', action: 'logout', icon: '\u2192' },
 ];
 
-function HeaderInner({ flowName, uptimeSecs, sseStatus, onOpenControllerServices, onOpenBulletins }: HeaderProps) {
+function HeaderInner({ flowName, uptimeSecs, sseStatus, onOpenControllerServices, onOpenBulletins, onOpenSystemDiagnostics }: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -71,6 +72,9 @@ function HeaderInner({ flowName, uptimeSecs, sseStatus, onOpenControllerServices
         break;
       case 'controller-services':
         onOpenControllerServices?.();
+        break;
+      case 'system-diagnostics':
+        onOpenSystemDiagnostics?.();
         break;
       case 'about':
         setAboutOpen(true);

--- a/crates/runifi-api/dashboard-react/src/components/SystemDiagnosticsModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/SystemDiagnosticsModal.tsx
@@ -1,0 +1,137 @@
+import { memo } from 'react';
+import { useSystemDiagnostics } from '../hooks/useSystemDiagnostics';
+import { formatBytes, formatUptime } from '../utils/format';
+
+interface SystemDiagnosticsModalProps {
+  onClose: () => void;
+}
+
+function UsageBar({ label, used, total, format }: {
+  label: string;
+  used: number;
+  total: number;
+  format: (n: number) => string;
+}) {
+  const pct = total > 0 ? Math.min((used / total) * 100, 100) : 0;
+  const color = pct >= 90 ? 'var(--danger)' : pct >= 75 ? 'var(--warning)' : 'var(--accent)';
+
+  return (
+    <div className="diag-usage-bar-wrap">
+      <div className="diag-usage-bar-header">
+        <span className="diag-usage-bar-label">{label}</span>
+        <span className="diag-usage-bar-value">{format(used)} / {format(total)}</span>
+      </div>
+      <div className="diag-usage-bar-track" role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100}>
+        <div className="diag-usage-bar-fill" style={{ width: `${pct}%`, backgroundColor: color }} />
+      </div>
+      <span className="diag-usage-bar-pct">{pct.toFixed(1)}%</span>
+    </div>
+  );
+}
+
+function MetricRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="diag-metric-row">
+      <span className="diag-metric-label">{label}</span>
+      <span className="diag-metric-value">{value}</span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="diag-section">
+      <h4 className="diag-section-title">{title}</h4>
+      <div className="diag-section-body">{children}</div>
+    </div>
+  );
+}
+
+function SystemDiagnosticsModalInner({ onClose }: SystemDiagnosticsModalProps) {
+  const { data, loading, error, autoRefresh, setAutoRefresh, refresh } = useSystemDiagnostics(true);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content diag-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h3>System Diagnostics</h3>
+          <div className="diag-header-controls">
+            <label className="diag-auto-refresh">
+              <input
+                type="checkbox"
+                checked={autoRefresh}
+                onChange={(e) => setAutoRefresh(e.target.checked)}
+              />
+              Auto-refresh (5s)
+            </label>
+            <button className="diag-refresh-btn" onClick={refresh} title="Refresh now">
+              &#x21bb;
+            </button>
+            <button className="modal-close" onClick={onClose} aria-label="Close">&times;</button>
+          </div>
+        </div>
+
+        {loading && !data && (
+          <div className="diag-loading">Loading diagnostics...</div>
+        )}
+
+        {error && (
+          <div className="diag-error">Failed to load diagnostics: {error}</div>
+        )}
+
+        {data && (
+          <div className="diag-body">
+            <Section title="System">
+              <MetricRow label="Version" value={data.version} />
+              <MetricRow label="Flow" value={data.flow_name} />
+              <MetricRow label="Uptime" value={formatUptime(data.uptime_secs)} />
+              <MetricRow label="CPU Cores" value={data.cpu.available_cores} />
+              <MetricRow label="Process CPU" value={`${data.cpu.process_cpu_percent.toFixed(1)}%`} />
+            </Section>
+
+            <Section title="Memory">
+              <UsageBar
+                label="Resident (RSS)"
+                used={data.memory.resident_bytes}
+                total={data.memory.total_system_bytes}
+                format={formatBytes}
+              />
+              <MetricRow label="Virtual Memory" value={formatBytes(data.memory.virtual_bytes)} />
+              <UsageBar
+                label="System Memory"
+                used={data.memory.used_system_bytes}
+                total={data.memory.total_system_bytes}
+                format={formatBytes}
+              />
+            </Section>
+
+            <Section title="Repositories">
+              <MetricRow label="Content Repo Type" value={data.repositories.content.storage_type} />
+              <MetricRow label="Content Entries" value={data.repositories.content.entry_count.toLocaleString()} />
+              <MetricRow label="Content Size" value={formatBytes(data.repositories.content.total_bytes)} />
+              <MetricRow label="FlowFile Repo Type" value={data.repositories.flowfile.storage_type} />
+              <MetricRow label="FlowFile Entries" value={data.repositories.flowfile.entry_count.toLocaleString()} />
+              <MetricRow label="FlowFile WAL Size" value={formatBytes(data.repositories.flowfile.storage_bytes)} />
+              <MetricRow label="Provenance Events" value={data.repositories.provenance.event_count.toLocaleString()} />
+            </Section>
+
+            <Section title="Connections">
+              <MetricRow label="Total Connections" value={data.connection_count} />
+              <MetricRow label="Queued FlowFiles" value={data.connections_summary.total_queued_flowfiles.toLocaleString()} />
+              <MetricRow label="Queued Bytes" value={formatBytes(data.connections_summary.total_queued_bytes)} />
+              <MetricRow label="Back-Pressured" value={data.connections_summary.back_pressured_count} />
+            </Section>
+
+            <Section title="Throughput">
+              <MetricRow label="Processors" value={data.processor_count} />
+              <MetricRow label="FlowFiles Processed" value={data.runtime.total_flowfiles_processed.toLocaleString()} />
+              <MetricRow label="Bytes Processed" value={formatBytes(data.runtime.total_bytes_processed)} />
+            </Section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const SystemDiagnosticsModal = memo(SystemDiagnosticsModalInner);

--- a/crates/runifi-api/dashboard-react/src/hooks/useSystemDiagnostics.ts
+++ b/crates/runifi-api/dashboard-react/src/hooks/useSystemDiagnostics.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { SystemResponse } from '../types/api';
+
+interface UseSystemDiagnosticsResult {
+  data: SystemResponse | null;
+  loading: boolean;
+  error: string | null;
+  autoRefresh: boolean;
+  setAutoRefresh: (enabled: boolean) => void;
+  refresh: () => void;
+}
+
+export function useSystemDiagnostics(open: boolean): UseSystemDiagnosticsResult {
+  const [data, setData] = useState<SystemResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchDiagnostics = useCallback(async () => {
+    try {
+      setLoading((prev) => !prev && !data ? true : prev);
+      const token = localStorage.getItem('runifi-token');
+      const headers: Record<string, string> = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch('/api/v1/system', { headers });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json: SystemResponse = await res.json();
+      setData(json);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [data]);
+
+  // Initial fetch when opened
+  useEffect(() => {
+    if (open) {
+      setLoading(true);
+      fetchDiagnostics();
+    } else {
+      setData(null);
+      setError(null);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh polling
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (open && autoRefresh) {
+      intervalRef.current = setInterval(fetchDiagnostics, 5000);
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [open, autoRefresh, fetchDiagnostics]);
+
+  return { data, loading, error, autoRefresh, setAutoRefresh, refresh: fetchDiagnostics };
+}

--- a/crates/runifi-api/dashboard-react/src/hooks/useSystemDiagnostics.ts
+++ b/crates/runifi-api/dashboard-react/src/hooks/useSystemDiagnostics.ts
@@ -19,7 +19,6 @@ export function useSystemDiagnostics(open: boolean): UseSystemDiagnosticsResult 
 
   const fetchDiagnostics = useCallback(async () => {
     try {
-      setLoading((prev) => !prev && !data ? true : prev);
       const token = localStorage.getItem('runifi-token');
       const headers: Record<string, string> = {};
       if (token) headers['Authorization'] = `Bearer ${token}`;
@@ -33,7 +32,7 @@ export function useSystemDiagnostics(open: boolean): UseSystemDiagnosticsResult 
     } finally {
       setLoading(false);
     }
-  }, [data]);
+  }, []);
 
   // Initial fetch when opened
   useEffect(() => {

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -2913,6 +2913,174 @@ body {
   color: var(--text);
 }
 
+/* ── System Diagnostics modal ─────────────────────────────── */
+
+.diag-modal {
+  max-width: 560px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.diag-modal .modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.diag-modal .modal-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.diag-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.diag-auto-refresh {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  user-select: none;
+}
+
+.diag-auto-refresh input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.diag-refresh-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.15rem 0.4rem;
+  line-height: 1;
+}
+
+.diag-refresh-btn:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.diag-body {
+  overflow-y: auto;
+  padding: 0.75rem 1.5rem 1.5rem;
+}
+
+.diag-loading,
+.diag-error {
+  padding: 2rem 1.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+.diag-loading {
+  color: var(--text-dim);
+}
+
+.diag-error {
+  color: var(--danger);
+}
+
+.diag-section {
+  margin-bottom: 1rem;
+}
+
+.diag-section:last-child {
+  margin-bottom: 0;
+}
+
+.diag-section-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.5rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.diag-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.diag-metric-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.2rem 0;
+  font-size: 0.82rem;
+}
+
+.diag-metric-label {
+  color: var(--text-dim);
+}
+
+.diag-metric-value {
+  color: var(--text);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.diag-usage-bar-wrap {
+  padding: 0.3rem 0;
+}
+
+.diag-usage-bar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.diag-usage-bar-label {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.diag-usage-bar-value {
+  font-size: 0.75rem;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.diag-usage-bar-track {
+  height: 8px;
+  background: var(--bg);
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.diag-usage-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.diag-usage-bar-pct {
+  display: block;
+  text-align: right;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  margin-top: 0.15rem;
+}
+
 /* ── NiFi status bar segments ──────────────────────────────── */
 
 .status-bar-segment {

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -130,12 +130,62 @@ export interface SseMetricsEvent {
   bulletins: BulletinResponse[];
 }
 
+export interface MemoryInfo {
+  resident_bytes: number;
+  virtual_bytes: number;
+  total_system_bytes: number;
+  used_system_bytes: number;
+}
+
+export interface CpuInfo {
+  process_cpu_percent: number;
+  available_cores: number;
+}
+
+export interface ContentRepoInfo {
+  entry_count: number;
+  total_bytes: number;
+  storage_type: string;
+}
+
+export interface FlowFileRepoInfo {
+  entry_count: number;
+  storage_bytes: number;
+  storage_type: string;
+}
+
+export interface ProvenanceRepoInfo {
+  event_count: number;
+}
+
+export interface RepositoryStorageInfo {
+  content: ContentRepoInfo;
+  flowfile: FlowFileRepoInfo;
+  provenance: ProvenanceRepoInfo;
+}
+
+export interface RuntimeInfo {
+  total_flowfiles_processed: number;
+  total_bytes_processed: number;
+}
+
+export interface ConnectionsSummary {
+  total_queued_flowfiles: number;
+  total_queued_bytes: number;
+  back_pressured_count: number;
+}
+
 export interface SystemResponse {
   flow_name: string;
   uptime_secs: number;
   version: string;
   processor_count: number;
   connection_count: number;
+  memory: MemoryInfo;
+  cpu: CpuInfo;
+  repositories: RepositoryStorageInfo;
+  runtime: RuntimeInfo;
+  connections_summary: ConnectionsSummary;
 }
 
 // Plugin/processor type registry (GET /api/v1/plugins)


### PR DESCRIPTION
## Summary

- Enable "System Diagnostics" in the global menu header
- Add modal dialog displaying comprehensive system health information from the `/api/v1/system` endpoint (#266)
- Auto-refresh toggle with 5-second polling interval

## Changes

**New files:**
- `SystemDiagnosticsModal.tsx` — modal with sections: System, Memory, Repositories, Connections, Throughput
- `useSystemDiagnostics.ts` — hook for fetching diagnostics with auto-refresh

**Modified files:**
- `api.ts` — expanded `SystemResponse` type with MemoryInfo, CpuInfo, RepositoryStorageInfo, RuntimeInfo, ConnectionsSummary
- `Header.tsx` — enabled System Diagnostics menu item, added `onOpenSystemDiagnostics` callback
- `App.tsx` — wired modal open/close state
- `global.css` — diagnostics modal styles (usage bars, metric rows, sections)

## Sections displayed
| Section | Metrics |
|---------|---------|
| System | Version, flow name, uptime, CPU cores, process CPU% |
| Memory | RSS usage bar, virtual memory, system memory usage bar |
| Repositories | Content repo (type, entries, size), FlowFile repo (type, entries, WAL size), Provenance events |
| Connections | Total connections, queued FlowFiles/bytes, back-pressured count |
| Throughput | Processor count, total FlowFiles processed, total bytes processed |

## Test plan

- [ ] Open global menu, verify "System Diagnostics" is enabled (not grayed out)
- [ ] Click System Diagnostics, verify modal opens with all sections populated
- [ ] Verify usage bars render with correct percentages for memory
- [ ] Toggle auto-refresh off, verify polling stops
- [ ] Toggle auto-refresh on, verify data updates every 5 seconds
- [ ] Click refresh button, verify immediate data update
- [ ] Close modal via X button and overlay click
- [ ] Verify graceful display when API returns zero values

Closes #290