### PR TITLE
feat: cluster management dashboard UI (#281)

### DIFF
--- a/crates/runifi-api/dashboard-react/src/App.tsx
+++ b/crates/runifi-api/dashboard-react/src/App.tsx
@@ -10,6 +10,7 @@ import { ControllerServicesPanel } from './components/ControllerServicesPanel';
 import { BulletinBoard } from './components/BulletinBoard';
 import { DataProvenance } from './components/DataProvenance';
 import { SystemDiagnosticsModal } from './components/SystemDiagnosticsModal';
+import { ClusterManagement } from './components/ClusterManagement';
 import { useFlowTopology } from './hooks/useFlowTopology';
 import { useGroupNavigation } from './hooks/useGroupNavigation';
 import { useSseMetrics } from './hooks/useSseMetrics';
@@ -38,6 +39,7 @@ export function App() {
   const [controllerServicesOpen, setControllerServicesOpen] = useState(false);
   const [provenanceOpen, setProvenanceOpen] = useState(false);
   const [systemDiagnosticsOpen, setSystemDiagnosticsOpen] = useState(false);
+  const [clusterOpen, setClusterOpen] = useState(false);
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [colorRequestNodeIds, setColorRequestNodeIds] = useState<string[] | null>(null);
 
@@ -94,6 +96,7 @@ export function App() {
         onOpenControllerServices={() => setControllerServicesOpen(true)}
         onOpenDataProvenance={() => setProvenanceOpen(true)}
         onOpenSystemDiagnostics={() => setSystemDiagnosticsOpen(true)}
+        onOpenCluster={() => setClusterOpen(true)}
       />
       <ComponentToolbar
         plugins={plugins}
@@ -191,6 +194,13 @@ export function App() {
       {systemDiagnosticsOpen && (
         <SystemDiagnosticsModal
           onClose={() => setSystemDiagnosticsOpen(false)}
+        />
+      )}
+
+      {clusterOpen && (
+        <ClusterManagement
+          onToast={pushToast}
+          onClose={() => setClusterOpen(false)}
         />
       )}
     </div>

--- a/crates/runifi-api/dashboard-react/src/components/ClusterManagement.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/ClusterManagement.tsx
@@ -1,0 +1,367 @@
+import { memo, useState, useEffect, useCallback } from 'react';
+import { useCluster } from '../hooks/useCluster';
+import { ConfirmDialog } from './ConfirmDialog';
+import { formatUptime } from '../utils/format';
+import type { ClusterNodeResponse, NodeState } from '../types/api';
+import type { ToastKind } from '../hooks/useToast';
+
+interface ClusterManagementProps {
+  onClose: () => void;
+  onToast: (kind: ToastKind, message: string) => void;
+}
+
+type NodeAction = {
+  type: 'disconnect' | 'connect' | 'decommission' | 'remove' | 'primary';
+  node: ClusterNodeResponse;
+};
+
+const STATE_BADGE_CLASS: Record<NodeState, string> = {
+  Connected: 'cluster-badge-connected',
+  Connecting: 'cluster-badge-connecting',
+  Disconnected: 'cluster-badge-disconnected',
+  Decommissioning: 'cluster-badge-decommissioning',
+  Removed: 'cluster-badge-removed',
+};
+
+const ACTION_CONFIG: Record<
+  NodeAction['type'],
+  { title: string; message: (addr: string) => string; confirmLabel: string; destructive: boolean }
+> = {
+  disconnect: {
+    title: 'Disconnect Node',
+    message: (addr) => `Disconnect node "${addr}" from the cluster? The node will stop receiving work.`,
+    confirmLabel: 'Disconnect',
+    destructive: true,
+  },
+  connect: {
+    title: 'Connect Node',
+    message: (addr) => `Reconnect node "${addr}" to the cluster?`,
+    confirmLabel: 'Connect',
+    destructive: false,
+  },
+  decommission: {
+    title: 'Decommission Node',
+    message: (addr) =>
+      `Begin graceful decommission of node "${addr}"? The node will drain queued data and then disconnect.`,
+    confirmLabel: 'Decommission',
+    destructive: true,
+  },
+  remove: {
+    title: 'Remove Node',
+    message: (addr) =>
+      `Force-remove node "${addr}" from the cluster? This cannot be undone.`,
+    confirmLabel: 'Remove',
+    destructive: true,
+  },
+  primary: {
+    title: 'Designate Primary',
+    message: (addr) => `Designate node "${addr}" as the primary node?`,
+    confirmLabel: 'Designate',
+    destructive: false,
+  },
+};
+
+function ClusterManagementInner({ onClose, onToast }: ClusterManagementProps) {
+  const {
+    nodes,
+    status,
+    loading,
+    error,
+    autoRefresh,
+    setAutoRefresh,
+    refresh,
+    disconnectNode,
+    connectNode,
+    decommissionNode,
+    removeNode,
+    designatePrimary,
+  } = useCluster(true);
+
+  const [pendingAction, setPendingAction] = useState<NodeAction | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Close on Escape (only when no confirm dialog open)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !pendingAction) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose, pendingAction]);
+
+  const executeAction = useCallback(async () => {
+    if (!pendingAction) return;
+    setActionLoading(true);
+    try {
+      const { type, node } = pendingAction;
+      switch (type) {
+        case 'disconnect':
+          await disconnectNode(node.id);
+          break;
+        case 'connect':
+          await connectNode(node.id);
+          break;
+        case 'decommission':
+          await decommissionNode(node.id);
+          break;
+        case 'remove':
+          await removeNode(node.id);
+          break;
+        case 'primary':
+          await designatePrimary(node.id);
+          break;
+      }
+      onToast('success', `${ACTION_CONFIG[type].title}: ${node.address}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      onToast('error', `Action failed: ${msg}`);
+    } finally {
+      setActionLoading(false);
+      setPendingAction(null);
+    }
+  }, [pendingAction, disconnectNode, connectNode, decommissionNode, removeNode, designatePrimary, onToast]);
+
+  const nodeList = nodes?.nodes ?? [];
+  const primaryId = status?.primary_id;
+  const coordinatorId = status?.coordinator_id;
+
+  return (
+    <>
+      <div className="cluster-panel" role="complementary" aria-label="Cluster Management">
+        <div className="cluster-panel-header">
+          <span className="cluster-panel-title">Cluster Management</span>
+          <div className="cluster-header-controls">
+            <label className="cluster-auto-refresh">
+              <input
+                type="checkbox"
+                checked={autoRefresh}
+                onChange={(e) => setAutoRefresh(e.target.checked)}
+              />
+              Auto-refresh (5s)
+            </label>
+            <button className="cluster-refresh-btn" onClick={refresh} title="Refresh now">
+              Refresh
+            </button>
+            <button
+              className="config-close-btn"
+              onClick={onClose}
+              aria-label="Close cluster management"
+            >
+              &times;
+            </button>
+          </div>
+        </div>
+
+        {/* Cluster Overview */}
+        {status && (
+          <div className="cluster-overview">
+            <div className="cluster-overview-item">
+              <span className="cluster-overview-label">Nodes</span>
+              <span className="cluster-overview-value">
+                {status.connected_count} / {status.total_count}
+              </span>
+            </div>
+            <div className="cluster-overview-item">
+              <span className="cluster-overview-label">Quorum</span>
+              <span
+                className={`cluster-overview-value ${
+                  status.has_quorum ? 'cluster-quorum-ok' : 'cluster-quorum-lost'
+                }`}
+              >
+                {status.has_quorum ? 'Yes' : 'No'}
+              </span>
+            </div>
+            <div className="cluster-overview-item">
+              <span className="cluster-overview-label">Primary</span>
+              <span className="cluster-overview-value">
+                {primaryId
+                  ? nodeList.find((n) => n.id === primaryId)?.address ?? primaryId
+                  : 'None'}
+              </span>
+            </div>
+            <div className="cluster-overview-item">
+              <span className="cluster-overview-label">Coordinator</span>
+              <span className="cluster-overview-value">
+                {coordinatorId
+                  ? nodeList.find((n) => n.id === coordinatorId)?.address ?? coordinatorId
+                  : 'None'}
+              </span>
+            </div>
+            <div className="cluster-overview-item">
+              <span className="cluster-overview-label">Flow Version</span>
+              <span className="cluster-overview-value">{status.flow_version}</span>
+            </div>
+            <div className="cluster-overview-item">
+              <span className="cluster-overview-label">Election Term</span>
+              <span className="cluster-overview-value">{status.election_term}</span>
+            </div>
+          </div>
+        )}
+
+        {loading && !nodes && (
+          <div className="cluster-loading">Loading cluster info...</div>
+        )}
+
+        {error && (
+          <div className="cluster-error">Failed to load cluster info: {error}</div>
+        )}
+
+        {/* Node Table */}
+        {nodes && (
+          <div className="cluster-table-wrap">
+            <table className="cluster-table">
+              <thead>
+                <tr>
+                  <th>Address</th>
+                  <th>Status</th>
+                  <th>Roles</th>
+                  <th>Heartbeat</th>
+                  <th>Active Threads</th>
+                  <th>Queued</th>
+                  <th>Uptime</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {nodeList.length === 0 ? (
+                  <tr>
+                    <td colSpan={8} className="cluster-empty-row">
+                      No cluster nodes found.
+                    </td>
+                  </tr>
+                ) : (
+                  nodeList.map((node) => (
+                    <tr key={node.id} className="cluster-row">
+                      <td className="cluster-cell-addr">{node.address}</td>
+                      <td>
+                        <span
+                          className={`cluster-status-badge ${
+                            STATE_BADGE_CLASS[node.state] ?? 'cluster-badge-disconnected'
+                          }`}
+                        >
+                          {node.state}
+                        </span>
+                      </td>
+                      <td>
+                        <div className="cluster-roles">
+                          {node.roles.map((role) => (
+                            <span
+                              key={role}
+                              className={`cluster-role-badge ${
+                                role === 'Primary'
+                                  ? 'cluster-role-primary'
+                                  : role === 'Coordinator'
+                                    ? 'cluster-role-coordinator'
+                                    : 'cluster-role-node'
+                              }`}
+                            >
+                              {role}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="cluster-cell-dim">
+                        {node.missed_heartbeats === 0
+                          ? 'OK'
+                          : `${node.missed_heartbeats} missed`}
+                      </td>
+                      <td className="cluster-cell-dim">
+                        {node.metrics?.active_threads ?? '-'}
+                      </td>
+                      <td className="cluster-cell-dim">
+                        {node.metrics?.queued_flowfiles != null
+                          ? node.metrics.queued_flowfiles.toLocaleString()
+                          : '-'}
+                      </td>
+                      <td className="cluster-cell-dim">
+                        {node.uptime_secs != null
+                          ? formatUptime(node.uptime_secs)
+                          : '-'}
+                      </td>
+                      <td>
+                        <div className="cluster-actions">
+                          {node.state === 'Connected' && (
+                            <button
+                              className="btn-link"
+                              onClick={() =>
+                                setPendingAction({ type: 'disconnect', node })
+                              }
+                              disabled={actionLoading}
+                            >
+                              Disconnect
+                            </button>
+                          )}
+                          {node.state === 'Disconnected' && (
+                            <>
+                              <button
+                                className="btn-link"
+                                onClick={() =>
+                                  setPendingAction({ type: 'connect', node })
+                                }
+                                disabled={actionLoading}
+                              >
+                                Connect
+                              </button>
+                              <button
+                                className="btn-link cluster-action-danger"
+                                onClick={() =>
+                                  setPendingAction({ type: 'remove', node })
+                                }
+                                disabled={actionLoading}
+                              >
+                                Remove
+                              </button>
+                            </>
+                          )}
+                          {(node.state === 'Connected' ||
+                            node.state === 'Disconnected') && (
+                            <button
+                              className="btn-link cluster-action-warn"
+                              onClick={() =>
+                                setPendingAction({ type: 'decommission', node })
+                              }
+                              disabled={actionLoading}
+                            >
+                              Decommission
+                            </button>
+                          )}
+                          {node.state === 'Connected' &&
+                            !node.roles.includes('Primary') && (
+                              <button
+                                className="btn-link"
+                                onClick={() =>
+                                  setPendingAction({ type: 'primary', node })
+                                }
+                                disabled={actionLoading}
+                              >
+                                Set Primary
+                              </button>
+                            )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {pendingAction && (
+        <ConfirmDialog
+          title={ACTION_CONFIG[pendingAction.type].title}
+          message={ACTION_CONFIG[pendingAction.type].message(pendingAction.node.address)}
+          confirmLabel={ACTION_CONFIG[pendingAction.type].confirmLabel}
+          destructive={ACTION_CONFIG[pendingAction.type].destructive}
+          onConfirm={executeAction}
+          onCancel={() => setPendingAction(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export const ClusterManagement = memo(ClusterManagementInner);

--- a/crates/runifi-api/dashboard-react/src/components/Header.tsx
+++ b/crates/runifi-api/dashboard-react/src/components/Header.tsx
@@ -10,6 +10,7 @@ interface HeaderProps {
   onOpenBulletins?: () => void;
   onOpenDataProvenance?: () => void;
   onOpenSystemDiagnostics?: () => void;
+  onOpenCluster?: () => void;
 }
 
 interface MenuItem {
@@ -26,6 +27,7 @@ const MENU_ITEMS: MenuItem[] = [
   { label: 'Bulletin Board', action: 'bulletin-board', icon: '\uD83D\uDCCB' },
   { label: 'Controller Services', action: 'controller-services', icon: '\u2699' },
   { label: 'Data Provenance', action: 'data-provenance', icon: '\uD83D\uDD0D', separator: true },
+  { label: 'Cluster', action: 'cluster', icon: '\uD83D\uDDA5' },
   { label: 'Flow Configuration History', action: 'flow-history', icon: '\uD83D\uDCC4', disabled: true, disabledReason: 'Not yet implemented' },
   { label: 'System Diagnostics', action: 'system-diagnostics', icon: '\uD83D\uDCCA', separator: true },
   { label: 'Users & Groups', action: 'users', icon: '\uD83D\uDC65', adminOnly: true, disabled: true, disabledReason: 'Not yet implemented', separator: true },
@@ -34,7 +36,7 @@ const MENU_ITEMS: MenuItem[] = [
   { label: 'Logout', action: 'logout', icon: '\u2192' },
 ];
 
-function HeaderInner({ flowName, uptimeSecs, sseStatus, onOpenControllerServices, onOpenBulletins, onOpenDataProvenance, onOpenSystemDiagnostics }: HeaderProps) {
+function HeaderInner({ flowName, uptimeSecs, sseStatus, onOpenControllerServices, onOpenBulletins, onOpenDataProvenance, onOpenSystemDiagnostics, onOpenCluster }: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -79,6 +81,9 @@ function HeaderInner({ flowName, uptimeSecs, sseStatus, onOpenControllerServices
         break;
       case 'system-diagnostics':
         onOpenSystemDiagnostics?.();
+        break;
+      case 'cluster':
+        onOpenCluster?.();
         break;
       case 'about':
         setAboutOpen(true);

--- a/crates/runifi-api/dashboard-react/src/hooks/useCluster.ts
+++ b/crates/runifi-api/dashboard-react/src/hooks/useCluster.ts
@@ -1,0 +1,143 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type {
+  ClusterNodesResponse,
+  ClusterStatusResponse,
+} from '../types/api';
+
+interface UseClusterResult {
+  nodes: ClusterNodesResponse | null;
+  status: ClusterStatusResponse | null;
+  loading: boolean;
+  error: string | null;
+  autoRefresh: boolean;
+  setAutoRefresh: (enabled: boolean) => void;
+  refresh: () => void;
+  disconnectNode: (id: string) => Promise<void>;
+  connectNode: (id: string) => Promise<void>;
+  decommissionNode: (id: string) => Promise<void>;
+  removeNode: (id: string) => Promise<void>;
+  designatePrimary: (id: string) => Promise<void>;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('runifi-token');
+  const headers: Record<string, string> = {};
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+export function useCluster(open: boolean): UseClusterResult {
+  const [nodes, setNodes] = useState<ClusterNodesResponse | null>(null);
+  const [status, setStatus] = useState<ClusterStatusResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchCluster = useCallback(async () => {
+    try {
+      const headers = authHeaders();
+      const [nodesRes, statusRes] = await Promise.all([
+        fetch('/api/v1/cluster/nodes', { headers }),
+        fetch('/api/v1/cluster/status', { headers }),
+      ]);
+
+      if (!nodesRes.ok) throw new Error(`Nodes: HTTP ${nodesRes.status}`);
+      if (!statusRes.ok) throw new Error(`Status: HTTP ${statusRes.status}`);
+
+      const nodesData: ClusterNodesResponse = await nodesRes.json();
+      const statusData: ClusterStatusResponse = await statusRes.json();
+
+      setNodes(nodesData);
+      setStatus(statusData);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setLoading(true);
+      fetchCluster();
+    } else {
+      setNodes(null);
+      setStatus(null);
+      setError(null);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (open && autoRefresh) {
+      intervalRef.current = setInterval(fetchCluster, 5000);
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [open, autoRefresh, fetchCluster]);
+
+  const nodeAction = useCallback(
+    async (id: string, path: string, method: string) => {
+      const headers = authHeaders();
+      const res = await fetch(`/api/v1/cluster/nodes/${id}${path}`, {
+        method,
+        headers,
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(body || `HTTP ${res.status}`);
+      }
+      await fetchCluster();
+    },
+    [fetchCluster],
+  );
+
+  const disconnectNode = useCallback(
+    (id: string) => nodeAction(id, '/disconnect', 'POST'),
+    [nodeAction],
+  );
+
+  const connectNode = useCallback(
+    (id: string) => nodeAction(id, '/connect', 'POST'),
+    [nodeAction],
+  );
+
+  const decommissionNode = useCallback(
+    (id: string) => nodeAction(id, '/decommission', 'POST'),
+    [nodeAction],
+  );
+
+  const removeNode = useCallback(
+    (id: string) => nodeAction(id, '', 'DELETE'),
+    [nodeAction],
+  );
+
+  const designatePrimary = useCallback(
+    (id: string) => nodeAction(id, '/primary', 'POST'),
+    [nodeAction],
+  );
+
+  return {
+    nodes,
+    status,
+    loading,
+    error,
+    autoRefresh,
+    setAutoRefresh,
+    refresh: fetchCluster,
+    disconnectNode,
+    connectNode,
+    decommissionNode,
+    removeNode,
+    designatePrimary,
+  };
+}

--- a/crates/runifi-api/dashboard-react/src/styles/global.css
+++ b/crates/runifi-api/dashboard-react/src/styles/global.css
@@ -4062,3 +4062,288 @@ body {
 .provenance-lineage-container .react-flow__controls button:hover {
   background: var(--surface-hover);
 }
+
+/* ── Cluster Management panel ──────────────────────────────── */
+
+.cluster-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin: 1rem;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 160px);
+  overflow: hidden;
+  position: fixed;
+  inset: 60px 16px 60px 16px;
+  z-index: 900;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.cluster-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.cluster-panel-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-dim);
+  margin-right: auto;
+}
+
+.cluster-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cluster-auto-refresh {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  user-select: none;
+}
+
+.cluster-auto-refresh input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.cluster-refresh-btn {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-size: 0.73rem;
+  font-family: var(--font);
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s;
+}
+
+.cluster-refresh-btn:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+/* ── Cluster overview bar ──────────────────────────────────── */
+
+.cluster-overview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.cluster-overview-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 80px;
+}
+
+.cluster-overview-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.cluster-overview-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cluster-quorum-ok {
+  color: var(--success);
+}
+
+.cluster-quorum-lost {
+  color: var(--danger);
+}
+
+/* ── Cluster loading/error ─────────────────────────────────── */
+
+.cluster-loading,
+.cluster-error {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+}
+
+.cluster-error {
+  color: var(--danger);
+}
+
+/* ── Cluster node table ────────────────────────────────────── */
+
+.cluster-table-wrap {
+  flex: 1;
+  overflow: auto;
+}
+
+.cluster-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.cluster-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  padding: 0.5rem 0.6rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.cluster-table tbody td {
+  padding: 0.45rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.cluster-row:hover {
+  background: var(--surface-hover);
+}
+
+.cluster-empty-row {
+  text-align: center;
+  color: var(--text-dim);
+  padding: 2rem !important;
+}
+
+.cluster-cell-addr {
+  font-family: monospace;
+  font-size: 0.78rem;
+}
+
+.cluster-cell-dim {
+  color: var(--text-dim);
+}
+
+/* ── Status badges ─────────────────────────────────────────── */
+
+.cluster-status-badge {
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.cluster-badge-connected {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--success);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+}
+
+.cluster-badge-connecting {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--warning);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.cluster-badge-disconnected {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+}
+
+.cluster-badge-decommissioning {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--warning);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.cluster-badge-removed {
+  background: rgba(139, 144, 160, 0.15);
+  color: var(--text-dim);
+  border: 1px solid rgba(139, 144, 160, 0.3);
+}
+
+/* ── Role badges ───────────────────────────────────────────── */
+
+.cluster-roles {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.cluster-role-badge {
+  display: inline-block;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.cluster-role-primary {
+  background: rgba(79, 143, 247, 0.15);
+  color: var(--accent);
+  border: 1px solid rgba(79, 143, 247, 0.3);
+}
+
+.cluster-role-coordinator {
+  background: rgba(168, 85, 247, 0.15);
+  color: #a855f7;
+  border: 1px solid rgba(168, 85, 247, 0.3);
+}
+
+.cluster-role-node {
+  background: rgba(139, 144, 160, 0.1);
+  color: var(--text-dim);
+  border: 1px solid rgba(139, 144, 160, 0.2);
+}
+
+/* ── Action buttons ────────────────────────────────────────── */
+
+.cluster-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.cluster-actions .btn-link {
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.cluster-action-danger {
+  color: var(--danger) !important;
+}
+
+.cluster-action-danger:hover {
+  color: #fca5a5 !important;
+}
+
+.cluster-action-warn {
+  color: var(--warning) !important;
+}
+
+.cluster-action-warn:hover {
+  color: #fcd34d !important;
+}

--- a/crates/runifi-api/dashboard-react/src/types/api.ts
+++ b/crates/runifi-api/dashboard-react/src/types/api.ts
@@ -376,3 +376,52 @@ export interface ProvenanceStatsResponse {
   oldest_timestamp_ms?: number;
   newest_timestamp_ms?: number;
 }
+
+// ── Cluster management types ──────────────────────────────────
+
+export type NodeState =
+  | 'Connected'
+  | 'Connecting'
+  | 'Disconnected'
+  | 'Decommissioning'
+  | 'Removed';
+
+export type ClusterRole = 'Primary' | 'Coordinator' | 'Node';
+
+export interface NodeMetricsSummary {
+  active_threads: number;
+  queued_flowfiles: number;
+  queued_bytes: number;
+}
+
+export interface ClusterNodeResponse {
+  id: string;
+  address: string;
+  state: NodeState;
+  roles: ClusterRole[];
+  missed_heartbeats: number;
+  flow_version: number;
+  metrics?: NodeMetricsSummary;
+  uptime_secs?: number;
+}
+
+export interface ClusterNodesResponse {
+  nodes: ClusterNodeResponse[];
+  connected_count: number;
+  total_count: number;
+  has_quorum: boolean;
+}
+
+export interface ClusterStatusResponse {
+  enabled: boolean;
+  node_id: string;
+  state: NodeState;
+  roles: ClusterRole[];
+  connected_count: number;
+  total_count: number;
+  flow_version: number;
+  election_term: number;
+  has_quorum: boolean;
+  coordinator_id?: string;
+  primary_id?: string;
+}


### PR DESCRIPTION
## Summary
- Add cluster management panel accessible from the global navigation menu
- Cluster overview header: node count, quorum status, primary/coordinator nodes
- Node table with color-coded status badges, role badges, heartbeat info, metrics
- Management actions: Disconnect, Connect, Decommission, Remove with confirmation dialogs
- Designate Primary action for connected non-primary nodes
- Auto-refresh polling (5s) with manual refresh toggle

## Changes
- **New**: `ClusterManagement.tsx` — full cluster management panel component
- **New**: `useCluster.ts` — hook for fetching cluster data and executing node actions
- **Modified**: `api.ts` — TypeScript types for cluster API responses
- **Modified**: `Header.tsx` — added Cluster menu item to global navigation
- **Modified**: `App.tsx` — wired ClusterManagement panel state and rendering
- **Modified**: `global.css` — cluster panel, status badges, role badges, action styles

## Test plan
- [ ] Open global menu and verify Cluster item appears
- [ ] Click Cluster and verify panel opens with overview header
- [ ] Verify node table displays with status badges (Connected=green, Disconnected=red, etc.)
- [ ] Verify role badges display (Primary=blue, Coordinator=purple, Node=gray)
- [ ] Test Disconnect action on connected node (shows confirmation dialog)
- [ ] Test Connect action on disconnected node
- [ ] Test Decommission and Remove actions with confirmation
- [ ] Verify auto-refresh updates data every 5 seconds
- [ ] Toggle auto-refresh off and verify polling stops
- [ ] Click manual Refresh button and verify data updates
- [ ] Press Escape to close the panel

Closes #281