### PR TITLE
feat: processor config dialog — editable scheduling, name editing, retry config (#280)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Issue #280
+
+## Analysis
+
+### Current State
+- ProcessorConfigModal.tsx has 5 tabs (settings, scheduling, properties, relationships, comments)
+- Scheduling strategy and interval are readOnly/disabled text inputs
+- Processor name is readOnly/disabled
+- Relationships tab only shows auto-terminate checkboxes (no retry config)
+- Execution node selection is missing
+
+### Backend Analysis
+- `ProcessorConfigUpdateRequest` DTO already has `scheduling_strategy` and `scheduling_interval_ms` fields
+- The API handler `update_processor_config` does NOT pass these fields to the engine
+- The engine `update_processor_config` does NOT accept scheduling params
+- `ProcessorInfo.scheduling` is a plain field, not Arc<RwLock<...>>
+- `ProcessorNode.scheduling` is consumed at creation, used in `wait_for_trigger()`
+- Making scheduling mutable requires: Arc<RwLock<SchedulingStrategy>> on ProcessorNode + ProcessorInfo, update in handle, update scheduling_display
+
+### Scope Decision
+Focus on what can be done cleanly:
+
+**Phase 1 (this PR):**
+1. Make scheduling strategy + interval editable in the UI (form state, dropdown, editable input)
+2. Wire scheduling_strategy + scheduling_interval_ms through the API handler to the engine
+3. Make ProcessorInfo.scheduling and scheduling_display mutable (Arc<RwLock<...>>)
+4. Make ProcessorNode.scheduling an Arc<RwLock<...>> so wait_for_trigger reads updated value
+5. Make processor name editable + add rename support (backend + UI)
+6. Add execution node selection dropdown (UI + backend field on ProcessorInfo)
+7. Add retry configuration display on relationships tab (UI only — placeholders for backend)
+
+## Changes
+
+### 1. Backend: Mutable scheduling on ProcessorInfo
+**File**: `crates/runifi-core/src/engine/handle.rs`
+- Change `ProcessorInfo.scheduling` from `SchedulingStrategy` to `Arc<RwLock<SchedulingStrategy>>`
+- Change `ProcessorInfo.scheduling_display` from `String` to `Arc<RwLock<String>>`
+- Update `update_processor_config` to accept and apply `scheduling_strategy` and `scheduling_interval_ms`
+- Add `rename_processor` method
+
+### 2. Backend: Mutable scheduling on ProcessorNode
+**File**: `crates/runifi-core/src/engine/processor_node.rs`
+- Change `self.scheduling` from `SchedulingStrategy` to `Arc<RwLock<SchedulingStrategy>>`
+- Update `wait_for_trigger` to read from the lock
+- Update constructor
+
+### 3. Backend: Wire scheduling through FlowEngine
+**File**: `crates/runifi-core/src/engine/flow_engine.rs`
+- Pass Arc<RwLock<SchedulingStrategy>> when creating ProcessorNode
+- Update scheduling_display assignment
+
+### 4. Backend: Wire scheduling through MutationHandler
+**File**: `crates/runifi-core/src/engine/mutation_handler.rs`
+- Same pattern as flow_engine.rs for hot-added processors
+
+### 5. Backend: Wire scheduling through API handler
+**File**: `crates/runifi-api/src/routes/processors.rs`
+- Pass `body.scheduling_strategy` and `body.scheduling_interval_ms` to engine
+
+### 6. Backend: Update persistence
+**File**: `crates/runifi-core/src/engine/persistence.rs`
+- Update reads of scheduling_display to go through lock
+
+### 7. Frontend: Scheduling Tab
+**File**: `crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx`
+- Add `schedulingStrategy` and `schedulingIntervalMs` to ConfigFormState
+- Initialize from config response
+- Replace readOnly text input with dropdown for strategy
+- Replace readOnly text input with editable number input for interval
+- Include in save payload
+
+### 8. Frontend: Processor Name Editing
+- Add `name` to ConfigFormState
+- Make name input editable
+- Call rename API on save if name changed
+
+### 9. Frontend: Execution Node Selection
+- Add execution_node dropdown to scheduling tab
+- Backed by a new field on ProcessorInfo
+
+### 10. Frontend: Retry Configuration (UI only)
+- Add retry attempt count, back off policy, max back off period columns to relationships table
+- Currently read-only with placeholder values since backend doesn't support it yet
+
+## Testing
+- Unit tests for scheduling update in handle.rs
+- Unit tests for rename
+- Verify existing tests pass with Arc<RwLock<SchedulingStrategy>> changes

--- a/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ProcessorConfigModal.tsx
@@ -18,11 +18,15 @@ interface ProcessorConfigModalProps {
 /** Form state for all editable fields across all tabs. */
 interface ConfigFormState {
   // Settings
+  name: string;
   penaltyDurationMs: number;
   yieldDurationMs: number;
   bulletinLevel: string;
   // Scheduling
+  schedulingStrategy: string;
+  schedulingIntervalMs: number;
   concurrentTasks: number;
+  executionNode: string;
   // Properties
   properties: Record<string, string>;
   // Relationships
@@ -60,10 +64,14 @@ function initFormState(data: ProcessorConfigResponse): ConfigFormState {
     }
   }
   return {
+    name: data.processor_name,
     penaltyDurationMs: data.penalty_duration_ms,
     yieldDurationMs: data.yield_duration_ms,
     bulletinLevel: data.bulletin_level,
+    schedulingStrategy: data.scheduling.strategy,
+    schedulingIntervalMs: data.scheduling.interval_ms ?? 1000,
     concurrentTasks: data.scheduling.concurrent_tasks,
+    executionNode: data.scheduling.execution_node ?? 'all',
     properties,
     autoTerminatedRelationships: [...data.auto_terminated_relationships],
     comments: data.comments,
@@ -202,7 +210,7 @@ function ProcessorConfigModalInner({
       setSaving(true);
       setSaveStatus(null);
 
-      const payload = {
+      const payload: Record<string, unknown> = {
         properties,
         penalty_duration_ms: form.penaltyDurationMs,
         yield_duration_ms: form.yieldDurationMs,
@@ -210,7 +218,14 @@ function ProcessorConfigModalInner({
         concurrent_tasks: form.concurrentTasks,
         auto_terminated_relationships: form.autoTerminatedRelationships,
         comments: form.comments,
+        scheduling_strategy: form.schedulingStrategy,
+        scheduling_interval_ms: form.schedulingIntervalMs,
+        execution_node: form.executionNode,
       };
+      // Include name only if changed.
+      if (form.name !== processorName) {
+        payload.name = form.name;
+      }
 
       fetch(`/api/v1/processors/${encodeURIComponent(processorName)}/config`, {
         method: 'PUT',
@@ -309,7 +324,13 @@ function ProcessorConfigModalInner({
                   <h4 className="config-section-heading">Processor Details</h4>
                   <div className="config-field">
                     <label className="config-label">Name</label>
-                    <input className="form-input" type="text" value={processorName} disabled readOnly />
+                    <input
+                      className="form-input"
+                      type="text"
+                      value={form.name}
+                      onChange={(e) => handleFormChange('name', e.target.value)}
+                      disabled={!isStopped}
+                    />
                   </div>
                   <div className="config-field">
                     <label className="config-label">Type</label>
@@ -382,29 +403,29 @@ function ProcessorConfigModalInner({
                 <div className="config-field">
                   <label className="config-label">Scheduling Strategy</label>
                   <span className="config-description">How the processor is triggered</span>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={
-                      config.scheduling.strategy === 'timer' ? 'Timer Driven'
-                        : config.scheduling.strategy === 'cron' ? 'CRON Driven'
-                        : 'Event Driven'
-                    }
-                    disabled
-                    readOnly
-                  />
+                  <select
+                    className="form-select"
+                    value={form.schedulingStrategy}
+                    onChange={(e) => handleFormChange('schedulingStrategy', e.target.value)}
+                    disabled={!isStopped}
+                  >
+                    <option value="timer">Timer Driven</option>
+                    <option value="cron">CRON Driven</option>
+                    <option value="event">Event Driven</option>
+                  </select>
                 </div>
-                {config.scheduling.interval_ms != null && (
+                {form.schedulingStrategy === 'timer' && (
                   <div className="config-field">
                     <label className="config-label">Run Schedule</label>
                     <span className="config-description">Trigger interval in milliseconds</span>
                     <div className="config-input-with-unit">
                       <input
                         className="form-input"
-                        type="text"
-                        value={config.scheduling.interval_ms}
-                        disabled
-                        readOnly
+                        type="number"
+                        min={0}
+                        value={form.schedulingIntervalMs}
+                        onChange={(e) => handleFormChange('schedulingIntervalMs', Number(e.target.value))}
+                        disabled={!isStopped}
                       />
                       <span className="config-unit">ms</span>
                     </div>
@@ -425,6 +446,19 @@ function ProcessorConfigModalInner({
                     onChange={(e) => handleFormChange('concurrentTasks', Number(e.target.value))}
                     disabled={!isStopped}
                   />
+                </div>
+                <div className="config-field">
+                  <label className="config-label">Execution</label>
+                  <span className="config-description">Which nodes run this processor in a cluster</span>
+                  <select
+                    className="form-select"
+                    value={form.executionNode}
+                    onChange={(e) => handleFormChange('executionNode', e.target.value)}
+                    disabled={!isStopped}
+                  >
+                    <option value="all">All Nodes</option>
+                    <option value="primary">Primary Node Only</option>
+                  </select>
                 </div>
               </div>
             )}
@@ -609,6 +643,9 @@ function ProcessorConfigModalInner({
                           <th>Name</th>
                           <th>Description</th>
                           <th>Auto-Terminate</th>
+                          <th>Retry Attempts</th>
+                          <th>Back Off Policy</th>
+                          <th>Max Back Off</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -626,10 +663,16 @@ function ProcessorConfigModalInner({
                                 aria-label={`Auto-terminate ${rel.name}`}
                               />
                             </td>
+                            <td className="config-readonly-cell">0</td>
+                            <td className="config-readonly-cell">Penalize</td>
+                            <td className="config-readonly-cell">10 sec</td>
                           </tr>
                         ))}
                       </tbody>
                     </table>
+                    <span className="config-description" style={{ marginTop: '8px', display: 'block', fontStyle: 'italic' }}>
+                      Retry configuration is read-only. Backend support for retry is planned.
+                    </span>
                   </>
                 )}
               </div>

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -205,6 +205,7 @@ export interface SchedulingConfig {
   strategy: string;
   interval_ms: number | null;
   concurrent_tasks: number;
+  execution_node: string;
 }
 
 export interface ProcessorConfigResponse {

--- a/crates/runifi-api/src/dto.rs
+++ b/crates/runifi-api/src/dto.rs
@@ -145,7 +145,7 @@ impl ProcessorResponse {
         Self {
             name: info.name.clone(),
             type_name: info.type_name.clone(),
-            scheduling: info.scheduling_display.clone(),
+            scheduling: info.scheduling_display.read().clone(),
             state,
             metrics: snapshot.into(),
             validation_errors,
@@ -412,6 +412,7 @@ pub struct SchedulingResponse {
     pub strategy: String,
     pub interval_ms: Option<u64>,
     pub concurrent_tasks: u64,
+    pub execution_node: String,
     #[serde(skip_serializing_if = "is_zero_u64")]
     pub run_duration_ms: u64,
     #[serde(skip_serializing_if = "is_zero_u64")]
@@ -431,7 +432,6 @@ pub struct RelationshipResponse {
 
 /// Request body for `PUT /api/v1/processors/{name}/config`.
 #[derive(Deserialize)]
-#[allow(dead_code)]
 pub struct ProcessorConfigUpdateRequest {
     #[serde(default)]
     pub properties: Option<HashMap<String, String>>,
@@ -455,18 +455,23 @@ pub struct ProcessorConfigUpdateRequest {
     pub run_duration_ms: Option<u64>,
     #[serde(default)]
     pub batch_commit_count: Option<u64>,
+    #[serde(default)]
+    pub execution_node: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
 }
 
 impl ProcessorConfigResponse {
     pub fn from_info(info: &ProcessorInfo) -> Self {
         // Parse the display string to extract strategy/interval for the config response.
         // Format is "timer-driven (Nms)", "cron-driven (expr)", or "event-driven".
+        let sched_display = info.scheduling_display.read().clone();
         let (strategy, interval_ms) =
-            if let Some(rest) = info.scheduling_display.strip_prefix("timer-driven (") {
+            if let Some(rest) = sched_display.strip_prefix("timer-driven (") {
                 let ms_str = rest.trim_end_matches("ms)");
                 let interval = ms_str.parse::<u64>().unwrap_or(1000);
                 ("timer".to_string(), Some(interval))
-            } else if info.scheduling_display.starts_with("cron-driven") {
+            } else if sched_display.starts_with("cron-driven") {
                 ("cron".to_string(), None)
             } else {
                 ("event".to_string(), None)
@@ -556,6 +561,10 @@ impl ProcessorConfigResponse {
                 concurrent_tasks: info
                     .concurrent_tasks
                     .load(std::sync::atomic::Ordering::Relaxed),
+                execution_node: match *info.execution_node.read() {
+                    runifi_plugin_api::ExecutionNode::All => "all".to_string(),
+                    runifi_plugin_api::ExecutionNode::Primary => "primary".to_string(),
+                },
                 run_duration_ms: info
                     .run_duration_ms
                     .load(std::sync::atomic::Ordering::Relaxed),

--- a/crates/runifi-api/src/routes/processors.rs
+++ b/crates/runifi-api/src/routes/processors.rs
@@ -295,7 +295,7 @@ async fn create_processor(
 
     let snapshot = info.metrics.snapshot();
     let state_str = snapshot.state.as_str().to_string();
-    let scheduling_str = info.scheduling_display.clone();
+    let scheduling_str = info.scheduling_display.read().clone();
 
     let relationships: Vec<RelationshipResponse> = info
         .relationships
@@ -399,10 +399,20 @@ async fn update_processor_config(
         body.comments,
         body.run_duration_ms,
         body.batch_commit_count,
+        body.scheduling_strategy,
+        body.scheduling_interval_ms,
+        body.execution_node,
+        body.name.clone(),
     )?;
 
+    // Use new name if renamed, otherwise the path name.
+    let effective_name = body
+        .name
+        .filter(|n| !n.is_empty() && n != &name)
+        .unwrap_or(name);
+
     Ok(Json(
-        serde_json::json!({ "status": "updated", "processor": name }),
+        serde_json::json!({ "status": "updated", "processor": effective_name }),
     ))
 }
 

--- a/crates/runifi-core/src/engine/flow_engine.rs
+++ b/crates/runifi-core/src/engine/flow_engine.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use runifi_plugin_api::{InputRequirement, Processor};
+use runifi_plugin_api::{ExecutionNode, InputRequirement, Processor};
 
 use super::bulletin::BulletinBoard;
 use super::handle::{
@@ -489,6 +489,8 @@ impl FlowEngine {
                 SharedInputNotifiers,
             ),
         > = HashMap::new();
+        type SchedulingArcs = (Arc<RwLock<SchedulingStrategy>>, Arc<RwLock<ExecutionNode>>);
+        let mut scheduling_arcs: HashMap<usize, SchedulingArcs> = HashMap::new();
 
         for node_builder in &mut self.nodes {
             let processor = node_builder
@@ -507,11 +509,16 @@ impl FlowEngine {
                 .expect("shared_props must exist")
                 .clone();
 
+            // Create shared scheduling and execution node arcs that will be
+            // shared between ProcessorNode and ProcessorInfo for runtime updates.
+            let shared_scheduling = Arc::new(RwLock::new(node_builder.scheduling.clone()));
+            let shared_exec_node = Arc::new(RwLock::new(ExecutionNode::All));
+
             let mut pn = ProcessorNode::new(
                 node_builder.name.clone(),
                 format!("node-{}", node_builder.id),
                 processor,
-                node_builder.scheduling.clone(),
+                shared_scheduling.clone(),
                 shared_props,
                 self.content_repo.clone(),
                 self.id_gen.clone(),
@@ -547,8 +554,16 @@ impl FlowEngine {
             if let Some(ref provider) = self.cluster_state_provider {
                 pn.set_cluster_state_provider(provider.clone());
             }
-            pn.set_execution_node(pn.processor_execution_node());
+            // Set execution node from processor annotation, shared with ProcessorInfo.
+            *shared_exec_node.write() = pn.processor_execution_node();
+            pn.set_execution_node_shared(shared_exec_node.clone());
             pn.set_primary_node_flag(self.is_primary_node.clone());
+
+            // Store shared arcs for ProcessorInfo construction later.
+            scheduling_arcs.insert(
+                node_builder.id,
+                (shared_scheduling.clone(), shared_exec_node.clone()),
+            );
 
             for (src, rel, dst, fc) in &flow_connections {
                 if *src == node_builder.id {
@@ -620,11 +635,19 @@ impl FlowEngine {
                 Vec::new()
             };
 
+            let (shared_scheduling, shared_exec_node) = scheduling_arcs
+                .get(&node_builder.id)
+                .expect("scheduling arcs must exist for every node")
+                .clone();
+
             processor_infos.push(ProcessorInfo {
                 name: node_builder.name.clone(),
                 type_name: node_builder.type_name.clone(),
-                scheduling_display: scheduling_display(&node_builder.scheduling),
-                scheduling: node_builder.scheduling.clone(),
+                scheduling_display: Arc::new(RwLock::new(scheduling_display(
+                    &node_builder.scheduling,
+                ))),
+                scheduling: shared_scheduling,
+                execution_node: shared_exec_node,
                 metrics,
                 property_descriptors: prop_descriptors,
                 relationships,

--- a/crates/runifi-core/src/engine/handle.rs
+++ b/crates/runifi-core/src/engine/handle.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
 use super::bulletin::BulletinBoard;
+use super::flow_engine::scheduling_display;
 use super::metrics::{ProcessorMetrics, RunOnceResult};
 use super::mutation::{MutationCommand, MutationError};
 use super::persistence::{
@@ -28,7 +29,7 @@ use super::remote_process_group::RemoteProcessGroup;
 /// is preserved (the caller did not change it).
 pub const SENSITIVE_VALUE_MASK: &str = "********";
 
-use runifi_plugin_api::InputRequirement;
+use runifi_plugin_api::{ExecutionNode, InputRequirement};
 
 use crate::audit::{AuditAction, AuditEvent, AuditLogger, AuditTarget};
 use crate::connection::back_pressure::BackPressureConfig;
@@ -89,8 +90,12 @@ pub struct ProcessorInfo {
     pub type_name: String,
     /// Human-readable scheduling description, e.g. "timer-driven (1000ms)" or "event-driven".
     /// The concrete `SchedulingStrategy` enum is kept internal to the engine.
-    pub scheduling_display: String,
-    pub scheduling: SchedulingStrategy,
+    /// Wrapped in `Arc<RwLock<>>` so scheduling updates propagate at runtime.
+    pub scheduling_display: Arc<RwLock<String>>,
+    pub scheduling: Arc<RwLock<SchedulingStrategy>>,
+    /// Execution node requirement: "all" or "primary".
+    /// Shared with ProcessorNode for runtime updates.
+    pub execution_node: Arc<RwLock<ExecutionNode>>,
     pub metrics: Arc<ProcessorMetrics>,
     /// Property descriptors (static metadata from the processor type).
     pub property_descriptors: Vec<PropertyDescriptorInfo>,
@@ -737,8 +742,12 @@ impl EngineHandle {
         comments: Option<String>,
         run_duration_ms: Option<u64>,
         batch_commit_count: Option<u64>,
+        scheduling_strategy: Option<String>,
+        scheduling_interval_ms: Option<u64>,
+        execution_node: Option<String>,
+        new_name: Option<String>,
     ) -> Result<(), ConfigUpdateError> {
-        let processors = self.processors.read();
+        let mut processors = self.processors.write();
         let info = processors
             .iter()
             .find(|p| p.name == name)
@@ -871,10 +880,98 @@ impl EngineHandle {
                 .store(bc, std::sync::atomic::Ordering::Relaxed);
         }
 
+        // Apply scheduling strategy and/or interval changes.
+        if scheduling_strategy.is_some() || scheduling_interval_ms.is_some() {
+            let current_sched = info.scheduling.read().clone();
+            let new_sched = match scheduling_strategy.as_deref() {
+                Some("timer") => {
+                    let ms = scheduling_interval_ms.unwrap_or(match &current_sched {
+                        SchedulingStrategy::TimerDriven { interval_ms } => *interval_ms,
+                        _ => 1000,
+                    });
+                    SchedulingStrategy::TimerDriven { interval_ms: ms }
+                }
+                Some("cron") => {
+                    // Preserve existing CRON expression or use a default.
+                    let expr = match &current_sched {
+                        SchedulingStrategy::CronDriven { expression } => expression.clone(),
+                        _ => "0 0/5 * * * ?".to_string(),
+                    };
+                    SchedulingStrategy::CronDriven { expression: expr }
+                }
+                Some("event") => SchedulingStrategy::EventDriven,
+                Some(other) => {
+                    return Err(ConfigUpdateError::ValidationError(format!(
+                        "Invalid scheduling strategy '{}'. Allowed: timer, cron, event",
+                        other
+                    )));
+                }
+                None => {
+                    // Only interval change — must be timer-driven.
+                    if let Some(ms) = scheduling_interval_ms {
+                        match &current_sched {
+                            SchedulingStrategy::TimerDriven { .. } => {
+                                SchedulingStrategy::TimerDriven { interval_ms: ms }
+                            }
+                            _ => {
+                                return Err(ConfigUpdateError::ValidationError(
+                                    "Cannot set interval on non-timer scheduling strategy"
+                                        .to_string(),
+                                ));
+                            }
+                        }
+                    } else {
+                        current_sched.clone()
+                    }
+                }
+            };
+            *info.scheduling.write() = new_sched.clone();
+            *info.scheduling_display.write() = scheduling_display(&new_sched);
+        }
+
+        // Apply execution node.
+        if let Some(ref exec_str) = execution_node {
+            match exec_str.as_str() {
+                "all" => *info.execution_node.write() = ExecutionNode::All,
+                "primary" => *info.execution_node.write() = ExecutionNode::Primary,
+                _ => {
+                    return Err(ConfigUpdateError::ValidationError(format!(
+                        "Invalid execution node '{}'. Allowed: all, primary",
+                        exec_str
+                    )));
+                }
+            }
+        }
+
+        // Apply name change (rename).
+        if let Some(ref new_n) = new_name
+            && !new_n.is_empty()
+            && *new_n != name
+        {
+            // Check for duplicate name.
+            if processors.iter().any(|p| p.name == *new_n) {
+                return Err(ConfigUpdateError::ValidationError(format!(
+                    "A processor with name '{}' already exists",
+                    new_n
+                )));
+            }
+            // Find the mutable info and update its name.
+            // We need to re-find because `info` is an immutable reference.
+            let info_mut = processors
+                .iter_mut()
+                .find(|p| p.name == name)
+                .expect("processor was found earlier");
+            info_mut.name = new_n.clone();
+        }
+
+        let audit_name = new_name
+            .as_deref()
+            .filter(|n| !n.is_empty() && *n != name)
+            .unwrap_or(name);
         drop(processors);
         self.audit_logger.log(&AuditEvent::success(
             AuditAction::ProcessorConfigured,
-            AuditTarget::processor(name),
+            AuditTarget::processor(audit_name),
         ));
         self.notify_persist();
         Ok(())
@@ -1241,7 +1338,7 @@ impl EngineHandle {
                 PersistedProcessor {
                     name: p.name.clone(),
                     type_name: p.type_name.clone(),
-                    scheduling: scheduling_display_to_persisted(&p.scheduling_display),
+                    scheduling: scheduling_display_to_persisted(&p.scheduling_display.read()),
                     properties: p.properties.read().clone(),
                     sensitive_properties,
                     penalty_duration_ms: if penalty != 30_000 {

--- a/crates/runifi-core/src/engine/mutation_handler.rs
+++ b/crates/runifi-core/src/engine/mutation_handler.rs
@@ -7,7 +7,7 @@ use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 use runifi_plugin_api::relationship::Relationship;
-use runifi_plugin_api::{InputRequirement, Processor};
+use runifi_plugin_api::{ExecutionNode, InputRequirement, Processor};
 
 use super::bulletin::BulletinBoard;
 use super::handle::{ConnectionInfo, ProcessorInfo, PropertyDescriptorInfo, RelationshipInfo};
@@ -143,11 +143,15 @@ impl DefaultMutationHandler {
         let shared_props = Arc::new(RwLock::new(properties));
         let child_token = self.parent_cancel.child_token();
 
+        // Create shared scheduling and execution node arcs.
+        let shared_scheduling = Arc::new(RwLock::new(scheduling.clone()));
+        let shared_exec_node = Arc::new(RwLock::new(ExecutionNode::All));
+
         let mut pn = ProcessorNode::new(
             name.to_string(),
             format!("runtime-{}", name),
             processor,
-            scheduling.clone(),
+            shared_scheduling.clone(),
             shared_props.clone(),
             self.content_repo.clone(),
             self.id_gen.clone(),
@@ -166,6 +170,9 @@ impl DefaultMutationHandler {
         if !sensitive_names.is_empty() {
             pn.set_sensitive_property_names(sensitive_names);
         }
+        // Set execution node from processor annotation, shared with ProcessorInfo.
+        *shared_exec_node.write() = pn.processor_execution_node();
+        pn.set_execution_node_shared(shared_exec_node.clone());
 
         let input_h = pn.input_connections_handle();
         let output_h = pn.output_connections_handle();
@@ -179,8 +186,9 @@ impl DefaultMutationHandler {
         self.live_procs.write().push(ProcessorInfo {
             name: name.to_string(),
             type_name: type_name.to_string(),
-            scheduling_display: scheduling_display(&scheduling),
-            scheduling: scheduling.clone(),
+            scheduling_display: Arc::new(RwLock::new(scheduling_display(&scheduling))),
+            scheduling: shared_scheduling,
+            execution_node: shared_exec_node,
             metrics,
             property_descriptors: prop_descriptors,
             relationships,
@@ -471,8 +479,9 @@ impl DefaultMutationHandler {
             .cloned()
             .ok_or_else(|| MutationError::ProcessorNotFound(processor_name.to_string()))?;
 
+        let scheduling_snapshot = scheduling.read().clone();
         let timer_notify = if count > 1 {
-            if let SchedulingStrategy::TimerDriven { interval_ms } = &scheduling {
+            if let SchedulingStrategy::TimerDriven { interval_ms } = &scheduling_snapshot {
                 let notify = Arc::new(Notify::new());
                 let timer_token = cancel_token.child_token();
                 let interval = *interval_ms;

--- a/crates/runifi-core/src/engine/persistence.rs
+++ b/crates/runifi-core/src/engine/persistence.rs
@@ -346,7 +346,7 @@ impl PersistedFlowState {
                 let comments = p.comments.read().clone();
                 let auto_term = p.auto_terminated_relationships.read().clone();
 
-                let mut sched = scheduling_display_to_persisted(&p.scheduling_display);
+                let mut sched = scheduling_display_to_persisted(&p.scheduling_display.read());
                 sched.run_duration_ms =
                     p.run_duration_ms.load(std::sync::atomic::Ordering::Relaxed);
                 sched.batch_commit_count = p

--- a/crates/runifi-core/src/engine/processor_node.rs
+++ b/crates/runifi-core/src/engine/processor_node.rs
@@ -124,7 +124,7 @@ pub struct ProcessorNode {
     pub id: String,
     /// Processor type name (e.g. "GenerateFlowFile").
     pub type_name: String,
-    pub scheduling: SchedulingStrategy,
+    pub scheduling: Arc<RwLock<SchedulingStrategy>>,
     pub properties: Arc<RwLock<HashMap<String, String>>>,
     supervisor: ProcessorSupervisor,
     /// Shared so the mutation handler can wire hot-added connections to the
@@ -158,7 +158,8 @@ pub struct ProcessorNode {
     /// Cluster-scoped state provider for shared processor state.
     cluster_state_provider: Option<SharedClusterStateProvider>,
     /// Whether this processor should run on all nodes or only the primary.
-    execution_node: ExecutionNode,
+    /// Shared with ProcessorInfo for runtime updates.
+    execution_node: Arc<RwLock<ExecutionNode>>,
     /// Shared flag indicating whether this node is the primary in the cluster.
     is_primary_node: Arc<AtomicBool>,
     /// Run duration in milliseconds for batch processing (0 = disabled).
@@ -175,7 +176,7 @@ impl ProcessorNode {
         name: String,
         id: String,
         processor: Box<dyn Processor>,
-        scheduling: SchedulingStrategy,
+        scheduling: Arc<RwLock<SchedulingStrategy>>,
         properties: Arc<RwLock<HashMap<String, String>>>,
         content_repo: Arc<dyn ContentRepository>,
         id_gen: Arc<IdGenerator>,
@@ -211,7 +212,7 @@ impl ProcessorNode {
             concurrent_tasks: Arc::new(AtomicU64::new(1)),
             timer_notify: None,
             cluster_state_provider: None,
-            execution_node: ExecutionNode::All,
+            execution_node: Arc::new(RwLock::new(ExecutionNode::All)),
             is_primary_node: Arc::new(AtomicBool::new(true)),
             run_duration_ms: 0,
             batch_commit_count: 0,
@@ -264,8 +265,8 @@ impl ProcessorNode {
         self.cluster_state_provider = Some(provider);
     }
 
-    /// Set which nodes should execute this processor.
-    pub fn set_execution_node(&mut self, exec: ExecutionNode) {
+    /// Set which nodes should execute this processor (shared with ProcessorInfo).
+    pub fn set_execution_node_shared(&mut self, exec: Arc<RwLock<ExecutionNode>>) {
         self.execution_node = exec;
     }
 
@@ -526,7 +527,7 @@ impl ProcessorNode {
 
                 // Primary-node-only check: if this processor requires the primary
                 // node and we are not the primary, sleep and re-check.
-                if self.execution_node == ExecutionNode::Primary
+                if *self.execution_node.read() == ExecutionNode::Primary
                     && !self.is_primary_node.load(Ordering::Relaxed)
                 {
                     tokio::select! {
@@ -1197,7 +1198,10 @@ impl ProcessorNode {
     }
 
     async fn wait_for_trigger(&self) {
-        match &self.scheduling {
+        // Snapshot the scheduling strategy under a brief lock to avoid holding
+        // parking_lot across an await point.
+        let strategy = self.scheduling.read().clone();
+        match &strategy {
             SchedulingStrategy::TimerDriven { interval_ms } => {
                 if let Some(ref notify) = self.timer_notify {
                     notify.notified().await;

--- a/crates/runifi-core/tests/concurrent_tasks.rs
+++ b/crates/runifi-core/tests/concurrent_tasks.rs
@@ -120,6 +120,10 @@ async fn concurrent_tasks_clamp_accepts_up_to_64() {
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
         )
         .expect("config update failed");
 
@@ -161,6 +165,10 @@ async fn concurrent_tasks_clamp_enforces_max_64() {
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
         )
         .expect("config update failed");
 
@@ -198,6 +206,10 @@ async fn concurrent_tasks_clamp_enforces_min_1() {
             None,
             None,
             Some(0),
+            None,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -244,6 +256,10 @@ async fn spawn_concurrent_tasks_creates_sibling_tasks() {
             None,
             None,
             Some(4),
+            None,
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -408,6 +424,10 @@ async fn event_driven_concurrent_tasks_share_input_connections() {
             None,
             None,
             Some(3),
+            None,
+            None,
+            None,
+            None,
             None,
             None,
             None,

--- a/crates/runifi-core/tests/end_to_end_flow.rs
+++ b/crates/runifi-core/tests/end_to_end_flow.rs
@@ -180,7 +180,8 @@ async fn fault_tolerance_panic_recovery() {
     engine.start().await.unwrap();
 
     // Wait for the panic processor to trip its circuit breaker.
-    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+    // The 5 failures with exponential backoff (100ms base) need ~3.5s total.
+    tokio::time::sleep(std::time::Duration::from_millis(4000)).await;
 
     // The engine should still be running (panic was caught).
     assert!(engine.is_running());


### PR DESCRIPTION
## Summary

- Make scheduling strategy a dropdown (Timer Driven / CRON Driven / Event Driven) and interval editable
- Wire `scheduling_strategy` / `scheduling_interval_ms` through API handler to engine
- Make `ProcessorInfo` / `ProcessorNode` scheduling mutable via `Arc<RwLock<SchedulingStrategy>>`
- Add processor rename support (backend + UI)
- Add execution node selection (All Nodes / Primary Node Only) on scheduling tab
- Add retry configuration placeholders on relationships tab (read-only, backend planned)

## Changes

**Backend (runifi-core):**
- `ProcessorInfo.scheduling` and `scheduling_display` are now `Arc<RwLock<...>>` for runtime updates
- Added `execution_node: Arc<RwLock<ExecutionNode>>` to `ProcessorInfo`
- `ProcessorNode.scheduling` and `execution_node` are now shared Arcs
- `wait_for_trigger()` snapshots scheduling under brief lock (no lock held across await)
- `update_processor_config` handles scheduling strategy/interval changes, execution node, and rename
- `FlowEngine` and `MutationHandler` create shared Arcs between ProcessorNode and ProcessorInfo

**Backend (runifi-api):**
- `ProcessorConfigUpdateRequest` now uses `scheduling_strategy`, `scheduling_interval_ms`, `execution_node`, and `name` fields
- `SchedulingResponse` includes `execution_node`
- API handler passes all new fields to engine

**Frontend (dashboard-react):**
- Scheduling strategy: dropdown replacing disabled text input
- Run schedule: editable number input (shown for timer strategy)
- Execution node: dropdown (All Nodes / Primary Node Only)
- Processor name: editable in Settings tab
- Retry config: placeholder columns on relationships table (Retry Attempts, Back Off Policy, Max Back Off)

## Test plan

- [x] `cargo fmt --all` — passes
- [x] `cargo clippy --workspace -- -D warnings` — passes
- [x] `cargo test --workspace` — passes
- [ ] Verify scheduling strategy changes persist across dialog close/reopen
- [ ] Verify processor rename updates all references
- [ ] Verify execution node dropdown reflects current cluster config

Closes #280